### PR TITLE
catalog: absolute macro import for left-nav (fix publish validator) [skip-docs-check]

### DIFF
--- a/clean-x-hedgehog-templates/learn/catalog.html
+++ b/clean-x-hedgehog-templates/learn/catalog.html
@@ -3,7 +3,7 @@
   isAvailableForNewContent: true
 -->
 {% extends "../layouts/base.html" %}
-{% from "macros/left-nav.html" import learning_left_nav %}
+{% from "/CLEAN x HEDGEHOG/templates/learn/macros/left-nav.html" import learning_left_nav %}
 
 {% block head %}
   {{ super() }}


### PR DESCRIPTION
Switch macro import in catalog.html from relative to absolute path to resolve HubSpot validator error: ‘Could not resolve function `learning_left_nav`’. No UI change. Verified local build + CMS validate dry-run still OK.\n\n- From: \n- To: \n\nAfter merge, please (re)publish the Catalog template to clear the validator warning.