### PR TITLE
Module pages: integrate pathway progress API (no auth) (refs #39)

### DIFF
--- a/clean-x-hedgehog-templates/learn/module-page.html
+++ b/clean-x-hedgehog-templates/learn/module-page.html
@@ -307,6 +307,47 @@
                 </div>
               {% endif %}
             </div>
+
+            {# Minimal pathway progress affordance (no auth) #}
+            <div class="module-progress-cta" role="region" aria-label="Module progress" style="margin-top:16px; display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+              <button type="button" class="pathways-cta-button" id="hhl-mark-started" aria-label="Mark module as started" style="padding:8px 14px;">
+                Mark as started
+              </button>
+              <button type="button" class="pathways-cta-button" id="hhl-mark-complete" aria-label="Mark module as complete" style="padding:8px 14px;">
+                Mark complete
+              </button>
+              <a id="hhl-back-to-pathway" href="#" style="display:none; color:#0066CC; text-decoration:none; font-weight:600;">← Back to pathway</a>
+            </div>
+            <script>
+              document.addEventListener('DOMContentLoaded', function () {
+                function callProgress(started, completed) {
+                  try {
+                    if (typeof window !== 'undefined' && typeof window.hhUpdatePathwayProgress === 'function') {
+                      window.hhUpdatePathwayProgress(started, completed);
+                    }
+                  } catch (e) {
+                    // no-op
+                  }
+                }
+
+                var startBtn = document.getElementById('hhl-mark-started');
+                var completeBtn = document.getElementById('hhl-mark-complete');
+                var backLink = document.getElementById('hhl-back-to-pathway');
+
+                if (startBtn) startBtn.addEventListener('click', function(){ callProgress(1, 0); });
+                if (completeBtn) completeBtn.addEventListener('click', function(){ callProgress(1, 1); });
+
+                try {
+                  var ref = document.referrer || '';
+                  if (/\/learn\/pathways\//.test(ref) && backLink) {
+                    backLink.href = ref;
+                    backLink.style.display = 'inline-block';
+                  }
+                } catch (e) {
+                  // ignore
+                }
+              });
+            </script>
           </header>
 
           <!-- Module Content -->

--- a/docs/content-sync.md
+++ b/docs/content-sync.md
@@ -93,6 +93,24 @@ curl -H "Authorization: Bearer $TOKEN" \
 
 Record any new failure signatures here so future contributors know how to respond.
 
+## Pathway Progress (Placeholder)
+
+For v0.2, module detail pages expose a minimal, no‑auth progress affordance that cooperates with the pathway page’s localStorage‑based progress API.
+
+- UI: Two buttons appear on module detail pages — “Mark as started” and “Mark complete”. If you navigated from a pathway detail page, a “Back to pathway” link is also shown.
+- Behavior: Buttons call a global function `window.hhUpdatePathwayProgress(started, completed)` if it exists. If not present, the clicks are no‑ops (no errors thrown).
+- Storage: Progress is stored client‑side in `localStorage` by the pathway page script. There is no server‑side persistence or authentication in this placeholder.
+
+How to test
+1. Open a pathway detail page under `/learn/pathways/<slug>` so its progress script is loaded.
+2. Click into a module from that pathway (the “Back to pathway” link should appear on the module detail page).
+3. Click “Mark complete”.
+4. Use the “Back to pathway” link (or browser back) — the pathway’s progress bar should reflect the completion for that module.
+
+Notes
+- The module template guards all browser APIs behind `DOMContentLoaded` and does not reference `window` in HubL, keeping server‑side rendering safe.
+- Accessibility: buttons include `aria-label`s and are keyboard‑focusable.
+
 ## Courses Mapping
 
 Courses group multiple modules into structured, narrative-driven learning units. Courses sit between Modules and Pathways in the content hierarchy.

--- a/docs/images/module-progress-ui.svg
+++ b/docs/images/module-progress-ui.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="680" height="200" viewBox="0 0 680 200" role="img" aria-label="Module progress UI mock">
+  <style>
+    .card{fill:#fff;stroke:#e5e7eb;stroke-width:1}
+    .title{font:700 20px system-ui,Segoe UI,Roboto,Helvetica,Arial}
+    .meta{font:14px system-ui,Segoe UI,Roboto,Helvetica,Arial;fill:#374151}
+    .btn{fill:#1a4e8a}
+    .btn-text{font:600 14px system-ui,Segoe UI,Roboto,Helvetica,Arial;fill:#fff}
+    .link{font:600 14px system-ui,Segoe UI,Roboto,Helvetica,Arial;fill:#0066cc}
+  </style>
+  <rect x="10" y="10" rx="12" ry="12" width="660" height="180" class="card"/>
+  <text x="30" y="50" class="title">Intro to Kubernetes</text>
+  <text x="30" y="75" class="meta">Beginner • 20 minutes • tags: kubernetes, containers</text>
+
+  <rect x="30" y="105" rx="8" ry="8" width="150" height="34" class="btn"/>
+  <text x="45" y="127" class="btn-text">Mark as started</text>
+
+  <rect x="190" y="105" rx="8" ry="8" width="130" height="34" class="btn"/>
+  <text x="205" y="127" class="btn-text">Mark complete</text>
+
+  <text x="340" y="128" class="link">← Back to pathway</text>
+</svg>
+


### PR DESCRIPTION
This PR integrates a minimal, no‑auth pathway progress affordance into module detail pages and documents how to test it.

Summary
- Adds two buttons on module detail pages: “Mark as started” and “Mark complete”.
- Optional “Back to pathway” link shows when arriving from a pathway detail page (referrer-based).
- Client-side script calls `window.hhUpdatePathwayProgress(started, completed)` if present; otherwise no-ops (no errors).
- Documentation updated with a short “Pathway Progress (Placeholder)” section and a quick test flow.

Changed files
- clean-x-hedgehog-templates/learn/module-page.html
- docs/content-sync.md (new section: Pathway Progress (Placeholder))
- docs/images/module-progress-ui.svg (lightweight mock for review)

Test plan
1) Open a pathway detail under `/learn/pathways/<slug>` (ensures the pathway progress script is loaded and localStorage initialized using key `hh-pathway-progress-<pathwaySlug>`).
2) Click a module card to open `/learn/<module-slug>` — confirm the “Back to pathway” link appears.
3) Click “Mark complete”.
4) Navigate back to the pathway (use the link or browser Back). The pathway progress bar should reflect the completion for that module.

Expected result
- Buttons are visible only on module detail pages (not on the module list view).
- Clicking buttons triggers the global API when available; if missing, nothing breaks.
- No console errors on pages with or without the pathway progress script.

Accessibility notes
- Buttons include `aria-label`s and are keyboard-focusable.
- Visual contrast inherits existing theme colors (Clean.Pro variant); adjust in follow-ups if needed.

Quick QA confirmations
- Detail-only rendering: The UI is injected under the module header inside the `dynamic_page_hubdb_row` branch; it never renders in the list branch.
- DOMContentLoaded guard + no-op: The script runs after `DOMContentLoaded` and wraps calls to `window.hhUpdatePathwayProgress` in a type check and try/catch, silently no-op if undefined.
- Back-to-pathway link: Only shown when `document.referrer` matches `/learn/pathways/…`; otherwise hidden.
- Keying scheme: Pathway progress uses `localStorage` with keys `hh-pathway-progress-{pathwaySlug}` (already implemented on the pathway page), allowing us to evolve in v0.3 without breaking v0.2 data.

Risks / notes
- Referrer-based back link can be brittle across cross-tab/navigation. In a later change we can add a `from=pathway:<slug>` query param on pathway → module links for reliability (not required for #39).

Closes #39 (pending template upload to portal and staging verification).