### PR TITLE
ops: add CloudWatch alarms + composite; deploy workflow inputs; runbook update

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,6 +1,15 @@
 name: Deploy AWS (manual)
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: "Serverless stage (e.g., dev, staging, prod)"
+        required: true
+        default: "dev"
+      region:
+        description: "AWS region (e.g., us-west-2)"
+        required: true
+        default: "${{ secrets.AWS_REGION }}"
 
 jobs:
   deploy:
@@ -19,8 +28,8 @@ jobs:
         env:
           HUBSPOT_PRIVATE_APP_TOKEN: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
           HUBSPOT_ACCOUNT_ID: ${{ secrets.HUBSPOT_ACCOUNT_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          APP_STAGE: prod
+          AWS_REGION: ${{ github.event.inputs.region || secrets.AWS_REGION }}
+          APP_STAGE: ${{ github.event.inputs.stage }}
 
       - name: Verify package size
         run: |
@@ -68,7 +77,7 @@ jobs:
       - name: Verify deployment configuration
         run: |
           echo "=== Deployment Configuration ==="
-          npx serverless print --stage prod --region ${{ secrets.AWS_REGION }} | grep -E "(region|stage|runtime)" || true
+          npx serverless print --stage ${{ github.event.inputs.stage }} --region ${{ github.event.inputs.region || secrets.AWS_REGION }} | grep -E "(region|stage|runtime)" || true
 
       - name: Deploy to AWS
         run: npm run deploy:aws
@@ -77,7 +86,7 @@ jobs:
           HUBSPOT_PROJECT_ACCESS_TOKEN: ${{ secrets.HUBSPOT_PROJECT_ACCESS_TOKEN }}
           HUBSPOT_PRIVATE_APP_TOKEN: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
           HUBSPOT_ACCOUNT_ID: ${{ secrets.HUBSPOT_ACCOUNT_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ github.event.inputs.region || secrets.AWS_REGION }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          APP_STAGE: prod
+          APP_STAGE: ${{ github.event.inputs.stage }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,19 @@ _Last updated: keep in sync when major platform or integration changes land._
 - HubSpot Private App token with required scopes
 - Serverless Framework installed (`npm install` includes it as dev dependency)
 
+### Observability & Alarms (added Oct 13, 2025)
+- CloudWatch alarms are provisioned via CloudFormation in `serverless.yml`:
+  - `hedgehog-learn-${APP_STAGE}-lambda-errors` (AWS/Lambda Errors ≥ 5 over 1 min)
+  - `hedgehog-learn-${APP_STAGE}-lambda-throttles` (AWS/Lambda Throttles ≥ 1 within 5 min)
+  - `hedgehog-learn-${APP_STAGE}-httpapi-5xx` (AWS/ApiGateway 5XXError ≥ 5 over 1 min; Stage `$default`)
+  - `hedgehog-learn-${APP_STAGE}-httpapi-latency` (AWS/ApiGateway Latency avg ≥ 1000 ms over 5 min; Stage `$default`)
+  - Composite: `hedgehog-learn-${APP_STAGE}-api-red` (OR of the four alarms above)
+
+Notes
+- HTTP API uses the `$default` stage in this project; CloudWatch metrics use `Stage=$default` as the dimension value.
+- Alarm actions (SNS) are intentionally not wired yet. Add an SNS topic ARN and hook via `AlarmActions` if paging is required.
+- Costs are minimal at current scale (<< $25/mo); see CloudWatch pricing.
+
 ### Environment Variables Required
 
 #### For Local Deployment

--- a/serverless.yml
+++ b/serverless.yml
@@ -157,3 +157,86 @@ package:
     - '!*.html'
     - '!*.csv'
     - '!scratch.txt'
+
+resources:
+  Resources:
+    # Lambda error alarm (sum of Errors in 1-minute periods)
+    ApiLambdaErrorsAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-lambda-errors
+        Namespace: AWS/Lambda
+        MetricName: Errors
+        Dimensions:
+          - Name: FunctionName
+            Value: { Ref: ApiLambdaFunction }
+        Statistic: Sum
+        Period: 60
+        EvaluationPeriods: 1
+        Threshold: 5
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+
+    # Lambda throttles alarm (any throttle within 5 minutes)
+    ApiLambdaThrottlesAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-lambda-throttles
+        Namespace: AWS/Lambda
+        MetricName: Throttles
+        Dimensions:
+          - Name: FunctionName
+            Value: { Ref: ApiLambdaFunction }
+        Statistic: Sum
+        Period: 60
+        EvaluationPeriods: 5
+        Threshold: 1
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+
+    # API Gateway 5XX errors (HTTP API)
+    ApiGateway5xxAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-httpapi-5xx
+        Namespace: AWS/ApiGateway
+        MetricName: 5XXError
+        Dimensions:
+          - Name: ApiId
+            Value: { Ref: HttpApi }
+          - Name: Stage
+            Value: "$default"
+        Statistic: Sum
+        Period: 60
+        EvaluationPeriods: 1
+        Threshold: 5
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+
+    # API Gateway latency (average > 1s over 5 minutes)
+    ApiGatewayLatencyAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-httpapi-latency
+        Namespace: AWS/ApiGateway
+        MetricName: Latency
+        Dimensions:
+          - Name: ApiId
+            Value: { Ref: HttpApi }
+          - Name: Stage
+            Value: "$default"
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 5
+        Threshold: 1000
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+
+    # Composite alarm: page when any of the above are ALARM
+    ApiErrorCompositeAlarm:
+      Type: AWS::CloudWatch::CompositeAlarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-api-red
+        AlarmRule:
+          Fn::Sub: |
+            ALARM('${ApiLambdaErrorsAlarm}') OR ALARM('${ApiGateway5xxAlarm}') OR ALARM('${ApiLambdaThrottlesAlarm}') OR ALARM('${ApiGatewayLatencyAlarm}')


### PR DESCRIPTION
## Summary

Adds baseline CloudWatch monitoring for Lambda and API Gateway with composite alarm for overall health.

## Changes

- [x] **Adds 4 metric alarms + 1 composite alarm**
  - `hedgehog-learn-dev-lambda-errors` (Errors ≥ 5, 1 min)
  - `hedgehog-learn-dev-lambda-throttles` (Throttles ≥ 1, within 5 mins)
  - `hedgehog-learn-dev-httpapi-5xx` (5XXError ≥ 5, 1 min)
  - `hedgehog-learn-dev-httpapi-latency` (Latency avg ≥ 1000 ms, 5 mins)
  - `hedgehog-learn-dev-api-red` (composite OR of the above)

- [x] **Uses HTTP API Stage `$default` in metric dimensions**
  - Correctly targets the default stage used by our HTTP API

- [x] **Manual deploy workflow accepts stage and region inputs**
  - `stage` input with default "dev"
  - `region` input with default from secrets.AWS_REGION

- [x] **Docs updated (Observability & Alarms)**
  - Added new section in `docs/architecture.md`
  - Documents alarm thresholds, stage dimension, and cost notes

- [x] **Packaging verified locally; no Lambda code changes**
  - CloudFormation template validated with all 5 alarm resources
  - No changes to runtime code

- [x] **No changes to constants.json**
  - Infrastructure-only changes

## Verification Steps

After merge and deploy:

1. **Deploy via GitHub Actions**:
   - Go to Actions → "Deploy AWS (manual)"
   - Inputs: `stage=dev`, `region=us-west-2`
   - Wait for success

2. **Verify alarms in AWS Console**:
   ```bash
   aws cloudwatch describe-alarms \
     --alarm-names hedgehog-learn-dev-lambda-errors \
                   hedgehog-learn-dev-httpapi-5xx \
                   hedgehog-learn-dev-httpapi-latency \
                   hedgehog-learn-dev-lambda-throttles \
                   hedgehog-learn-dev-api-red \
     --region us-west-2 \
     --query 'MetricAlarms[].{Name:AlarmName,State:StateValue}' \
     --output table
   ```

3. **Smoke test endpoints** (unchanged):
   ```bash
   curl -s https://hvoog2lnha.execute-api.us-west-2.amazonaws.com/progress/read
   # Expected: {"mode":"anonymous"}
   
   curl -s -X POST https://hvoog2lnha.execute-api.us-west-2.amazonaws.com/events/track \
     -H 'Content-Type: application/json' \
     --data '{"eventName":"learning_module_started","payload":{"module_slug":"intro-to-hedgehog"}}'
   # Expected: {"status":"logged","mode":"anonymous"}
   ```

## Related

- Builds on PR #85 (Lambda deployment stabilization)
- No runtime dependencies changed
- Safe infrastructure-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
