### PR TITLE
Add MVP content slice: 1 course + 1 pathway

### DIFF
--- a/content/courses/accessing-the-hedgehog-virtual-lab.json
+++ b/content/courses/accessing-the-hedgehog-virtual-lab.json
@@ -1,0 +1,12 @@
+{
+  "slug": "accessing-the-hedgehog-virtual-lab",
+  "title": "Accessing the Hedgehog Virtual Lab",
+  "summary_markdown": "Learn how to access the Hedgehog Virtual Lab across AWS, Azure, and Google Cloud. This course walks you through prerequisites, login, and environment setup so you can start learning fast.",
+  "modules": [
+    "accessing-the-hedgehog-virtual-lab-with-amazon-web-services",
+    "accessing-the-hedgehog-virtual-lab-with-microsoft-azure",
+    "accessing-the-hedgehog-virtual-lab-with-google-cloud"
+  ],
+  "display_order": 1,
+  "tags": "getting-started,virtual-lab"
+}

--- a/content/pathways/getting-started-with-hedgehog-lab.json
+++ b/content/pathways/getting-started-with-hedgehog-lab.json
@@ -1,0 +1,8 @@
+{
+  "slug": "getting-started-with-hedgehog-lab",
+  "title": "Getting Started with Hedgehog Lab",
+  "summary_markdown": "Start here to get hands‑on in the Hedgehog Virtual Lab. Follow this guided pathway to access the lab in your preferred cloud and complete your introductory exercises.",
+  "courses": ["accessing-the-hedgehog-virtual-lab"],
+  "display_order": 1,
+  "tags": "getting-started"
+}


### PR DESCRIPTION
## Summary
Creates minimal viable content for MVP launch:
- **Course**: "Accessing the Hedgehog Virtual Lab" (references 3 existing modules)
- **Pathway**: "Getting Started with Hedgehog Lab" (references the new course)

This enables a clean content-first launch with:
- 3 modules (already present in repo)
- 1 real course
- 1 pathway

## Content Details

### Course: `accessing-the-hedgehog-virtual-lab.json`
- **Slug**: `accessing-the-hedgehog-virtual-lab`
- **Title**: "Accessing the Hedgehog Virtual Lab"
- **Modules**: 
  - accessing-the-hedgehog-virtual-lab-with-amazon-web-services
  - accessing-the-hedgehog-virtual-lab-with-microsoft-azure
  - accessing-the-hedgehog-virtual-lab-with-google-cloud

### Pathway: `getting-started-with-hedgehog-lab.json`
- **Slug**: `getting-started-with-hedgehog-lab`
- **Title**: "Getting Started with Hedgehog Lab"
- **Courses**: [`accessing-the-hedgehog-virtual-lab`]

## Post-Merge Actions
After merging:
1. Run sync commands:
   ```bash
   npm run sync:content && npm run sync:courses && npm run sync:pathways
   ```
2. Publish pages in HubSpot:
   - `/learn` (main landing)
   - `/learn/modules` (list)
   - `/learn/courses` (list)
   - `/learn/pathways` (list)
   - Course detail page
   - 3 module detail pages
3. Verification:
   - HubDB row counts (modules: 3, courses: 1, pathways: 1)
   - Live URLs for list + detail pages
   - Beacon tests (incognito + logged-in) with screenshots
   - Contact Properties spot-check for test user

## Next Steps
After MVP launch, scale content to 10 modules / 2 courses / 1 pathway over the next week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)