### PR TITLE
fix: add DependsOn to CompositeAlarm for metric alarms

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -235,6 +235,11 @@ resources:
     # Composite alarm: page when any of the above are ALARM
     ApiErrorCompositeAlarm:
       Type: AWS::CloudWatch::CompositeAlarm
+      DependsOn:
+        - ApiLambdaErrorsAlarm
+        - ApiLambdaThrottlesAlarm
+        - ApiGateway5xxAlarm
+        - ApiGatewayLatencyAlarm
       Properties:
         AlarmName: ${self:service}-${sls:stage}-api-red
         AlarmRule:


### PR DESCRIPTION
## Issue

CompositeAlarm deployment failed because it tried to reference alarms that didn't exist yet:

```
CREATE_FAILED: ApiErrorCompositeAlarm
Could not save the composite alarm as alarms [...] in the alarm rule do not exist
```

## Fix

Added explicit `DependsOn` to CompositeAlarm to ensure the 4 individual metric alarms are created first.

## Testing

Ready for immediate merge and deploy.

Fixes #86 deployment blocker (second issue after #87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)