### PR TITLE
fix: Add JWT_SECRET to Package Lambda step (Issue #248)

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           HUBSPOT_PRIVATE_APP_TOKEN: ${{ secrets.HUBSPOT_PRIVATE_APP_TOKEN }}
           HUBSPOT_ACCOUNT_ID: ${{ secrets.HUBSPOT_ACCOUNT_ID }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
           AWS_REGION: ${{ github.event.inputs.region || secrets.AWS_REGION }}
           APP_STAGE: ${{ github.event.inputs.stage }}
           ENABLE_CRM_PROGRESS: ${{ github.event.inputs.enable_crm_progress && 'true' || 'false' }}


### PR DESCRIPTION
## Summary
Fixes the deployment workflow to include JWT_SECRET in the Package Lambda step.

## Problem
The deployment workflow was failing at the "Package Lambda" step with the error:
```
Cannot resolve variable at "provider.environment.JWT_SECRET": Value not found at "env" source
```

This happened because `JWT_SECRET` was only configured in the "Deploy to AWS" step but not in the "Package Lambda" step, where serverless needs it to resolve the `provider.environment.JWT_SECRET` variable in serverless.yml.

## Solution
Added `JWT_SECRET: ${{ secrets.JWT_SECRET }}` to the environment variables for the "Package Lambda" step.

## Testing
- Will trigger deployment after PR merge
- Will verify /auth/login endpoint works with JWT authentication
- Will run API smoke tests from Issue #248

## Related Issues
- Resolves #248 (partially - enables JWT authentication in Lambda)
- Fixes deployment workflow for JWT-based authentication

## Checklist
- [x] Workflow file updated
- [ ] Deployment successful (after merge)
- [ ] /auth/login endpoint tested
- [ ] API smoke tests passing