### PR TITLE
chore(constants): re‑verify auto‑publish with no‑op change

### DIFF
--- a/clean-x-hedgehog-templates/config/constants.json
+++ b/clean-x-hedgehog-templates/config/constants.json
@@ -4,8 +4,8 @@
   "HUBDB_COURSES_TABLE_ID": "135381433",
   "DEFAULT_SOCIAL_IMAGE_URL": "https://hedgehog.cloud/hubfs/social-share-default.png",
   "ENABLE_CRM_PROGRESS": true,
-  "LOGIN_URL": "/_hcms/mem/login",
   "LOGOUT_URL": "/_hcms/mem/logout",
+  "LOGIN_URL": "/_hcms/mem/login",
   "TRACK_EVENTS_ENABLED": true,
   "TRACK_EVENTS_URL": "https://hvoog2lnha.execute-api.us-west-2.amazonaws.com/events/track"
 }


### PR DESCRIPTION
Reorders keys in constants.json (no functional change) to trigger the publish workflow after PR #81 fix. On merge to main, expect publish job success. Will verify with SHA/diff and report on Issue #80.