### PR TITLE
fix: remove trailing whitespace from CompositeAlarm rule

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -238,5 +238,4 @@ resources:
       Properties:
         AlarmName: ${self:service}-${sls:stage}-api-red
         AlarmRule:
-          Fn::Sub: |
-            ALARM('${ApiLambdaErrorsAlarm}') OR ALARM('${ApiGateway5xxAlarm}') OR ALARM('${ApiLambdaThrottlesAlarm}') OR ALARM('${ApiGatewayLatencyAlarm}')
+          Fn::Sub: "ALARM('${ApiLambdaErrorsAlarm}') OR ALARM('${ApiGateway5xxAlarm}') OR ALARM('${ApiLambdaThrottlesAlarm}') OR ALARM('${ApiGatewayLatencyAlarm}')"


### PR DESCRIPTION
## Issue

PR #86 introduced a CompositeAlarm with a trailing newline in the AlarmRule that causes deployment failure:

```
CREATE_FAILED: ApiErrorCompositeAlarm (AWS::CloudWatch::CompositeAlarm)
AlarmRule must not contain leading or trailing whitespace or be null
```

## Fix

Changed from YAML block scalar (`|`) to quoted string to avoid trailing newline.

**Before:**
```yaml
AlarmRule:
  Fn::Sub: |
    ALARM('...')
```

**After:**
```yaml
AlarmRule:
  Fn::Sub: "ALARM('...')"
```

## Testing

- Verified fix locally with serverless package
- CloudFormation template no longer has trailing whitespace in AlarmRule

Fixes deployment blocker introduced in #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)