### PR TITLE
Issue #73 Priority 1: Token Migration to HUBSPOT_PROJECT_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -14,6 +14,8 @@ jobs:
       - run: npm run build
       - run: npm run deploy:aws
         env:
+          # Prefer Project App token; fall back to Private App during migration
+          HUBSPOT_PROJECT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_PROJECT_ACCESS_TOKEN }}
           HUBSPOT_PRIVATE_APP_TOKEN: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
           HUBSPOT_ACCOUNT_ID: ${{ secrets.HUBSPOT_ACCOUNT_ID }}
           AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/scripts/hubspot/check-and-publish-pages.ts
+++ b/scripts/hubspot/check-and-publish-pages.ts
@@ -5,9 +5,12 @@
 
 import 'dotenv/config';
 import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
+
+const TOKEN = getHubSpotToken();
 
 const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
+  accessToken: TOKEN
 });
 
 const pageIds = [
@@ -39,7 +42,7 @@ async function main() {
             {
               method: 'POST',
               headers: {
-                'Authorization': `Bearer ${process.env.HUBSPOT_PRIVATE_APP_TOKEN}`,
+                'Authorization': `Bearer ${TOKEN}`,
                 'Content-Type': 'application/json'
               },
               body: JSON.stringify({})

--- a/scripts/hubspot/check-contact-properties.ts
+++ b/scripts/hubspot/check-contact-properties.ts
@@ -5,9 +5,10 @@
 
 import 'dotenv/config';
 import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
 
 const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
+  accessToken: getHubSpotToken()
 });
 
 interface PropertyConfig {

--- a/scripts/hubspot/check-hubdb-state.ts
+++ b/scripts/hubspot/check-hubdb-state.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
+
+const TOKEN = getHubSpotToken();
+const client = new Client({ accessToken: TOKEN });
+
+const tableIds = {
+  modules: 135621904,
+  courses: 135381433,
+  pathways: 135381504
+};
+
+async function checkTableState(name: string, id: number) {
+  try {
+    const table = await client.cms.hubdb.tablesApi.getTableDetails(String(id));
+    console.log(`\n=== ${name.toUpperCase()} (ID: ${id}) ===`);
+    console.log(`Name: ${table.name}`);
+    console.log(`Published: ${table.publishedAt || 'Not published'}`);
+    console.log(`Row Count: ${table.rowCount || 0}`);
+    console.log(`Updated: ${table.updatedAt}`);
+  } catch (err: any) {
+    console.error(`Error fetching ${name}:`, err.message);
+  }
+}
+
+async function main() {
+  console.log('🔍 Checking HubDB table publish states...\n');
+
+  for (const [name, id] of Object.entries(tableIds)) {
+    await checkTableState(name, id);
+  }
+
+  console.log('\n✅ Done!');
+}
+
+main().catch(console.error);

--- a/scripts/hubspot/check-template-files.ts
+++ b/scripts/hubspot/check-template-files.ts
@@ -4,6 +4,9 @@
  */
 
 import 'dotenv/config';
+import { getHubSpotToken } from './get-hubspot-token.js';
+
+const TOKEN = getHubSpotToken();
 
 const nestedPaths = [
   'CLEAN x HEDGEHOG/templates/learn/courses/courses-page.html',
@@ -16,7 +19,7 @@ async function checkTemplate(path: string) {
       `https://api.hubapi.com/cms/v3/source-code/draft/metadata/${encodeURIComponent(path)}`,
       {
         headers: {
-          'Authorization': `Bearer ${process.env.HUBSPOT_PRIVATE_APP_TOKEN}`
+          'Authorization': `Bearer ${TOKEN}`
         }
       }
     );
@@ -53,7 +56,7 @@ async function checkAllPages() {
         `https://api.hubapi.com/cms/v3/pages/site-pages/${page.id}`,
         {
           headers: {
-            'Authorization': `Bearer ${process.env.HUBSPOT_PRIVATE_APP_TOKEN}`
+            'Authorization': `Bearer ${TOKEN}`
           }
         }
       );

--- a/scripts/hubspot/provision-tables.ts
+++ b/scripts/hubspot/provision-tables.ts
@@ -15,9 +15,10 @@ import 'dotenv/config';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
 
 const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
+  accessToken: getHubSpotToken()
 });
 
 interface ColumnOption {
@@ -173,7 +174,7 @@ async function createOrUpdateTable(
 
   try {
     let table: any;
-    const token = process.env.HUBSPOT_PRIVATE_APP_TOKEN;
+    const token = getHubSpotToken();
 
     if (existingTable) {
       // Update existing table via raw HTTP API
@@ -271,8 +272,12 @@ async function provisionTables(dryRun: boolean = false) {
     console.log('📝 DRY RUN MODE - no changes will be made\n');
   }
 
-  if (!dryRun && !process.env.HUBSPOT_PRIVATE_APP_TOKEN) {
-    throw new Error('HUBSPOT_PRIVATE_APP_TOKEN environment variable not set');
+  if (!dryRun) {
+    try {
+      getHubSpotToken(); // This will throw if no token is available
+    } catch (err: any) {
+      throw new Error(err.message);
+    }
   }
 
   const tableSchemas = ['courses', 'pathways', 'modules'];

--- a/scripts/hubspot/publish-pages-patch.ts
+++ b/scripts/hubspot/publish-pages-patch.ts
@@ -4,6 +4,9 @@
  */
 
 import 'dotenv/config';
+import { getHubSpotToken } from './get-hubspot-token.js';
+
+const TOKEN = getHubSpotToken();
 
 const pageIds = [
   { id: '197280289288', name: 'Courses' },
@@ -17,7 +20,7 @@ async function publishPage(pageId: string, pageName: string) {
       {
         method: 'PATCH',
         headers: {
-          'Authorization': `Bearer ${process.env.HUBSPOT_PRIVATE_APP_TOKEN}`,
+          'Authorization': `Bearer ${TOKEN}`,
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({

--- a/scripts/hubspot/update-constants.ts
+++ b/scripts/hubspot/update-constants.ts
@@ -13,9 +13,10 @@
 
 import 'dotenv/config';
 import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
 
 const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
+  accessToken: getHubSpotToken()
 });
 
 const CONSTANTS_PATH = 'CLEAN x HEDGEHOG/templates/config/constants.json';
@@ -91,7 +92,7 @@ async function readConstantsFile(): Promise<any> {
   try {
     console.log(`📥 Reading constants file: ${CONSTANTS_PATH}`);
 
-    const token = process.env.HUBSPOT_PRIVATE_APP_TOKEN;
+    const token = getHubSpotToken();
     const encodedPath = encodeURIComponent(CONSTANTS_PATH);
 
     // Use raw HTTP API for Source Code
@@ -139,7 +140,7 @@ async function writeConstantsFile(constants: any, publish: boolean = false): Pro
 
     // Format JSON with proper indentation
     const content = JSON.stringify(constants, null, 2);
-    const token = process.env.HUBSPOT_PRIVATE_APP_TOKEN;
+    const token = getHubSpotToken();
     const encodedPath = encodeURIComponent(CONSTANTS_PATH);
 
     // Update draft version using raw HTTP API
@@ -219,8 +220,12 @@ async function updateConstants(dryRun: boolean = false, publish: boolean = false
     console.log('🚀 PUBLISH MODE - constants will be published\n');
   }
 
-  if (!dryRun && !process.env.HUBSPOT_PRIVATE_APP_TOKEN) {
-    throw new Error('HUBSPOT_PRIVATE_APP_TOKEN environment variable not set');
+  if (!dryRun) {
+    try {
+      getHubSpotToken(); // This will throw if no token is available
+    } catch (err: any) {
+      throw new Error(err.message);
+    }
   }
 
   // Define updates to make

--- a/src/sync/courses-to-hubdb.ts
+++ b/src/sync/courses-to-hubdb.ts
@@ -19,7 +19,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { marked } from 'marked';
 import matter from 'gray-matter';
-import { Client } from '@hubspot/api-client';
+import { getHubSpotClient } from '../shared/hubspot.js';
 
 // ES module compatibility: get __dirname equivalent
 const __filename = fileURLToPath(import.meta.url);
@@ -31,9 +31,7 @@ marked.setOptions({
   breaks: false,
 });
 
-const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
-});
+const hubspot = getHubSpotClient();
 
 const TABLE_ID = process.env.HUBDB_COURSES_TABLE_ID;
 

--- a/src/sync/markdown-to-hubdb.ts
+++ b/src/sync/markdown-to-hubdb.ts
@@ -18,7 +18,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { marked } from 'marked';
 import matter from 'gray-matter';
-import { Client } from '@hubspot/api-client';
+import { getHubSpotClient } from '../shared/hubspot.js';
 
 // ES module compatibility: get __dirname equivalent
 const __filename = fileURLToPath(import.meta.url);
@@ -30,9 +30,7 @@ marked.setOptions({
   breaks: false,
 });
 
-const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
-});
+const hubspot = getHubSpotClient();
 
 const TABLE_ID = process.env.HUBDB_MODULES_TABLE_ID;
 

--- a/src/sync/pathways-to-hubdb.ts
+++ b/src/sync/pathways-to-hubdb.ts
@@ -18,7 +18,7 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { marked } from 'marked';
 import matter from 'gray-matter';
-import { Client } from '@hubspot/api-client';
+import { getHubSpotClient } from '../shared/hubspot.js';
 
 // ES module compatibility: get __dirname equivalent
 const __filename = fileURLToPath(import.meta.url);
@@ -30,9 +30,7 @@ marked.setOptions({
   breaks: false,
 });
 
-const hubspot = new Client({
-  accessToken: process.env.HUBSPOT_PRIVATE_APP_TOKEN
-});
+const hubspot = getHubSpotClient();
 
 const TABLE_ID = process.env.HUBDB_PATHWAYS_TABLE_ID;
 


### PR DESCRIPTION
## Summary
- Completes Priority 1 of Issue #73: Secrets & Token Usage Audit
- Migrates all scripts and workflows to use shared token helpers that prefer `HUBSPOT_PROJECT_ACCESS_TOKEN`
- Maintains `HUBSPOT_PRIVATE_APP_TOKEN` as fallback for graceful migration

## Changes

### Scripts Migration
All provisioning and sync scripts now use centralized token helpers:
- `scripts/hubspot/*` → use `getHubSpotToken()` from `get-hubspot-token.ts`
- `src/sync/*` → use `getHubSpotClient()` from `src/shared/hubspot.ts`

Both helpers implement the same token preference order:
1. **HUBSPOT_PROJECT_ACCESS_TOKEN** (OAuth - preferred)
2. **HUBSPOT_API_TOKEN** (fallback)
3. **HUBSPOT_PRIVATE_APP_TOKEN** (legacy fallback)

### Files Updated
**Provisioning Scripts:**
- scripts/hubspot/provision-tables.ts
- scripts/hubspot/update-constants.ts
- scripts/hubspot/provision-pages.ts
- scripts/hubspot/check-hubdb-state.ts
- scripts/hubspot/check-contact-properties.ts
- scripts/hubspot/check-template-files.ts
- scripts/hubspot/publish-pages-patch.ts
- scripts/hubspot/check-and-publish-pages.ts

**Sync Scripts:**
- src/sync/markdown-to-hubdb.ts
- src/sync/courses-to-hubdb.ts
- src/sync/pathways-to-hubdb.ts

**CI/CD:**
- .github/workflows/deploy-aws.yml - added HUBSPOT_PROJECT_ACCESS_TOKEN
- .github/workflows/sync-content.yml - already supports token preference ✓
- .github/workflows/cms-validate.yml - already supports token preference ✓

## Testing
- ✅ Build succeeds: `npm run build`
- ✅ Token helpers implement graceful fallback
- ✅ HUBSPOT_PRIVATE_APP_TOKEN remains functional during migration

## Acceptance Criteria
- [x] All scripts consume tokens via shared helpers (no direct `process.env.HUBSPOT_PRIVATE_APP_TOKEN` access)
- [x] CI workflows include HUBSPOT_PROJECT_ACCESS_TOKEN
- [x] Build passes without errors
- [ ] CI green on this PR
- [ ] Dry-run validation passes: `npm run validate:cms`

## Next Steps
After this PR merges:
1. Verify CI workflows succeed with token preference
2. Monitor for any edge cases in production
3. Consider removal of HUBSPOT_PRIVATE_APP_TOKEN from CI (as separate cleanup task per Issue #73)

## References
- Closes #73 Priority 1
- Builds on #60 (Projects App OAuth migration)
- PR #72 (CRM persistence enablement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)