### PR TITLE
Fix: functional ‘Back to …’ links on detail pages

### DIFF
--- a/clean-x-hedgehog-templates/learn/courses-page.html
+++ b/clean-x-hedgehog-templates/learn/courses-page.html
@@ -469,7 +469,7 @@
         <div class="course-detail">
           <!-- Breadcrumbs -->
           <nav class="course-breadcrumbs">
-            <a href="{{ request.path|split('/')|slice(0,-1)|join('/') }}">← Back to Courses</a>
+            <a href="/learn/courses">← Back to Courses</a>
           </nav>
 
           <!-- Course Header -->

--- a/clean-x-hedgehog-templates/learn/module-page.html
+++ b/clean-x-hedgehog-templates/learn/module-page.html
@@ -646,7 +646,7 @@
         <div class="module-detail">
           <!-- Breadcrumbs -->
           <nav class="module-breadcrumbs">
-            <a href="{{ request.path|split('/')|slice(0,-1)|join('/') }}">← Back to Learning Portal</a>
+            <a href="/learn">← Back to Learning Portal</a>
           </nav>
 
           <!-- Module Header -->

--- a/clean-x-hedgehog-templates/learn/pathways-page.html
+++ b/clean-x-hedgehog-templates/learn/pathways-page.html
@@ -526,7 +526,7 @@
         <div class="pathway-detail">
           <!-- Breadcrumbs -->
           <nav class="pathway-breadcrumbs">
-            <a href="{{ request.path|split('/')|slice(0,-1)|join('/') }}">← Back to Learning Pathways</a>
+            <a href="/learn/pathways">← Back to Learning Pathways</a>
           </nav>
 
           <!-- Pathway Header -->


### PR DESCRIPTION
This fixes the non-functional breadcrumb links on detail views.\n\nChanges\n- Module detail → `/learn`\n- Course detail → `/learn/courses`\n- Pathway detail → `/learn/pathways`\n\nRationale\n- Previous implementation derived parent path from `request.path`, which proved brittle with routing and trailing-slash differences. Canonical list URLs are stable.\n\nVerification\n- Open any detail page and click the back link — it navigates correctly.\n- No changes to debug banners or content rendering.\n\nRefs #128