### PR TITLE
fix(ci): parse publish-constants response to fix CI

### DIFF
--- a/dist-lambda/src/shared/hubspot.js
+++ b/dist-lambda/src/shared/hubspot.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getHubSpotClient = getHubSpotClient;
 const api_client_1 = require("@hubspot/api-client");
 function getHubSpotClient() {
-    // Prefer Project App (OAuth) token, then API token (static), then Private App token
+    // Prefer HubSpot Projects token (static bearer), then API token (static), then Private App token
     const token = process.env.HUBSPOT_PROJECT_ACCESS_TOKEN ||
         process.env.HUBSPOT_API_TOKEN ||
         process.env.HUBSPOT_PRIVATE_APP_TOKEN;

--- a/scripts/hubspot/publish-constants.ts
+++ b/scripts/hubspot/publish-constants.ts
@@ -41,11 +41,16 @@ async function publishConstants() {
       throw new Error(`HTTP ${res.status}: ${errorText}`);
     }
 
-    console.log('✅ Successfully uploaded constants.json to PUBLISHED environment.');
-    console.log(`   Published at: ${result.updatedAt || new Date().toISOString()}`);
-    console.log(`   Path: ${result.path || CONSTANTS_PATH}\n`);
+    const result = await res.json().catch(() => ({} as any));
 
-    return result;
+    console.log('✅ Successfully uploaded constants.json to PUBLISHED environment.');
+    // Optional metadata from API, fallback to defaults if not present
+    const updatedAt = (result as any).updatedAt || new Date().toISOString();
+    const path = (result as any).path || CONSTANTS_PATH;
+    console.log(`   Published at: ${updatedAt}`);
+    console.log(`   Path: ${path}\n`);
+
+    return result as any;
   } catch (err: any) {
     console.error('❌ Failed to publish constants.json:', err.message);
     if (err.body) {


### PR DESCRIPTION
Fixes Issue #80 TypeScript/CI error by adding result parsing in publish-constants.ts and removing undefined variable access.\n\n- Adds  and safe fallbacks for logs.\n- Builds locally; should unblock the workflow job in Actions.\n\nAfter merge, we can re-touch constants.json to confirm publish pipeline succeeds end-to-end.