### PR TITLE
ci: path-scope deploy push to relevant files (follow-up for #144)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -2,14 +2,6 @@ name: Deploy AWS
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'serverless.yml'
-      - 'src/**'
-      - 'dist/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/deploy-aws.yml'
-      - 'aws/**'
     tags:
       - 'v*'
   workflow_dispatch:
@@ -29,7 +21,29 @@ on:
         default: false
 
 jobs:
+  changes:
+    if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.filter.outputs.deploy }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            deploy:
+              - 'serverless.yml'
+              - 'src/**'
+              - 'dist/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/deploy-aws.yml'
+              - 'aws/**'
+
   deploy:
+    needs: changes
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     permissions: { contents: read }
     steps:


### PR DESCRIPTION
This follow-up PR narrows the push trigger for `deploy-aws.yml` so that deploy CI only runs when deployment-relevant files change. This reduces noisy failures on docs-only or template-only PRs while preserving deploy coverage when it matters.

- Path-scoped `push` to:
  - `serverless.yml`, `src/**`, `dist/**`, `package.json`, `package-lock.json`, `.github/workflows/deploy-aws.yml`, `aws/**`
- No change to `tags: [v*]` or to `workflow_dispatch`.
- No change to e2e (already path-scoped for push and PR).

Context: #144 experienced unrelated failures from push workflows; this PR implements the previously proposed scoping without changing any required checks or protections.

Once merged, future docs- or content-only changes won’t trigger deploy jobs on `main` unless paths above are touched.
