### PR TITLE
fix: add hardcoded fallback table IDs for courses/pathways rendering

### DIFF
--- a/clean-x-hedgehog-templates/learn/courses-page.html
+++ b/clean-x-hedgehog-templates/learn/courses-page.html
@@ -493,7 +493,7 @@
 
           <!-- Course Content: Prefer content_blocks_json if present, otherwise fallback to module_slugs_json -->
           {% set constants = get_asset_url("/CLEAN x HEDGEHOG/templates/config/constants.json")|request_json %}
-          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants else hubdb_table_id("modules") %}
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "135621904" %}
 
           {% if dynamic_page_hubdb_row.content_blocks_json %}
             {# Render content blocks (narrative-driven course) #}

--- a/clean-x-hedgehog-templates/learn/pathways-page.html
+++ b/clean-x-hedgehog-templates/learn/pathways-page.html
@@ -592,8 +592,8 @@
 
           <!-- Pathway Content: Prefer course_slugs_json if present, otherwise fallback to module_slugs_json -->
           {% set constants = get_asset_url("/CLEAN x HEDGEHOG/templates/config/constants.json")|request_json %}
-          {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID if constants else hubdb_table_id("courses") %}
-          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants else hubdb_table_id("modules") %}
+          {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else "135381433" %}
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "135621904" %}
 
           {% if dynamic_page_hubdb_row.course_slugs_json and courses_table_id %}
             {# Prefer courses when available #}


### PR DESCRIPTION
## Summary

Adds hardcoded fallback table IDs to course and pathway templates to ensure modules/courses render even when `constants.json` fails to load or is cached.

## Problem

Issue #98 reported that course and pathway detail pages were not displaying their associated modules/courses. Investigation revealed:

1. ✅ HubDB tables have correct schema with all required columns
2. ✅ All data is present and correct in HubDB  
3. ✅ Path matching works - all modules/courses are findable via API
4. ⚠️  Templates rely on loading `constants.json` via `get_asset_url()` + `request_json`
5. ❌ If `constants.json` doesn't load (caching, path issues, etc), `modules_table_id` is undefined
6. ❌ Template logic skips rendering when table IDs are undefined

## Solution

Added hardcoded fallback table IDs when `constants.json` is unavailable or empty:

**courses-page.html:**
```hubl
{% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "135621904" %}
```

**pathways-page.html:**
```hubl
{% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else "135381433" %}
{% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "135621904" %}
```

## Changes

- `clean-x-hedgehog-templates/learn/courses-page.html`: Add fallback for `modules_table_id`
- `clean-x-hedgehog-templates/learn/pathways-page.html`: Add fallbacks for `courses_table_id` and `modules_table_id`

## Testing

### Diagnostic Evidence

<details>
<summary>HubDB Schema Verification ✅</summary>

All required columns present:
- `module_slugs_json` ✓
- `content_blocks_json` ✓  
- `course_slugs_json` ✓

Tables published and up-to-date.
</details>

<details>
<summary>Data Verification ✅</summary>

Course Authoring 101:
- 3 modules in `module_slugs_json` ✓
- 6 content blocks including 3 module_ref blocks ✓

Course Authoring Expert Pathway:
- 2 courses in `course_slugs_json` ✓
- All referenced modules/courses exist and are findable ✓
</details>

<details>
<summary>Path Matching ✅</summary>

API queries work perfectly - all modules and courses findable via the same path matching logic templates use.
</details>

### Verification Status

Templates uploaded and published. Due to HubSpot CDN caching, changes may take time to propagate. The fix ensures fallback table IDs are always available even if `constants.json` fails to load.

## Related Issues

Fixes #98

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>