### PR TITLE
docs: resolve issue #197 - CloudFormation ChangeSet deployment failure

### DIFF
--- a/docs/learn-launch-runbook.md
+++ b/docs/learn-launch-runbook.md
@@ -264,7 +264,7 @@ POST https://hvoog2lnha.execute-api.us-west-2.amazonaws.com/events/track
 4. Click **Run workflow** and monitor deployment
 
 **Post-Deployment Verification:**
-- [ ] Deployment completes successfully _(API dispatch using reviewer token returned 204 on 2025-10-17, but no new workflow run appeared—needs owner follow-up to confirm GitHub token scopes or trigger from UI.)_
+- [x] Deployment completes successfully _(Manual workflow_dispatch run 18618585385 completed successfully on 2025-10-18T17:13Z; see `verification-output/issue-188/github-deploy-dispatch-success-2025-10-18T171311Z.log` and `issue-197-resolution-summary.md`.)_
 - [x] POST `/events/track` returns `mode: "authenticated"` (when user logged in) _(See `verification-output/issue-188/events-track-auth-response.json`.)_
 - [x] Contact Properties update in HubSpot CRM within 2-3 minutes _(HubSpot contact snapshot `verification-output/issue-188/hubspot-contact-progress-after.json` updated with new module slug at 2025-10-17T17:49Z.)_
 - [x] No CloudWatch alarms triggered _(All relevant alarms report `OK` in `verification-output/issue-188/aws-cloudwatch-alarms.json`.)_

--- a/verification-output/issue-188/issue-197-resolution-summary.md
+++ b/verification-output/issue-188/issue-197-resolution-summary.md
@@ -1,0 +1,79 @@
+# Issue #197 Resolution Summary
+
+## Issue
+Manual runs of `.github/workflows/deploy-aws.yml` were failing with CloudFormation error:
+```
+Cannot delete ChangeSet in status CREATE_IN_PROGRESS
+```
+
+## Investigation (2025-10-18T17:13Z)
+
+### CloudFormation Stack Status
+- Stack Name: `hedgehog-learn-dev`
+- Stack Status: `UPDATE_COMPLETE` (no issues found)
+- Region: `us-west-2`
+- ChangeSets: No stale ChangeSets detected
+
+### Root Cause
+The previous failure (run ID 18618316985 at 2025-10-18T16:48Z) encountered a transient CloudFormation state where a ChangeSet was still in `CREATE_IN_PROGRESS` status, preventing Serverless Framework from deleting it during deployment.
+
+By the time investigation began (~25 minutes later), the CloudFormation stack had returned to a clean `UPDATE_COMPLETE` state with no lingering ChangeSets.
+
+## Resolution
+
+### Actions Taken
+1. **Investigated CloudFormation stack**: Confirmed stack status was `UPDATE_COMPLETE` with no stale ChangeSets
+2. **Re-triggered deployment**: Initiated new workflow_dispatch run (ID 18618585385)
+3. **Successful deployment**: Workflow completed successfully in 1m42s
+
+### Verification Results
+
+#### Workflow Run Details
+- **Run ID**: 18618585385
+- **Trigger**: workflow_dispatch (manual)
+- **Status**: ✓ Success
+- **Duration**: 1m42s
+- **Timestamp**: 2025-10-18T17:13:11Z
+- **Branch**: main
+- **Inputs**:
+  - stage: `dev`
+  - region: `us-west-2`
+  - enable_crm_progress: `true`
+
+#### Deployment Verification
+```bash
+# Lambda configuration confirmed
+$ aws lambda get-function-configuration --function-name hedgehog-learn-dev-api
+ENABLE_CRM_PROGRESS: true
+
+# Stack last updated
+$ aws cloudformation describe-stacks --stack-name hedgehog-learn-dev
+LastUpdatedTime: 2025-10-18T17:14:14.393000+00:00
+```
+
+#### Evidence Artifacts
+- Successful deployment log: `verification-output/issue-188/github-deploy-dispatch-success-2025-10-18T171311Z.log`
+- Failed deployment log (reference): `verification-output/issue-188/github-deploy-dispatch-attempt-2025-10-18T164845Z.log`
+
+## Runbook Update
+The manual deploy checkbox in `docs/learn-launch-runbook.md` (line 267) can now be marked complete:
+- ✓ Deployment completes successfully
+- ✓ ENABLE_CRM_PROGRESS confirmed as `true`
+- ✓ CloudFormation stack successfully updated
+
+## Next Steps
+1. Update `docs/learn-launch-runbook.md` to reflect successful deployment
+2. Close Issue #197
+3. Update Issue #188 runbook verification status
+
+## Notes
+- The original ChangeSet error appears to have been transient
+- No manual CloudFormation intervention was required
+- Simply re-running the workflow after ~25 minutes resolved the issue
+- Future occurrences of this error can likely be resolved by waiting a few minutes and retrying
+
+## Related Issues
+- Issue #197: CloudFormation ChangeSet failure (this issue)
+- Issue #193: workflow_dispatch failure (fixed in PR #194)
+- Issue #188: MVP launch runbook tracking
+- Issue #195: Branch protection check naming mismatch (resolved)


### PR DESCRIPTION
## Summary
Resolves #197 by investigating and successfully resolving the CloudFormation ChangeSet deployment failure.

## Investigation Results
- **CloudFormation Stack**: `hedgehog-learn-dev` in `UPDATE_COMPLETE` status
- **ChangeSet Status**: No stale ChangeSets detected
- **Root Cause**: Previous deployment encountered a transient ChangeSet in `CREATE_IN_PROGRESS` status. By the time we investigated (~25 minutes later), the stack had recovered to a clean state.

## Resolution
Successfully triggered a fresh manual deployment workflow run that completed without errors.

### Successful Deployment Details
- **Workflow Run**: [18618585385](https://github.com/afewell-hh/hh-learn/actions/runs/18618585385)
- **Status**: ✓ Success
- **Duration**: 1m42s
- **Timestamp**: 2025-10-18T17:13:11Z
- **Configuration**:
  - Stage: `dev`
  - Region: `us-west-2`
  - `ENABLE_CRM_PROGRESS`: `true` ✓

## Changes
- ✓ Update `docs/learn-launch-runbook.md` line 267 to mark deployment checkbox complete
- ✓ Add comprehensive resolution summary: `verification-output/issue-188/issue-197-resolution-summary.md`

## Verification
```bash
# Confirmed ENABLE_CRM_PROGRESS is set
$ aws lambda get-function-configuration --function-name hedgehog-learn-dev-api
ENABLE_CRM_PROGRESS: true

# Stack successfully updated
$ aws cloudformation describe-stacks --stack-name hedgehog-learn-dev
LastUpdatedTime: 2025-10-18T17:14:14.393000+00:00
```

## Test Plan
- [x] CloudFormation stack checked and confirmed healthy
- [x] Manual deployment workflow run completed successfully
- [x] Lambda environment variable `ENABLE_CRM_PROGRESS` verified as `true`
- [x] Runbook updated with verification evidence
- [x] Resolution summary documented

## Impact
This completes the final pending item in the MVP launch runbook (Issue #188) for enabling authenticated CRM progress tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)