### PR TITLE
feat(shadow-env): Phase 0A — clone and isolate CMS assets for shadow HH-Learn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ test-results/
 playwright-report/
 aws/
 awscliv2.zip
-module-page.html
+/module-page.html
 
 # Build output
 dist-cjs/

--- a/clean-x-hedgehog-templates/assets/css/learn-landing.css
+++ b/clean-x-hedgehog-templates/assets/css/learn-landing.css
@@ -1,0 +1,418 @@
+/* Learn Landing Page Specific Styles */
+/* Issue #286: Dedicated /learn landing page */
+
+/* ==================== BUTTON STYLES ==================== */
+
+/* Primary button - main CTAs */
+.button {
+  display: inline-block;
+  padding: 12px 24px;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  text-align: center;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border: none;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.button-primary {
+  background: #1a4e8a;
+  color: #fff;
+  border: 2px solid #1a4e8a;
+}
+
+.button-primary:hover {
+  background: #0d2855;
+  border-color: #0d2855;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(26, 78, 138, 0.3);
+}
+
+.button-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(26, 78, 138, 0.3);
+}
+
+/* Secondary button - alternative CTAs */
+.button-secondary {
+  background: transparent;
+  color: #1a4e8a;
+  border: 2px solid #1a4e8a;
+}
+
+.button-secondary:hover {
+  background: #1a4e8a;
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(26, 78, 138, 0.2);
+}
+
+.button-secondary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(26, 78, 138, 0.2);
+}
+
+/* Large button variant */
+.button-large {
+  padding: 16px 32px;
+  font-size: 1.125rem;
+}
+
+/* Hero CTA button container */
+.hero-ctas {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+/* ==================== LAYOUT STRUCTURE ==================== */
+
+/* Main landing page container */
+.learn-landing {
+  width: 100%;
+}
+
+/* Content container with max-width and padding */
+.landing-content-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 32px 64px 32px;
+}
+
+/* Section spacing */
+.landing-section {
+  margin-top: 80px;
+  margin-bottom: 80px;
+}
+
+.landing-section:first-child {
+  margin-top: 64px;
+}
+
+/* Section headers */
+.section-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.section-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 12px 0;
+  letter-spacing: -0.5px;
+}
+
+.section-subtitle {
+  font-size: 1.125rem;
+  color: #6B7280;
+  margin: 0;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ==================== LEVEL CARDS SECTION ==================== */
+
+.level-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.level-card {
+  background: #fff;
+  border: 2px solid #E5E7EB;
+  border-radius: 12px;
+  padding: 32px 24px;
+  text-align: center;
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.level-card:hover {
+  border-color: #1a4e8a;
+  box-shadow: 0 8px 20px rgba(26, 78, 138, 0.12);
+  transform: translateY(-4px);
+}
+
+.level-icon {
+  font-size: 3rem;
+  margin-bottom: 8px;
+}
+
+.level-card-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.level-card-description {
+  font-size: 1rem;
+  color: #6B7280;
+  line-height: 1.6;
+  margin: 0;
+  flex-grow: 1;
+}
+
+/* Level-specific colors */
+.level-card-beginner:hover {
+  border-color: #10B981;
+}
+
+.level-card-intermediate:hover {
+  border-color: #F59E0B;
+}
+
+.level-card-advanced:hover {
+  border-color: #8B5CF6;
+}
+
+/* ==================== EMPTY STATE ==================== */
+
+.empty-state {
+  text-align: center;
+  padding: 64px 32px;
+  background: #F9FAFB;
+  border-radius: 12px;
+  border: 1px dashed #D1D5DB;
+}
+
+.empty-state p {
+  font-size: 1.125rem;
+  color: #6B7280;
+  margin: 0 0 24px 0;
+}
+
+.empty-state .button {
+  margin-top: 8px;
+}
+
+/* ==================== FINAL CTA SECTION ==================== */
+
+.landing-cta-section {
+  background: linear-gradient(135deg, #1a4e8a 0%, #0d2855 100%);
+  color: #fff;
+  padding: 80px 32px;
+  border-radius: 16px;
+  margin-top: 96px;
+  text-align: center;
+}
+
+.cta-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.cta-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 16px 0;
+  letter-spacing: -0.5px;
+}
+
+.cta-subtitle {
+  font-size: 1.25rem;
+  margin: 0 0 32px 0;
+  opacity: 0.95;
+  line-height: 1.6;
+}
+
+.cta-buttons {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.landing-cta-section .button-primary {
+  background: #fff;
+  color: #1a4e8a;
+  border-color: #fff;
+}
+
+.landing-cta-section .button-primary:hover {
+  background: #F3F4F6;
+  border-color: #F3F4F6;
+  color: #0d2855;
+}
+
+/* ==================== RESPONSIVE DESIGN ==================== */
+
+/* Tablet breakpoint */
+@media (max-width: 900px) {
+  .landing-content-container {
+    padding: 0 24px 48px 24px;
+  }
+
+  .landing-section {
+    margin-top: 60px;
+    margin-bottom: 60px;
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+  }
+
+  .section-subtitle {
+    font-size: 1rem;
+  }
+
+  .cta-title {
+    font-size: 2rem;
+  }
+
+  .cta-subtitle {
+    font-size: 1.125rem;
+  }
+
+  .level-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Mobile breakpoint */
+@media (max-width: 768px) {
+  .hero-ctas {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-ctas .button {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .landing-content-container {
+    padding: 0 16px 32px 16px;
+  }
+
+  .landing-section {
+    margin-top: 48px;
+    margin-bottom: 48px;
+  }
+
+  .section-header {
+    margin-bottom: 32px;
+  }
+
+  .section-title {
+    font-size: 1.5rem;
+  }
+
+  .section-subtitle {
+    font-size: 0.9375rem;
+  }
+
+  .landing-cta-section {
+    padding: 60px 24px;
+    margin-top: 64px;
+  }
+
+  .cta-title {
+    font-size: 1.75rem;
+  }
+
+  .cta-subtitle {
+    font-size: 1rem;
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+  }
+
+  .cta-buttons .button {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .level-card {
+    padding: 24px 20px;
+  }
+
+  .level-icon {
+    font-size: 2.5rem;
+  }
+
+  .level-card-title {
+    font-size: 1.25rem;
+  }
+
+  .empty-state {
+    padding: 48px 24px;
+  }
+
+  .empty-state p {
+    font-size: 1rem;
+  }
+}
+
+/* Small mobile breakpoint */
+@media (max-width: 375px) {
+  .button {
+    font-size: 0.9375rem;
+    padding: 10px 20px;
+  }
+
+  .button-large {
+    font-size: 1rem;
+    padding: 14px 28px;
+  }
+}
+
+/* ==================== ACCESSIBILITY ==================== */
+
+/* Focus styles for keyboard navigation */
+.button:focus {
+  outline: 2px solid #1a4e8a;
+  outline-offset: 2px;
+}
+
+.button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.button:focus-visible {
+  outline: 2px solid #1a4e8a;
+  outline-offset: 2px;
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .button-primary {
+    border-width: 3px;
+  }
+
+  .button-secondary {
+    border-width: 3px;
+  }
+
+  .level-card {
+    border-width: 3px;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .catalog-card,
+  .level-card {
+    transition: none;
+  }
+
+  .button:hover,
+  .level-card:hover {
+    transform: none;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/css/catalog.css
+++ b/clean-x-hedgehog-templates/assets/shadow/css/catalog.css
@@ -1,0 +1,248 @@
+/* Catalog Page Specific Styles */
+
+.learn-header-section {
+  width: 100vw;
+  background: #1a4e8a url('https://hedgehog.cloud/hubfs/hh-clouds.webp') center center/cover no-repeat;
+  color: #fff;
+  padding: 96px 0 64px 0;
+  margin-left: calc(-50vw + 50%);
+  margin-right: calc(-50vw + 50%);
+}
+
+.learn-header-content {
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 0 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  text-align: center;
+}
+
+.learn-page-title {
+  font-size: 2.25rem;
+  font-weight: 700;
+  margin: 0;
+  letter-spacing: -0.5px;
+}
+
+.learn-page-subtitle {
+  font-size: 1.125rem;
+  font-weight: 400;
+  margin: 0;
+  opacity: 0.9;
+}
+
+/* Catalog grid layout */
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 20px;
+  margin-top: 32px;
+}
+
+/* Catalog card */
+.catalog-card {
+  border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  padding: 20px;
+  background: #fff;
+  transition: box-shadow 0.2s, transform 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.catalog-card:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transform: translateY(-2px);
+}
+
+/* Hidden cards (filtered out) */
+.catalog-card.hidden {
+  display: none;
+}
+
+.catalog-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Type badges */
+.catalog-type-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.catalog-type-module {
+  background: #EFF6FF;
+  color: #1E40AF;
+}
+
+.catalog-type-course {
+  background: #F0FDF4;
+  color: #15803D;
+}
+
+.catalog-type-pathway {
+  background: #FEF3C7;
+  color: #92400E;
+}
+
+/* Level badge */
+.catalog-level-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: #F3F4F6;
+  color: #6B7280;
+}
+
+.catalog-card-title {
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.4;
+  font-weight: 600;
+}
+
+.catalog-card-title a {
+  color: #1a4e8a;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.catalog-card-title a:hover {
+  color: #0066CC;
+}
+
+.catalog-card-summary {
+  color: #666;
+  line-height: 1.65;
+  font-size: 0.95rem;
+  flex-grow: 1;
+}
+
+.catalog-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  color: #4B5563;
+  font-size: 0.875rem;
+  padding-top: 6px;
+  border-top: 1px solid #E5E7EB;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.catalog-meta-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
+}
+
+.catalog-card-cta {
+  color: #1a4e8a;
+  text-decoration: none;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 8px;
+  transition: color 0.2s, text-decoration-color 0.2s;
+}
+
+.catalog-card-cta:hover {
+  color: #1a4e8a;
+  text-decoration: underline;
+}
+
+/* Filter controls */
+.learn-filter-clear {
+  width: 100%;
+  padding: 10px 16px;
+  background: #fff;
+  border: 1px solid #D1D5DB;
+  border-radius: 6px;
+  color: #374151;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-top: 16px;
+}
+
+.learn-filter-clear:hover {
+  background: #F9FAFB;
+  border-color: #9CA3AF;
+}
+
+.learn-filter-clear:active {
+  background: #F3F4F6;
+}
+
+.learn-filter-results {
+  margin-top: 16px;
+  padding: 12px;
+  background: #F0F9FF;
+  border: 1px solid #BFDBFE;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #1E40AF;
+  text-align: center;
+}
+
+.learn-filter-results strong {
+  font-weight: 700;
+}
+
+/* No results message */
+.no-results {
+  text-align: center;
+  padding: 64px 32px;
+  color: #6B7280;
+}
+
+.no-results p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+
+/* Screen reader only */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 900px) {
+  .catalog-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .learn-page-title {
+    font-size: 2rem;
+  }
+
+  .learn-page-subtitle {
+    font-size: 1rem;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/css/learn-landing.css
+++ b/clean-x-hedgehog-templates/assets/shadow/css/learn-landing.css
@@ -1,0 +1,418 @@
+/* Learn Landing Page Specific Styles */
+/* Issue #286: Dedicated /learn landing page */
+
+/* ==================== BUTTON STYLES ==================== */
+
+/* Primary button - main CTAs */
+.button {
+  display: inline-block;
+  padding: 12px 24px;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  text-align: center;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border: none;
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.button-primary {
+  background: #1a4e8a;
+  color: #fff;
+  border: 2px solid #1a4e8a;
+}
+
+.button-primary:hover {
+  background: #0d2855;
+  border-color: #0d2855;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(26, 78, 138, 0.3);
+}
+
+.button-primary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(26, 78, 138, 0.3);
+}
+
+/* Secondary button - alternative CTAs */
+.button-secondary {
+  background: transparent;
+  color: #1a4e8a;
+  border: 2px solid #1a4e8a;
+}
+
+.button-secondary:hover {
+  background: #1a4e8a;
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(26, 78, 138, 0.2);
+}
+
+.button-secondary:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(26, 78, 138, 0.2);
+}
+
+/* Large button variant */
+.button-large {
+  padding: 16px 32px;
+  font-size: 1.125rem;
+}
+
+/* Hero CTA button container */
+.hero-ctas {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+/* ==================== LAYOUT STRUCTURE ==================== */
+
+/* Main landing page container */
+.learn-landing {
+  width: 100%;
+}
+
+/* Content container with max-width and padding */
+.landing-content-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 32px 64px 32px;
+}
+
+/* Section spacing */
+.landing-section {
+  margin-top: 80px;
+  margin-bottom: 80px;
+}
+
+.landing-section:first-child {
+  margin-top: 64px;
+}
+
+/* Section headers */
+.section-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.section-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0 0 12px 0;
+  letter-spacing: -0.5px;
+}
+
+.section-subtitle {
+  font-size: 1.125rem;
+  color: #6B7280;
+  margin: 0;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* ==================== LEVEL CARDS SECTION ==================== */
+
+.level-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.level-card {
+  background: #fff;
+  border: 2px solid #E5E7EB;
+  border-radius: 12px;
+  padding: 32px 24px;
+  text-align: center;
+  transition: all 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.level-card:hover {
+  border-color: #1a4e8a;
+  box-shadow: 0 8px 20px rgba(26, 78, 138, 0.12);
+  transform: translateY(-4px);
+}
+
+.level-icon {
+  font-size: 3rem;
+  margin-bottom: 8px;
+}
+
+.level-card-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.level-card-description {
+  font-size: 1rem;
+  color: #6B7280;
+  line-height: 1.6;
+  margin: 0;
+  flex-grow: 1;
+}
+
+/* Level-specific colors */
+.level-card-beginner:hover {
+  border-color: #10B981;
+}
+
+.level-card-intermediate:hover {
+  border-color: #F59E0B;
+}
+
+.level-card-advanced:hover {
+  border-color: #8B5CF6;
+}
+
+/* ==================== EMPTY STATE ==================== */
+
+.empty-state {
+  text-align: center;
+  padding: 64px 32px;
+  background: #F9FAFB;
+  border-radius: 12px;
+  border: 1px dashed #D1D5DB;
+}
+
+.empty-state p {
+  font-size: 1.125rem;
+  color: #6B7280;
+  margin: 0 0 24px 0;
+}
+
+.empty-state .button {
+  margin-top: 8px;
+}
+
+/* ==================== FINAL CTA SECTION ==================== */
+
+.landing-cta-section {
+  background: linear-gradient(135deg, #1a4e8a 0%, #0d2855 100%);
+  color: #fff;
+  padding: 80px 32px;
+  border-radius: 16px;
+  margin-top: 96px;
+  text-align: center;
+}
+
+.cta-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.cta-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 16px 0;
+  letter-spacing: -0.5px;
+}
+
+.cta-subtitle {
+  font-size: 1.25rem;
+  margin: 0 0 32px 0;
+  opacity: 0.95;
+  line-height: 1.6;
+}
+
+.cta-buttons {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.landing-cta-section .button-primary {
+  background: #fff;
+  color: #1a4e8a;
+  border-color: #fff;
+}
+
+.landing-cta-section .button-primary:hover {
+  background: #F3F4F6;
+  border-color: #F3F4F6;
+  color: #0d2855;
+}
+
+/* ==================== RESPONSIVE DESIGN ==================== */
+
+/* Tablet breakpoint */
+@media (max-width: 900px) {
+  .landing-content-container {
+    padding: 0 24px 48px 24px;
+  }
+
+  .landing-section {
+    margin-top: 60px;
+    margin-bottom: 60px;
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+  }
+
+  .section-subtitle {
+    font-size: 1rem;
+  }
+
+  .cta-title {
+    font-size: 2rem;
+  }
+
+  .cta-subtitle {
+    font-size: 1.125rem;
+  }
+
+  .level-cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Mobile breakpoint */
+@media (max-width: 768px) {
+  .hero-ctas {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .hero-ctas .button {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .landing-content-container {
+    padding: 0 16px 32px 16px;
+  }
+
+  .landing-section {
+    margin-top: 48px;
+    margin-bottom: 48px;
+  }
+
+  .section-header {
+    margin-bottom: 32px;
+  }
+
+  .section-title {
+    font-size: 1.5rem;
+  }
+
+  .section-subtitle {
+    font-size: 0.9375rem;
+  }
+
+  .landing-cta-section {
+    padding: 60px 24px;
+    margin-top: 64px;
+  }
+
+  .cta-title {
+    font-size: 1.75rem;
+  }
+
+  .cta-subtitle {
+    font-size: 1rem;
+  }
+
+  .cta-buttons {
+    flex-direction: column;
+  }
+
+  .cta-buttons .button {
+    width: 100%;
+    max-width: 320px;
+  }
+
+  .level-card {
+    padding: 24px 20px;
+  }
+
+  .level-icon {
+    font-size: 2.5rem;
+  }
+
+  .level-card-title {
+    font-size: 1.25rem;
+  }
+
+  .empty-state {
+    padding: 48px 24px;
+  }
+
+  .empty-state p {
+    font-size: 1rem;
+  }
+}
+
+/* Small mobile breakpoint */
+@media (max-width: 375px) {
+  .button {
+    font-size: 0.9375rem;
+    padding: 10px 20px;
+  }
+
+  .button-large {
+    font-size: 1rem;
+    padding: 14px 28px;
+  }
+}
+
+/* ==================== ACCESSIBILITY ==================== */
+
+/* Focus styles for keyboard navigation */
+.button:focus {
+  outline: 2px solid #1a4e8a;
+  outline-offset: 2px;
+}
+
+.button:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.button:focus-visible {
+  outline: 2px solid #1a4e8a;
+  outline-offset: 2px;
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .button-primary {
+    border-width: 3px;
+  }
+
+  .button-secondary {
+    border-width: 3px;
+  }
+
+  .level-card {
+    border-width: 3px;
+  }
+}
+
+/* Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .catalog-card,
+  .level-card {
+    transition: none;
+  }
+
+  .button:hover,
+  .level-card:hover {
+    transform: none;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/css/left-nav.css
+++ b/clean-x-hedgehog-templates/assets/shadow/css/left-nav.css
@@ -1,0 +1,289 @@
+/* Learning Left Navigation and Filter Panel Styles */
+
+/* Layout wrapper for list pages with left nav */
+.learn-layout-with-nav {
+  display: flex;
+  gap: 32px;
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 40px 32px;
+  align-items: flex-start;
+}
+
+/* Left navigation sidebar */
+.learn-left-nav {
+  width: 260px;
+  flex-shrink: 0;
+  background: #ffffff;
+  border: 1px solid #E5E7EB;
+  border-radius: 12px;
+  padding: 24px;
+  position: sticky;
+  top: 24px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+}
+
+.learn-left-nav-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Navigation links */
+.learn-nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.learn-nav-link,
+.learn-auth-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: #374151;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  transition: all 0.2s;
+}
+
+.learn-nav-link:hover,
+.learn-auth-link:hover {
+  background: #F3F4F6;
+  color: #1a4e8a;
+}
+
+.learn-nav-link.active {
+  background: #EFF6FF;
+  color: #1a4e8a;
+  font-weight: 600;
+}
+
+.learn-nav-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.learn-nav-text {
+  flex: 1;
+}
+
+/* Divider */
+.learn-nav-divider {
+  height: 1px;
+  background: #E5E7EB;
+  margin: 8px 0;
+}
+
+/* Auth section */
+.learn-nav-auth {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.learn-user-greeting {
+  padding: 8px 16px;
+  color: #6B7280;
+  font-size: 0.875rem;
+}
+
+/* Filters */
+.learn-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.learn-filters-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.learn-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.learn-filter-group fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.learn-filter-label,
+.learn-filter-group legend {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.learn-filter-search,
+.learn-filter-select {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #D1D5DB;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: #fff;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.learn-filter-search:focus,
+.learn-filter-select:focus {
+  outline: none;
+  border-color: #1a4e8a;
+  box-shadow: 0 0 0 3px rgba(26, 78, 138, 0.1);
+}
+
+.learn-filter-search:disabled,
+.learn-filter-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: #F9FAFB;
+}
+
+.learn-filter-options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.learn-filter-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: #374151;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.learn-filter-checkbox:hover {
+  color: #1a4e8a;
+}
+
+.learn-filter-checkbox input {
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+  accent-color: #1a4e8a;
+}
+
+.learn-filter-checkbox input:disabled {
+  cursor: not-allowed;
+}
+
+.learn-filters-note {
+  font-size: 0.75rem;
+  color: #9CA3AF;
+  font-style: italic;
+  margin: 8px 0 0 0;
+  text-align: center;
+}
+
+/* Main content area when using left nav */
+.learn-main-content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Mobile nav overlay */
+.learn-nav-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 998;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.learn-nav-overlay.active {
+  display: block;
+  opacity: 1;
+}
+
+/* Mobile toggle button */
+.learn-nav-toggle {
+  display: none;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #1a4e8a;
+  color: white;
+  border: none;
+  box-shadow: 0 4px 12px rgba(26, 78, 138, 0.3);
+  cursor: pointer;
+  z-index: 999;
+  transition: transform 0.2s;
+}
+
+.learn-nav-toggle:hover {
+  transform: scale(1.1);
+}
+
+.learn-nav-toggle-icon {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+/* Responsive behavior - under 900px */
+@media (max-width: 900px) {
+  .learn-layout-with-nav {
+    padding: 24px 16px;
+  }
+
+  .learn-left-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 280px;
+    max-height: 100vh;
+    border-radius: 0;
+    border-right: 1px solid #E5E7EB;
+    border-left: none;
+    border-top: none;
+    border-bottom: none;
+    z-index: 999;
+    transform: translateX(-100%);
+    transition: transform 0.3s;
+    margin: 0;
+    padding-top: 32px;
+  }
+
+  .learn-left-nav.active {
+    transform: translateX(0);
+  }
+
+  .learn-nav-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .learn-main-content {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .learn-left-nav {
+    width: 100%;
+    max-width: 320px;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/css/module-media.css
+++ b/clean-x-hedgehog-templates/assets/shadow/css/module-media.css
@@ -1,0 +1,63 @@
+.module-media-gallery {
+  margin: 32px 0;
+}
+
+.module-media-gallery h2 {
+  font-size: 1.5rem;
+  margin-bottom: 16px;
+}
+
+.module-media-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.module-media-card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.06);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.module-media-card img,
+.module-media-card video {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: #f5f7fa;
+}
+
+.module-media-card--video video {
+  background: #0b1f3a;
+}
+
+.module-media-card video {
+  max-height: 360px;
+}
+
+.module-media-card figcaption {
+  padding: 16px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: #1f2933;
+}
+
+.module-media-caption + .module-media-credit {
+  margin-top: 6px;
+}
+
+.module-media-credit {
+  display: block;
+  font-size: 0.85rem;
+  color: #52606d;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .module-media-card video {
+    animation: none;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/css/registration.css
+++ b/clean-x-hedgehog-templates/assets/shadow/css/registration.css
@@ -1,0 +1,341 @@
+/* Registration Page Styles */
+
+.registration-hero {
+  width: 100vw;
+  background: linear-gradient(135deg, #1a4e8a 0%, #0d2847 100%);
+  color: #fff;
+  padding: 96px 0 64px 0;
+  margin-left: calc(-50vw + 50%);
+  margin-right: calc(-50vw + 50%);
+  text-align: center;
+}
+
+.registration-hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.registration-title {
+  font-size: 3rem;
+  font-weight: 700;
+  margin: 0 0 16px 0;
+  letter-spacing: -1px;
+}
+
+.registration-subtitle {
+  font-size: 1.25rem;
+  margin: 0;
+  opacity: 0.9;
+  line-height: 1.6;
+}
+
+/* Main registration section */
+.registration-section {
+  padding: 64px 0;
+  background: #F9FAFB;
+}
+
+.registration-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.registration-layout {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 48px;
+  align-items: start;
+}
+
+/* Benefits sidebar */
+.registration-benefits {
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+  position: sticky;
+  top: 32px;
+}
+
+.registration-benefits h2 {
+  font-size: 1.5rem;
+  margin: 0 0 24px 0;
+  color: #111827;
+}
+
+.benefits-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.benefits-list li {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.benefit-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+.benefit-content h3 {
+  margin: 0 0 8px 0;
+  font-size: 1.125rem;
+  color: #1a4e8a;
+}
+
+.benefit-content p {
+  margin: 0;
+  color: #6B7280;
+  line-height: 1.6;
+}
+
+/* Registration form container */
+.registration-form-container {
+  background: #fff;
+  border-radius: 12px;
+  padding: 40px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+}
+
+.registration-form-container h2 {
+  font-size: 1.75rem;
+  margin: 0 0 32px 0;
+  color: #111827;
+}
+
+/* Form styles */
+.membership-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.9375rem;
+}
+
+.required {
+  color: #DC2626;
+}
+
+.optional {
+  color: #9CA3AF;
+  font-weight: 400;
+  font-size: 0.875rem;
+}
+
+.form-input,
+.form-select {
+  padding: 12px 16px;
+  border: 1px solid #D1D5DB;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.form-input:focus,
+.form-select:focus {
+  outline: none;
+  border-color: #1a4e8a;
+  box-shadow: 0 0 0 3px rgba(26, 78, 138, 0.1);
+}
+
+.form-input::placeholder {
+  color: #9CA3AF;
+}
+
+.form-select {
+  cursor: pointer;
+  background-color: #fff;
+}
+
+/* Checkbox group */
+.checkbox-group {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  cursor: pointer;
+  color: #374151;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+}
+
+.form-checkbox {
+  margin-top: 4px;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #1a4e8a;
+}
+
+.checkbox-label a {
+  color: #0066CC;
+  text-decoration: none;
+}
+
+.checkbox-label a:hover {
+  text-decoration: underline;
+}
+
+/* Submit button */
+.form-submit {
+  padding: 14px 32px;
+  background: #1a4e8a;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+  margin-top: 8px;
+}
+
+.form-submit:hover {
+  background: #144173;
+}
+
+.form-submit:active {
+  transform: scale(0.98);
+}
+
+.form-submit:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(26, 78, 138, 0.3);
+}
+
+/* Form note */
+.form-note {
+  margin-top: 24px;
+  padding: 16px;
+  background: #FEF3C7;
+  border: 1px solid #FCD34D;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.form-note p {
+  margin: 0;
+  color: #92400E;
+}
+
+.form-note strong {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.form-note code {
+  background: #FDE68A;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.8125rem;
+}
+
+/* Registration footer */
+.registration-footer {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid #E5E7EB;
+  text-align: center;
+}
+
+.registration-footer p {
+  margin: 0;
+  color: #6B7280;
+}
+
+.registration-footer a {
+  color: #0066CC;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.registration-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Responsive design */
+@media (max-width: 900px) {
+  .registration-title {
+    font-size: 2.25rem;
+  }
+
+  .registration-subtitle {
+    font-size: 1.125rem;
+  }
+
+  .registration-layout {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .registration-benefits {
+    position: static;
+  }
+
+  .registration-form-container {
+    padding: 32px 24px;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .registration-hero {
+    padding: 64px 0 48px 0;
+  }
+
+  .registration-title {
+    font-size: 1.875rem;
+  }
+
+  .registration-section {
+    padding: 48px 0;
+  }
+
+  .registration-container {
+    padding: 0 16px;
+  }
+
+  .registration-benefits {
+    padding: 24px;
+  }
+
+  .registration-form-container {
+    padding: 24px 20px;
+  }
+}

--- a/clean-x-hedgehog-templates/assets/shadow/js/action-runner.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/action-runner.js
@@ -1,0 +1,464 @@
+/**
+ * Hedgehog Learn – Private Action Runner (Issue #245)
+ * Executes enrollment and progress operations on a private HubSpot page
+ * so public pages never need to send contact identifiers with actions.
+ */
+(function(){
+  'use strict';
+
+  function ready(fn){
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function parseJSON(value, fallback){
+    if (!value) return fallback;
+    try { return JSON.parse(value); } catch { return fallback; }
+  }
+
+  function sanitizeRedirect(url){
+    if (!url) return '/learn';
+    try {
+      var anchor = document.createElement('a');
+      anchor.href = url;
+      if (!anchor.host) {
+        return url.charAt(0) === '/' ? url : '/learn';
+      }
+      if (anchor.host !== window.location.host) return '/learn';
+      return anchor.pathname + anchor.search + anchor.hash;
+    } catch {
+      return '/learn';
+    }
+  }
+
+  function buildLoginRedirect(loginUrl, redirectUrl){
+    var base = loginUrl || '/_hcms/mem/login';
+    var target = redirectUrl || '/learn';
+    var join = base.indexOf('?') >= 0 ? '&' : '?';
+    return base + join + 'redirect_url=' + encodeURIComponent(target);
+  }
+
+  function redirectToLogin(loginUrl, redirectUrl){
+    var target = redirectUrl || (window.location.pathname + window.location.search + window.location.hash);
+    if (window.hhLoginHelper && typeof window.hhLoginHelper.login === 'function') {
+      window.hhLoginHelper.login(target);
+      return;
+    }
+    window.location.href = buildLoginRedirect(loginUrl, target);
+  }
+
+  function setStatus(opts){
+    var titleEl = document.getElementById('action-runner-title');
+    var messageEl = document.getElementById('action-runner-message');
+    var detailsEl = document.getElementById('action-runner-details');
+    var spinnerEl = document.getElementById('action-runner-spinner');
+    var badgeEl = document.getElementById('runner-badge');
+    var iconEl = document.getElementById('runner-icon');
+
+    if (opts.icon && iconEl) iconEl.textContent = opts.icon;
+    if (opts.badge && badgeEl) badgeEl.textContent = opts.badge;
+    if (titleEl && typeof opts.title === 'string') titleEl.textContent = opts.title;
+    if (messageEl && typeof opts.message === 'string') messageEl.textContent = opts.message;
+    if (detailsEl) {
+      if (opts.details) {
+        detailsEl.innerHTML = opts.details;
+        detailsEl.style.display = 'block';
+      } else {
+        detailsEl.innerHTML = '';
+        detailsEl.style.display = 'none';
+      }
+    }
+    if (spinnerEl) spinnerEl.style.display = opts.showSpinner ? 'block' : 'none';
+  }
+
+  function showActions(primaryLabel, primaryHandler, secondaryHref){
+    var actionsEl = document.getElementById('action-runner-actions');
+    var primaryBtn = document.getElementById('action-runner-primary');
+    var secondaryBtn = document.getElementById('action-runner-secondary');
+    if (!actionsEl || !primaryBtn || !secondaryBtn) return;
+    actionsEl.style.display = 'flex';
+    primaryBtn.textContent = primaryLabel || 'Return to Learn';
+    primaryBtn.onclick = null;
+    if (typeof primaryHandler === 'function') {
+      primaryBtn.addEventListener('click', function(evt){
+        evt.preventDefault();
+        primaryHandler();
+      }, { once: true });
+    } else if (typeof primaryHandler === 'string') {
+      primaryBtn.href = primaryHandler;
+    }
+    if (secondaryHref) secondaryBtn.href = secondaryHref;
+  }
+
+  function storeResult(payload){
+    try {
+      sessionStorage.setItem('hhl_last_action', JSON.stringify(payload));
+    } catch {
+      // ignore storage failures
+    }
+  }
+
+  function buildEventPayload(actionKey, params, status){
+    var now = new Date().toISOString();
+    if (actionKey === 'enroll_pathway') {
+      return [{
+        eventName: 'learning_pathway_enrolled',
+        payload: {
+          pathway_slug: params.slug,
+          course_slug: params.course_slug || null,
+          ts: now
+        },
+        enrollment_source: params.source || 'action_runner'
+      }];
+    }
+    if (actionKey === 'enroll_course') {
+      return [{
+        eventName: 'learning_course_enrolled',
+        payload: {
+          course_slug: params.slug,
+          pathway_slug: params.pathway_slug || null,
+          ts: now
+        },
+        enrollment_source: params.source || 'action_runner'
+      }];
+    }
+    if (actionKey === 'record_progress') {
+      var modulePayload = {
+        module_slug: params.module_slug,
+        pathway_slug: params.pathway_slug || null,
+        course_slug: params.course_slug || null,
+        ts: now
+      };
+      if (status === 'completed') {
+        return [
+          { eventName: 'learning_module_started', payload: modulePayload },
+          { eventName: 'learning_module_completed', payload: modulePayload }
+        ];
+      }
+      return [{ eventName: 'learning_module_started', payload: modulePayload }];
+    }
+    return [];
+  }
+
+  function parseTrackResponse(response){
+    if (!response.ok) {
+      return response.text().then(function(text){
+        var error = new Error('Track endpoint returned ' + response.status);
+        error.responseText = text;
+        error.code = 'http_' + response.status;
+        throw error;
+      });
+    }
+
+    var contentType = response.headers && response.headers.get ? response.headers.get('content-type') || '' : '';
+
+    if (contentType.indexOf('application/json') >= 0) {
+      return response.json().catch(function(){
+        return {};
+      });
+    }
+
+    return response.text().then(function(text){
+      if (!text) return {};
+      try {
+        return JSON.parse(text);
+      } catch {
+        return { raw: text };
+      }
+    });
+  }
+
+  function ensurePersisted(result){
+    if (result && result.status === 'persisted' && result.mode === 'authenticated') {
+      return result;
+    }
+
+    var error = new Error('Event did not persist to CRM');
+    if (result && result.mode === 'anonymous') {
+      error.code = 'missing_identity';
+    } else {
+      error.code = 'persistence_unconfirmed';
+    }
+    error.responseData = result || null;
+    throw error;
+  }
+
+  function executeEvents(trackUrl, contactIdentifier, events){
+    if (!events.length) return Promise.resolve();
+    var queue = Promise.resolve();
+    events.forEach(function(evt){
+      queue = queue.then(function(){
+        var body = {
+          eventName: evt.eventName,
+          payload: evt.payload
+        };
+        if (evt.enrollment_source) {
+          body.enrollment_source = evt.enrollment_source;
+        }
+        if (contactIdentifier && (contactIdentifier.email || contactIdentifier.contactId)) {
+          body.contactIdentifier = {};
+          if (contactIdentifier.email) body.contactIdentifier.email = contactIdentifier.email;
+          if (contactIdentifier.contactId) body.contactIdentifier.contactId = contactIdentifier.contactId;
+        }
+        return fetch(trackUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body)
+        })
+          .then(parseTrackResponse)
+          .then(ensurePersisted);
+      });
+    });
+    return queue;
+  }
+
+  function runAction(context, params, redirectUrl){
+    var actionKey = context.actionKey;
+    var status = params.get('status') || '';
+    var payloadEvents = buildEventPayload(actionKey, {
+      slug: params.get('slug'),
+      source: params.get('source'),
+      course_slug: params.get('course_slug'),
+      pathway_slug: params.get('pathway_slug'),
+      module_slug: params.get('module_slug')
+    }, status);
+
+    if (!payloadEvents.length) {
+      var err = new Error('Unsupported action payload');
+      err.code = 'payload_unsupported';
+      return Promise.reject(err);
+    }
+
+    return executeEvents(context.trackUrl, context.contactIdentifier, payloadEvents).then(function(){
+      storeResult({
+        action: actionKey,
+        status: 'success',
+        redirect: redirectUrl,
+        timestamp: new Date().toISOString(),
+        params: {
+          slug: params.get('slug'),
+          module_slug: params.get('module_slug'),
+          status: status,
+          source: params.get('source') || null
+        }
+      });
+    });
+  }
+
+  function humanize(actionKey, phase){
+    var base = {
+      'enroll_pathway': { start: 'Enrolling you in the pathway…', success: 'Pathway enrolled!', failure: 'Unable to enroll in the pathway.' },
+      'enroll_course': { start: 'Enrolling you in the course…', success: 'Course enrolled!', failure: 'Unable to enroll in the course.' },
+      'record_progress': { start: 'Saving your progress…', success: 'Progress saved!', failure: 'Unable to save your progress.' }
+    };
+    var phrases = base[actionKey] || base.record_progress;
+    return phrases[phase] || '';
+  }
+
+  function validateRequired(config, params){
+    var missing = [];
+    (config.required || []).forEach(function(name){
+      if (!params.get(name)) missing.push(name);
+    });
+    return missing;
+  }
+
+  ready(function(){
+    var contextNode = document.getElementById('hhl-action-runner');
+    if (!contextNode) return;
+    if (contextNode.dataset.isEditor === 'true') return;
+
+    var params = new URLSearchParams(window.location.search);
+    var actionKey = (params.get('action') || '').toLowerCase();
+    var redirectUrl = sanitizeRedirect(params.get('redirect_url') || '/learn');
+    var allowedActions = parseJSON(contextNode.dataset.actions, {});
+    var trackUrl = contextNode.dataset.trackUrl || '';
+    var loginUrl = contextNode.dataset.loginUrl || 'https://api.hedgehog.cloud/auth/login';
+
+    // Ensure secondary button always points home page to keep exit path
+    var secondaryBtn = document.getElementById('action-runner-secondary');
+    if (secondaryBtn) secondaryBtn.href = redirectUrl;
+
+    // Check action validity BEFORE auth - preserve previous behavior
+    if (!actionKey || !allowedActions[actionKey]) {
+      setStatus({
+        icon: '⛔️',
+        badge: 'Action blocked',
+        title: 'Unsupported action requested',
+        message: 'The requested action is not on the approved whitelist.',
+        details: 'Double-check the link you used. If this keeps happening, contact support.',
+        showSpinner: false
+      });
+      showActions('Return to Learn', function(){ window.location.href = '/learn'; }, redirectUrl);
+      return;
+    }
+
+    // Wait for Cognito identity to be ready
+    // DO NOT use server-side dataset.isLoggedIn - it reflects HubSpot Membership, not Cognito
+    if (!window.hhIdentity || !window.hhIdentity.ready) {
+      setStatus({
+        icon: '⚠️',
+        badge: 'Auth not ready',
+        title: 'Authentication system not loaded',
+        message: 'Please refresh the page to complete this action.',
+        showSpinner: false
+      });
+      showActions('Refresh page', function(){ window.location.reload(); }, redirectUrl);
+      return;
+    }
+
+    // Use window.hhIdentity.ready promise to wait for auth state
+    window.hhIdentity.ready
+      .then(function() {
+        var identityData = window.hhIdentity.get() || {};
+        var isLoggedIn = window.hhIdentity.isAuthenticated();
+        var contactIdentifier = {
+          email: identityData.email || '',
+          contactId: identityData.contactId || ''
+        };
+
+        // Action already validated above - check auth state
+
+        if (!isLoggedIn) {
+      setStatus({
+        icon: '🔒',
+        badge: 'Sign-in required',
+        title: 'Please sign in to continue',
+        message: 'This secure action can only run while you are signed in.',
+        details: 'You will be redirected to the login screen so we can verify your identity safely.',
+        showSpinner: false
+      });
+      showActions('Sign in to continue', function(){
+        redirectToLogin(loginUrl, window.location.pathname + window.location.search + window.location.hash);
+      }, '/learn');
+      return;
+    }
+
+    if (!trackUrl) {
+      setStatus({
+        icon: '⚠️',
+        badge: 'Configuration error',
+        title: 'Missing action endpoint',
+        message: 'We could not locate the backend endpoint required to run this action.',
+        details: 'Try reloading the page. If the problem persists, contact the Learn team.',
+        showSpinner: false
+      });
+      showActions('Reload', function(){ window.location.reload(); }, redirectUrl);
+      return;
+    }
+
+    if (!contactIdentifier.email && !contactIdentifier.contactId) {
+      setStatus({
+        icon: '🛑',
+        badge: 'Identity unavailable',
+        title: 'We could not verify your identity',
+        message: 'Please sign in again so we can complete this action securely.',
+        showSpinner: false
+      });
+      showActions('Sign in again', function(){
+        redirectToLogin(loginUrl, window.location.pathname + window.location.search + window.location.hash);
+      }, '/learn');
+      return;
+    }
+
+    var actionConfig = allowedActions[actionKey] || {};
+    var missingParams = validateRequired(actionConfig, params);
+    if (missingParams.length) {
+      setStatus({
+        icon: '📝',
+        badge: 'Incomplete request',
+        title: 'Missing required information',
+        message: 'We need a bit more detail to finish this action.',
+        details: 'Missing parameters: <strong>' + missingParams.join(', ') + '</strong>',
+        showSpinner: false
+      });
+      showActions('Return to previous page', function(){ window.location.href = redirectUrl; }, '/learn');
+      return;
+    }
+
+    setStatus({
+      icon: '⚙️',
+      badge: 'Processing',
+      title: humanize(actionKey, 'start'),
+      message: 'We are securely contacting the Hedgehog Learn backend. This usually takes a moment.',
+      details: '',
+      showSpinner: true
+    });
+
+    runAction({
+      actionKey: actionKey,
+      trackUrl: trackUrl,
+      contactIdentifier: contactIdentifier
+    }, params, redirectUrl).then(function(){
+      setStatus({
+        icon: '✅',
+        badge: 'Success',
+        title: humanize(actionKey, 'success'),
+        message: 'Redirecting you back in just a moment.',
+        details: '',
+        showSpinner: false
+      });
+      showActions('Return now', function(){ window.location.href = redirectUrl; }, redirectUrl);
+      setTimeout(function(){
+        window.location.href = redirectUrl;
+      }, 1200);
+    }).catch(function(error){
+      console.error('[hhl-action-runner] Action failed:', error);
+      storeResult({
+        action: actionKey,
+        status: 'error',
+        redirect: redirectUrl,
+        timestamp: new Date().toISOString(),
+        error: error && error.message ? error.message : 'unknown'
+      });
+      var detail = '';
+      if (error && error.responseData) {
+        try {
+          var pretty = JSON.stringify(error.responseData, null, 2);
+          detail = '<pre style="text-align:left; white-space:pre-wrap;">' + pretty.substring(0, 600) + '</pre>';
+        } catch {
+          detail = '<pre style="text-align:left; white-space:pre-wrap;">' + String(error.responseData).substring(0, 400) + '</pre>';
+        }
+      } else if (error && error.responseText) {
+        detail = '<pre style="text-align:left; white-space:pre-wrap;">' + error.responseText.substring(0, 400) + '</pre>';
+      }
+      var failureMessage = 'No changes were made. You can retry or head back to the previous page.';
+      if (error && error.code === 'missing_identity') {
+        failureMessage = 'We could not confirm your membership session, so enrollment was not saved. Please sign in again and retry.';
+      } else if (error && error.code === 'persistence_unconfirmed') {
+        failureMessage = 'We could not confirm that your enrollment saved to CRM. Please retry in a moment or contact support.';
+      }
+
+      setStatus({
+        icon: '⚠️',
+        badge: 'Action failed',
+        title: humanize(actionKey, 'failure'),
+        message: failureMessage,
+        details: detail,
+        showSpinner: false
+      });
+      showActions('Try again', function(){ window.location.reload(); }, redirectUrl);
+    });
+      })
+      .catch(function(error) {
+        // Handle auth initialization failure
+        setStatus({
+          icon: '⚠️',
+          badge: 'Auth failed',
+          title: 'Authentication check failed',
+          message: 'We could not verify your authentication status.',
+          details: 'Please try refreshing the page. If the problem persists, contact support.',
+          showSpinner: false
+        });
+        showActions('Refresh page', function(){ window.location.reload(); }, redirectUrl);
+
+        if (console && console.error) {
+          console.error('[action-runner] Auth initialization failed:', error);
+        }
+      });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/auth-context.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/auth-context.js
@@ -1,0 +1,638 @@
+/**
+ * HHL Membership Identity Bootstrapper (Issue #234)
+ *
+ * This module detects HubSpot CMS membership logins client-side and provides
+ * a unified API for downstream scripts to access authenticated user identity.
+ *
+ * ## Features
+ * - Fetches membership profile from HubSpot CMS API once per page load
+ * - Emits `hhl:identity` custom event with { email, contactId } when resolved
+ * - Provides promise-based API via `window.hhIdentity.ready`
+ * - Provides synchronous access via `window.hhIdentity.get()` after resolution
+ * - Gracefully handles anonymous sessions (returns empty email/contactId)
+ * - Caches result in memory to prevent duplicate network requests
+ * - Privacy-safe debug logging when HHL_DEBUG is enabled
+ *
+ * ## Usage
+ *
+ * ### Promise-based (Recommended)
+ * ```javascript
+ * window.hhIdentity.ready.then(function(identity) {
+ *   if (identity.email) {
+ *     console.log('User is authenticated:', identity.email);
+ *   } else {
+ *     console.log('User is anonymous');
+ *   }
+ * });
+ * ```
+ *
+ * ### Event-based
+ * ```javascript
+ * document.addEventListener('hhl:identity', function(event) {
+ *   var identity = event.detail; // { email: '', contactId: '' }
+ *   // Use identity here
+ * });
+ * ```
+ *
+ * ### Synchronous (after ready resolves)
+ * ```javascript
+ * var identity = window.hhIdentity.get();
+ * if (identity) {
+ *   // Identity is available
+ * }
+ * ```
+ *
+ * ## Related Issues
+ * - Issue #234: Implement membership identity bootstrapper
+ * - Issue #233: Membership login regression on Learn pages
+ * - Issue #237: Membership session instrumentation
+ *
+ * @module auth-context
+ */
+(function() {
+  'use strict';
+
+  // Check if already initialized (prevent double-loading)
+  if (window.hhIdentity) {
+    if (window.hhDebug && window.hhDebug.enabled) {
+      window.hhDebug.warn('auth-context', 'Already initialized, skipping');
+    }
+    return;
+  }
+
+  var debug = localStorage.getItem('HHL_DEBUG') === 'true';
+  var STORED_IDENTITY_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+  function updateAuthContextDom(identity) {
+    var node = document.getElementById('hhl-auth-context');
+    if (!node) return;
+    try {
+      var email = identity && identity.email ? identity.email : '';
+      var contactId = identity && identity.contactId ? String(identity.contactId) : '';
+      if (typeof node.setAttribute === 'function') {
+        node.setAttribute('data-email', email);
+        node.setAttribute('data-contact-id', contactId);
+        if (identity && identity.firstname) {
+          node.setAttribute('data-firstname', identity.firstname);
+        } else {
+          node.removeAttribute('data-firstname');
+        }
+        if (identity && identity.lastname) {
+          node.setAttribute('data-lastname', identity.lastname);
+        } else {
+          node.removeAttribute('data-lastname');
+        }
+      }
+    } catch (err) {
+      if (debug && window.hhDebug) {
+        window.hhDebug.warn('auth-context', 'Failed to update auth context DOM', err && err.message ? err.message : err);
+      }
+    }
+  }
+
+  function emitIdentityEvent(identity) {
+    if (typeof document === 'undefined') return;
+    try {
+      if (typeof window !== 'undefined' && typeof window.CustomEvent === 'function') {
+        var modernEvent = new window.CustomEvent('hhl:identity', {
+          detail: identity,
+          bubbles: true,
+          cancelable: false
+        });
+        document.dispatchEvent(modernEvent);
+        if (debug && window.hhDebug) {
+          window.hhDebug.log('auth-context', 'Dispatched hhl:identity event');
+        }
+        return;
+      }
+      if (typeof document.createEvent === 'function') {
+        var legacyEvent = document.createEvent('CustomEvent');
+        if (legacyEvent && legacyEvent.initCustomEvent) {
+          legacyEvent.initCustomEvent('hhl:identity', true, false, identity);
+          document.dispatchEvent(legacyEvent);
+          if (debug && window.hhDebug) {
+            window.hhDebug.log('auth-context', 'Dispatched hhl:identity event (legacy)');
+          }
+        }
+      }
+    } catch (e) {
+      if (debug && window.hhDebug) {
+        window.hhDebug.warn('auth-context', 'Failed to dispatch hhl:identity event', e && e.message ? e.message : e);
+      }
+    }
+  }
+
+  /**
+   * Identity state
+   * Cached in memory to prevent duplicate API calls
+   */
+  var identityCache = null;
+  var identityResolved = false;
+  var identityPromise = null;
+
+  /**
+   * Fetch membership profile from HubSpot CMS API
+   * Returns { email: string, contactId: string } or null on error
+   *
+   * @returns {Promise<Object>}
+   */
+  function fetchMembershipProfile() {
+    var apiUrl = '/_hcms/api/membership/v1/profile';
+
+    if (debug && window.hhDebug) {
+      window.hhDebug.log('auth-context', 'Fetching membership profile from ' + apiUrl);
+    }
+
+    return fetch(apiUrl, {
+      method: 'GET',
+      credentials: 'include', // Include session cookies
+      headers: {
+        'Accept': 'application/json'
+      }
+    })
+      .then(function(response) {
+        if (response.ok) {
+          return response.json().then(function(data) {
+            if (debug && window.hhDebug) {
+              window.hhDebug.log('auth-context', 'Profile API success', {
+                hasEmail: !!data.email,
+                hasContactId: !!(data.contactId || data.vid || data.hs_object_id)
+              });
+            }
+
+            // Extract contact ID (try multiple field names for compatibility)
+            var contactId = data.contactId ||
+                           data.hs_object_id ||
+                           data.vid ||
+                           '';
+
+            // Convert to string if numeric
+            if (contactId && typeof contactId === 'number') {
+              contactId = String(contactId);
+            }
+
+            return {
+              email: data.email || '',
+              contactId: contactId
+            };
+          });
+        } else if (response.status === 404) {
+          // 404 = No membership session (anonymous user)
+          if (debug && window.hhDebug) {
+            window.hhDebug.log('auth-context', 'Profile API returned 404 - anonymous session');
+          }
+          return { email: '', contactId: '' };
+        } else {
+          // Other error status
+          if (debug && window.hhDebug) {
+            window.hhDebug.warn('auth-context', 'Profile API error status: ' + response.status);
+          }
+          return { email: '', contactId: '' };
+        }
+      })
+      .catch(function(error) {
+        // Network error or other fetch failure
+        if (debug && window.hhDebug) {
+          window.hhDebug.error('auth-context', 'Profile API fetch failed', error.message);
+        }
+        return { email: '', contactId: '' };
+      });
+  }
+
+  /**
+   * Helper function to get constants.json configuration
+   * @param {Object} opts - Options object with constantsUrl
+   * @param {Function} callback - Callback function
+   */
+  function getConstants(opts, callback) {
+    var constantsUrl = opts.constantsUrl || '/learn/config/constants.json';
+    fetch(constantsUrl)
+      .then(function(response) {
+        if (!response.ok) throw new Error('Failed to fetch constants');
+        return response.json();
+      })
+      .then(callback)
+      .catch(function(err) {
+        if (debug && window.hhDebug) {
+          window.hhDebug.error('auth-context', 'Failed to load constants', err.message);
+        }
+        callback(null);
+      });
+  }
+
+  /**
+   * Check if stored JWT token is valid and not expired
+   * @returns {string|null} Token string or null if invalid/expired
+   */
+  function checkStoredToken() {
+    try {
+      var token = localStorage.getItem('hhl_auth_token');
+      var expires = localStorage.getItem('hhl_auth_token_expires');
+
+      if (!token || !expires) {
+        return null;
+      }
+
+      // Check expiry (with 15-minute buffer for refresh)
+      var expiryTime = parseInt(expires, 10);
+      var bufferMs = 15 * 60 * 1000; // 15 minutes
+
+      if (Date.now() >= (expiryTime - bufferMs)) {
+        // Token expired or about to expire
+        localStorage.removeItem('hhl_auth_token');
+        localStorage.removeItem('hhl_auth_token_expires');
+        localStorage.removeItem('hhl_identity_from_jwt');
+        return null;
+      }
+
+      return token;
+    } catch (e) {
+      if (debug && window.hhDebug) {
+        window.hhDebug.warn('auth-context', 'Failed to check stored token', e.message);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Attempt to login with email-only authentication via JWT
+   * Returns JWT token from Lambda /auth/login endpoint
+   * @param {string} email - User email address
+   * @param {string} constantsUrl - URL to constants.json
+   * @returns {Promise<Object>} Identity object with email, contactId, etc.
+   */
+  function attemptJWTLogin(email, constantsUrl) {
+    return new Promise(function(resolve, reject) {
+      getConstants({ constantsUrl: constantsUrl }, function(constants) {
+        if (!constants || !constants.AUTH_LOGIN_URL) {
+          reject(new Error('AUTH_LOGIN_URL not configured in constants'));
+          return;
+        }
+
+        if (debug && window.hhDebug) {
+          window.hhDebug.log('auth-context', 'Attempting JWT login for ' + email);
+        }
+
+        fetch(constants.AUTH_LOGIN_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'omit',
+          body: JSON.stringify({ email: email })
+        })
+        .then(function(response) {
+          if (!response.ok) {
+            return response.json().then(function(err) {
+              throw new Error(err.error || 'Login failed');
+            });
+          }
+          return response.json();
+        })
+        .then(function(data) {
+          // Store JWT token
+          try {
+            localStorage.setItem('hhl_auth_token', data.token);
+            localStorage.setItem('hhl_auth_token_expires', Date.now() + (24 * 60 * 60 * 1000));
+            localStorage.setItem('hhl_identity_from_jwt', JSON.stringify({
+              email: data.email || email,
+              contactId: String(data.contactId || ''),
+              firstname: data.firstname || '',
+              lastname: data.lastname || ''
+            }));
+
+            if (debug && window.hhDebug) {
+              window.hhDebug.log('auth-context', 'JWT login successful');
+            }
+          } catch (e) {
+            if (debug && window.hhDebug) {
+              window.hhDebug.warn('auth-context', 'Failed to store JWT token', e.message);
+            }
+          }
+
+          // Return identity
+          resolve({
+            email: data.email || email,
+            contactId: String(data.contactId || ''),
+            firstname: data.firstname || '',
+            lastname: data.lastname || ''
+          });
+        })
+        .catch(function(err) {
+          if (debug && window.hhDebug) {
+            window.hhDebug.error('auth-context', 'JWT login failed', err.message);
+          }
+          reject(err);
+        });
+      });
+    });
+  }
+
+  /**
+   * Initialize identity detection
+   * Priority order (Issue #272):
+   * 1. HubL server-side data attributes (NEW - preferred for native membership)
+   * 2. JWT token from localStorage (for test automation only)
+   * 3. sessionStorage (from legacy handshake - deprecated)
+   * 4. window.hhServerIdentity (alternative server-side injection)
+   * 5. Membership profile API (fallback for private pages)
+   *
+   * @returns {Promise<Object>}
+   */
+  function initIdentity() {
+    // Return cached promise if already initialized
+    if (identityPromise) {
+      return identityPromise;
+    }
+
+    // Priority 0: Check HubL data attributes from server-side rendering (Issue #272)
+    // This is the new preferred method for native HubSpot membership authentication
+    var authContextDiv = document.getElementById('hhl-auth-context');
+    if (authContextDiv) {
+      var serverEmail = authContextDiv.getAttribute('data-email');
+      var serverContactId = authContextDiv.getAttribute('data-contact-id');
+      var serverFirstname = authContextDiv.getAttribute('data-firstname');
+      var serverLastname = authContextDiv.getAttribute('data-lastname');
+
+      if (serverEmail || serverContactId) {
+        if (debug && window.hhDebug) {
+          window.hhDebug.log('auth-context', 'Using HubL data attributes from server-side rendering (Issue #272)');
+        }
+
+        identityPromise = Promise.resolve({
+          email: serverEmail || '',
+          contactId: serverContactId || '',
+          firstname: serverFirstname || '',
+          lastname: serverLastname || ''
+        });
+
+        return identityPromise.then(function(identity) {
+          identityCache = identity;
+          identityResolved = true;
+          updateAuthContextDom(identity);
+          if (debug && window.hhDebug) {
+            window.hhDebug.log('auth-context', 'Identity resolved from HubL data attributes', {
+              hasEmail: !!identity.email,
+              hasContactId: !!identity.contactId,
+              isAuthenticated: !!(identity.email || identity.contactId)
+            });
+          }
+          emitIdentityEvent(identity);
+          return identity;
+        });
+      }
+    }
+
+    // Priority 1: Check JWT token from localStorage (for test automation only - Issue #251)
+    var token = checkStoredToken();
+    if (token) {
+      // Token is valid, check for stored identity
+      try {
+        var storedJwtIdentity = localStorage.getItem('hhl_identity_from_jwt');
+        if (storedJwtIdentity) {
+          var parsed = JSON.parse(storedJwtIdentity);
+          if (parsed && (parsed.email || parsed.contactId)) {
+            if (debug && window.hhDebug) {
+              window.hhDebug.log('auth-context', 'Using JWT token identity from localStorage (test automation)');
+            }
+            identityPromise = Promise.resolve(parsed);
+            return identityPromise.then(function(identity) {
+              identityCache = identity;
+              identityResolved = true;
+              updateAuthContextDom(identity);
+              if (debug && window.hhDebug) {
+                window.hhDebug.log('auth-context', 'Identity resolved from JWT', {
+                  hasEmail: !!identity.email,
+                  hasContactId: !!identity.contactId,
+                  isAuthenticated: !!(identity.email || identity.contactId)
+                });
+              }
+              emitIdentityEvent(identity);
+              return identity;
+            });
+          }
+        }
+      } catch (e) {
+        if (debug && window.hhDebug) {
+          window.hhDebug.warn('auth-context', 'Failed to read JWT identity from localStorage', e.message);
+        }
+      }
+    }
+
+    // Priority 2: Check sessionStorage (from auth handshake page - deprecated, Issue #244)
+    var storedIdentity = null;
+    try {
+      var stored = sessionStorage.getItem('hhl_identity');
+      if (stored) {
+        storedIdentity = JSON.parse(stored);
+        var ts = 0;
+        if (storedIdentity && storedIdentity.timestamp) {
+          ts = Date.parse(storedIdentity.timestamp);
+        }
+        var isFresh = !ts || (Date.now() - ts) <= STORED_IDENTITY_TTL_MS;
+        if (!isFresh) {
+          sessionStorage.removeItem('hhl_identity');
+          storedIdentity = null;
+        }
+        if (storedIdentity && (storedIdentity.email || storedIdentity.contactId)) {
+          if (debug && window.hhDebug) {
+            window.hhDebug.log('auth-context', 'Using sessionStorage identity from handshake page (deprecated)');
+          }
+          identityPromise = Promise.resolve({
+            email: storedIdentity.email || '',
+            contactId: String(storedIdentity.contactId || ''),
+            firstname: storedIdentity.firstname || '',
+            lastname: storedIdentity.lastname || ''
+          });
+          return identityPromise.then(function(identity) {
+            identityCache = identity;
+            identityResolved = true;
+            updateAuthContextDom(identity);
+            if (debug && window.hhDebug) {
+              window.hhDebug.log('auth-context', 'Identity resolved from sessionStorage', {
+                hasEmail: !!identity.email,
+                hasContactId: !!identity.contactId,
+                isAuthenticated: !!(identity.email || identity.contactId)
+              });
+            }
+            emitIdentityEvent(identity);
+            return identity;
+          });
+        }
+      }
+    } catch (e) {
+      if (debug && window.hhDebug) {
+        window.hhDebug.warn('auth-context', 'Failed to read sessionStorage', e.message);
+      }
+    }
+
+    // Priority 3: Check if server-side identity is available (window.hhServerIdentity)
+    if (window.hhServerIdentity && (window.hhServerIdentity.email || window.hhServerIdentity.contactId)) {
+      if (debug && window.hhDebug) {
+        window.hhDebug.log('auth-context', 'Using server-side identity bootstrap (window.hhServerIdentity)');
+      }
+
+      // Resolve immediately with server identity
+      identityPromise = Promise.resolve({
+        email: window.hhServerIdentity.email || '',
+        contactId: String(window.hhServerIdentity.contactId || ''),
+        firstname: window.hhServerIdentity.firstname || '',
+        lastname: window.hhServerIdentity.lastname || ''
+      });
+    } else {
+      // Priority 4: Fallback to membership profile API (works on private pages)
+      if (debug && window.hhDebug) {
+        window.hhDebug.log('auth-context', 'No server identity found, fetching from membership API');
+      }
+      identityPromise = fetchMembershipProfile();
+    }
+
+    identityPromise = identityPromise
+      .then(function(identity) {
+        // Cache the identity
+        identityCache = identity;
+        identityResolved = true;
+        updateAuthContextDom(identity);
+
+        if (debug && window.hhDebug) {
+          window.hhDebug.log('auth-context', 'Identity resolved', {
+            hasEmail: !!identity.email,
+            hasContactId: !!identity.contactId,
+            isAuthenticated: !!(identity.email || identity.contactId)
+          });
+        }
+
+        // Emit custom event for downstream consumers
+        emitIdentityEvent(identity);
+
+        return identity;
+      });
+
+    return identityPromise;
+  }
+
+  /**
+   * Public API: window.hhIdentity
+   *
+   * Provides unified interface for accessing membership identity
+   */
+  window.hhIdentity = {
+    /**
+     * Promise that resolves when identity is detected
+     * @type {Promise<Object>}
+     *
+     * @example
+     * window.hhIdentity.ready.then(function(identity) {
+     *   console.log('Email:', identity.email);
+     *   console.log('Contact ID:', identity.contactId);
+     * });
+     */
+    ready: null,
+
+    /**
+     * Get identity synchronously (returns null if not yet resolved)
+     * @returns {Object|null} Identity object or null if not yet available
+     *
+     * @example
+     * var identity = window.hhIdentity.get();
+     * if (identity) {
+     *   console.log('User is authenticated:', identity.email);
+     * }
+     */
+    get: function() {
+      if (!identityResolved) {
+        if (debug && window.hhDebug) {
+          window.hhDebug.warn('auth-context', 'Identity not yet resolved, returning null');
+        }
+        return null;
+      }
+      return identityCache;
+    },
+
+    /**
+     * Check if identity has been resolved
+     * @returns {boolean}
+     */
+    isReady: function() {
+      return identityResolved;
+    },
+
+    /**
+     * Check if user is authenticated (has email or contactId)
+     * @returns {boolean|null} True if authenticated, false if anonymous, null if not yet resolved
+     */
+    isAuthenticated: function() {
+      if (!identityResolved) return null;
+      return !!(identityCache && (identityCache.email || identityCache.contactId));
+    },
+
+    /**
+     * Login with email via JWT authentication (Issue #251)
+     * @param {string} email - User email address
+     * @returns {Promise<Object>} Identity object with email, contactId, etc.
+     *
+     * @example
+     * window.hhIdentity.login('user@example.com')
+     *   .then(function(identity) {
+     *     console.log('Logged in:', identity.email);
+     *   })
+     *   .catch(function(err) {
+     *     console.error('Login failed:', err);
+     *   });
+     */
+    login: function(email) {
+      var authDiv = document.getElementById('hhl-auth-context');
+      var constantsUrl = authDiv ? authDiv.getAttribute('data-constants-url') : '/learn/config/constants.json';
+
+      return attemptJWTLogin(email, constantsUrl)
+        .then(function(identity) {
+          // Update cached identity
+          identityCache = identity;
+          identityResolved = true;
+          updateAuthContextDom(identity);
+          emitIdentityEvent(identity);
+
+          if (debug && window.hhDebug) {
+            window.hhDebug.log('auth-context', 'Login successful via JWT', {
+              hasEmail: !!identity.email,
+              hasContactId: !!identity.contactId
+            });
+          }
+
+          return identity;
+        });
+    },
+
+    /**
+     * Logout user by clearing JWT token and identity cache (Issue #251)
+     *
+     * @example
+     * window.hhIdentity.logout();
+     * location.reload(); // Refresh to show anonymous state
+     */
+    logout: function() {
+      try {
+        localStorage.removeItem('hhl_auth_token');
+        localStorage.removeItem('hhl_auth_token_expires');
+        localStorage.removeItem('hhl_identity_from_jwt');
+        identityCache = null;
+        identityResolved = false;
+        identityPromise = null;
+
+        if (debug && window.hhDebug) {
+          window.hhDebug.log('auth-context', 'Logged out - JWT token cleared');
+        }
+      } catch (e) {
+        if (debug && window.hhDebug) {
+          window.hhDebug.error('auth-context', 'Failed to logout', e.message);
+        }
+      }
+    }
+  };
+
+  // Initialize immediately
+  window.hhIdentity.ready = initIdentity();
+
+  if (debug && window.hhDebug) {
+    window.hhDebug.log('auth-context', 'Bootstrapper initialized');
+  }
+
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/catalog-filters.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/catalog-filters.js
@@ -1,0 +1,223 @@
+/**
+ * Catalog Filters - Client-side filtering for learning catalog
+ */
+
+(function() {
+  'use strict';
+
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  function init() {
+    const searchInput = document.getElementById('filter-search');
+    const durationSelect = document.getElementById('filter-duration');
+    const typeCheckboxes = document.querySelectorAll('input[name="type"]');
+    const levelCheckboxes = document.querySelectorAll('input[name="level"]');
+    const clearButton = document.getElementById('clear-filters');
+    const catalogGrid = document.getElementById('catalog-grid');
+    const noResults = document.getElementById('no-results');
+    const visibleCount = document.getElementById('visible-count');
+    const totalCount = document.getElementById('total-count');
+
+    if (!catalogGrid) return; // Exit if catalog grid doesn't exist
+
+    const allCards = Array.from(catalogGrid.querySelectorAll('.catalog-card'));
+    const totalItems = allCards.length;
+
+    // Set initial total count
+    if (totalCount) totalCount.textContent = totalItems;
+
+    // Attach event listeners
+    if (searchInput) {
+      searchInput.addEventListener('input', debounce(applyFilters, 300));
+    }
+
+    if (durationSelect) {
+      durationSelect.addEventListener('change', applyFilters);
+    }
+
+    // Type checkboxes with "All" logic
+    typeCheckboxes.forEach(cb => {
+      cb.addEventListener('change', function() {
+        handleCheckboxGroup('type', this);
+        applyFilters();
+      });
+    });
+
+    // Level checkboxes with "All" logic
+    levelCheckboxes.forEach(cb => {
+      cb.addEventListener('change', function() {
+        handleCheckboxGroup('level', this);
+        applyFilters();
+      });
+    });
+
+    if (clearButton) {
+      clearButton.addEventListener('click', clearAllFilters);
+    }
+
+    // Initial filter application
+    applyFilters();
+
+    /**
+     * Handle "All" checkbox logic for a group
+     */
+    function handleCheckboxGroup(groupName, changedCheckbox) {
+      const allCheckbox = document.getElementById(`${groupName}-all`);
+      const otherCheckboxes = Array.from(
+        document.querySelectorAll(`input[name="${groupName}"]:not([value="all"])`)
+      );
+
+      if (changedCheckbox.value === 'all') {
+        // If "All" was clicked
+        if (changedCheckbox.checked) {
+          // Check all others
+          otherCheckboxes.forEach(cb => cb.checked = true);
+        } else {
+          // Uncheck all others
+          otherCheckboxes.forEach(cb => cb.checked = false);
+        }
+      } else {
+        // If a specific option was clicked
+        const allOthersChecked = otherCheckboxes.every(cb => cb.checked);
+        if (allCheckbox) {
+          allCheckbox.checked = allOthersChecked;
+        }
+      }
+    }
+
+    /**
+     * Apply all filters to catalog cards
+     */
+    function applyFilters() {
+      const searchTerm = searchInput ? searchInput.value.toLowerCase().trim() : '';
+      const durationRange = durationSelect ? durationSelect.value : 'all';
+
+      // Get selected types (excluding "all")
+      const selectedTypes = Array.from(
+        document.querySelectorAll('input[name="type"]:checked:not([value="all"])')
+      ).map(cb => cb.value);
+
+      // Get selected levels (excluding "all")
+      const selectedLevels = Array.from(
+        document.querySelectorAll('input[name="level"]:checked:not([value="all"])')
+      ).map(cb => cb.value);
+
+      let visibleItems = 0;
+
+      allCards.forEach(card => {
+        const cardType = card.dataset.type;
+        const cardLevel = card.dataset.level || '';
+        const cardDuration = parseInt(card.dataset.duration) || 0;
+        const cardTitle = card.dataset.title || '';
+        const cardTags = card.dataset.tags || '';
+
+        let show = true;
+
+        // Filter by search term (searches title and tags)
+        if (searchTerm && !cardTitle.includes(searchTerm) && !cardTags.includes(searchTerm)) {
+          show = false;
+        }
+
+        // Filter by type
+        if (selectedTypes.length > 0 && !selectedTypes.includes(cardType)) {
+          show = false;
+        }
+
+        // Filter by level (allow items with no level if "all" is selected or empty levels)
+        if (selectedLevels.length > 0 && cardLevel) {
+          if (!selectedLevels.includes(cardLevel)) {
+            show = false;
+          }
+        }
+
+        // Filter by duration
+        if (durationRange !== 'all' && cardDuration > 0) {
+          const [min, max] = durationRange.split('-').map(Number);
+          if (cardDuration < min || (max && cardDuration > max)) {
+            show = false;
+          }
+        }
+
+        // Apply visibility
+        if (show) {
+          card.classList.remove('hidden');
+          visibleItems++;
+        } else {
+          card.classList.add('hidden');
+        }
+      });
+
+      // Update results count
+      if (visibleCount) {
+        visibleCount.textContent = visibleItems;
+      }
+
+      // Show/hide "no results" message
+      if (noResults) {
+        if (visibleItems === 0) {
+          noResults.style.display = 'block';
+          if (catalogGrid) catalogGrid.style.display = 'none';
+        } else {
+          noResults.style.display = 'none';
+          if (catalogGrid) catalogGrid.style.display = 'grid';
+        }
+      }
+    }
+
+    /**
+     * Clear all filters and reset to defaults
+     */
+    function clearAllFilters() {
+      // Clear search
+      if (searchInput) searchInput.value = '';
+
+      // Reset duration
+      if (durationSelect) durationSelect.value = 'all';
+
+      // Check all type checkboxes
+      typeCheckboxes.forEach(cb => cb.checked = true);
+
+      // Check all level checkboxes
+      levelCheckboxes.forEach(cb => cb.checked = true);
+
+      // Reapply filters
+      applyFilters();
+
+      // Announce to screen readers
+      announceToScreenReader('All filters have been cleared');
+    }
+
+    /**
+     * Debounce function for search input
+     */
+    function debounce(func, wait) {
+      let timeout;
+      return function executedFunction(...args) {
+        const later = () => {
+          clearTimeout(timeout);
+          func(...args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+      };
+    }
+
+    /**
+     * Announce message to screen readers
+     */
+    function announceToScreenReader(message) {
+      const announcement = document.createElement('div');
+      announcement.setAttribute('role', 'status');
+      announcement.setAttribute('aria-live', 'polite');
+      announcement.className = 'sr-only';
+      announcement.textContent = message;
+      document.body.appendChild(announcement);
+      setTimeout(() => announcement.remove(), 1000);
+    }
+  }
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/course-breadcrumbs.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/course-breadcrumbs.js
@@ -1,0 +1,168 @@
+/**
+ * Hedgehog Learn – Course Breadcrumbs & Position Indicator
+ * Updates breadcrumbs and shows module position when course context is present
+ * Depends on: course-context.js, constants.json
+ */
+(function() {
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function fetchJSON(url) {
+    return fetch(url, { credentials: 'omit' }).then(function(r) {
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      return r.json();
+    });
+  }
+
+  function getConstants() {
+    // Issue #345: Read constants from data attributes (no more CORS fetch)
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl
+    });
+  }
+
+  /**
+   * Fetch course data from HubDB
+   * @param {string} courseSlug
+   * @param {Object} constants
+   * @returns {Promise<Object|null>} Course row or null
+   */
+  function fetchCourseData(courseSlug, constants) {
+    if (!constants.HUBDB_COURSES_TABLE_ID) return Promise.resolve(null);
+
+    var tableId = constants.HUBDB_COURSES_TABLE_ID;
+    var url = '/_hcms/api/public/v2/hubdb/tables/' + tableId + '/rows?path__eq=' + encodeURIComponent(courseSlug);
+
+    return fetchJSON(url).then(function(data) {
+      if (data && data.objects && data.objects.length > 0) {
+        return data.objects[0].values;
+      }
+      return null;
+    }).catch(function() {
+      return null;
+    });
+  }
+
+  /**
+   * Update breadcrumbs to show course context
+   * @param {string} courseSlug
+   * @param {string} courseName
+   */
+  function updateBreadcrumbs(courseSlug, courseName) {
+    var breadcrumbsNav = document.getElementById('hhl-breadcrumbs');
+    if (!breadcrumbsNav) return;
+
+    var courseUrl = '/learn/courses/' + encodeURIComponent(courseSlug);
+    var linkHTML = '<a href="' + courseUrl + '">← Back to ' + escapeHtml(courseName) + '</a>';
+
+    // Replace the first child (default breadcrumb)
+    var firstChild = breadcrumbsNav.firstElementChild;
+    if (firstChild && firstChild.tagName === 'A') {
+      firstChild.outerHTML = linkHTML;
+    }
+  }
+
+  /**
+   * Update position indicator to show "Module X of Y in {Course}"
+   * @param {number} position - 1-based position
+   * @param {number} total - Total modules
+   * @param {string} courseName
+   */
+  function updatePositionIndicator(position, total, courseName) {
+    var positionSpan = document.getElementById('hhl-course-position');
+    if (!positionSpan) return;
+
+    var text = 'Module ' + position + ' of ' + total + ' in ' + escapeHtml(courseName);
+    positionSpan.textContent = text;
+    positionSpan.style.display = 'inline';
+  }
+
+  /**
+   * Escape HTML to prevent XSS
+   * @param {string} str
+   * @returns {string}
+   */
+  function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  /**
+   * Get module position in course
+   * @param {string} moduleSlug
+   * @param {Array} moduleSlugs - Course module slugs array
+   * @returns {number} 1-based position, or 0 if not found
+   */
+  function getModulePosition(moduleSlug, moduleSlugs) {
+    if (!moduleSlugs || !Array.isArray(moduleSlugs)) return 0;
+
+    for (var i = 0; i < moduleSlugs.length; i++) {
+      if (moduleSlugs[i] === moduleSlug) {
+        return i + 1; // 1-based
+      }
+    }
+    return 0;
+  }
+
+  ready(function() {
+    // Only run on module detail pages
+    var moduleSlug = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content;
+    if (!moduleSlug) return;
+
+    // Check for course context
+    if (!window.hhCourseContext) return;
+    var context = window.hhCourseContext.getContext();
+    if (!context || !context.courseSlug) return;
+
+    var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+    if (debug) console.log('[hhl] course-breadcrumbs.js - found context', context);
+
+    // Fetch course data and update UI
+    getConstants().then(function(constants) {
+      return fetchCourseData(context.courseSlug, constants).then(function(courseData) {
+        if (!courseData) {
+          if (debug) console.log('[hhl] course-breadcrumbs.js - course not found');
+          return;
+        }
+
+        var courseName = courseData.hs_name || courseData.name || context.courseSlug;
+
+        // Update breadcrumbs
+        updateBreadcrumbs(context.courseSlug, courseName);
+
+        // Update position indicator if we have module list
+        if (courseData.module_slugs_json) {
+          try {
+            var moduleSlugs = typeof courseData.module_slugs_json === 'string'
+              ? JSON.parse(courseData.module_slugs_json)
+              : courseData.module_slugs_json;
+
+            var position = getModulePosition(moduleSlug, moduleSlugs);
+            if (position > 0) {
+              updatePositionIndicator(position, moduleSlugs.length, courseName);
+            }
+
+            if (debug) console.log('[hhl] course-breadcrumbs.js - updated', {
+              courseName: courseName,
+              position: position,
+              total: moduleSlugs.length
+            });
+          } catch (e) {
+            if (debug) console.error('[hhl] course-breadcrumbs.js - parse error', e);
+          }
+        }
+      });
+    }).catch(function(err) {
+      if (debug) console.error('[hhl] course-breadcrumbs.js - error', err);
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/course-context.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/course-context.js
@@ -1,0 +1,118 @@
+/**
+ * Hedgehog Learn – Course Context Manager
+ * Detects and manages course context for module pages accessed from courses
+ * Stores context in sessionStorage for refresh resilience
+ */
+(function() {
+  window.hhCourseContext = window.hhCourseContext || {};
+
+  /**
+   * Parse course context from URL query parameter
+   * Expected format: ?from=course:{course-slug}
+   * @returns {Object|null} { courseSlug: string } or null
+   */
+  function parseUrlContext() {
+    var params = new URLSearchParams(window.location.search);
+    var from = params.get('from');
+
+    if (from && from.indexOf('course:') === 0) {
+      var courseSlug = from.substring(7); // Remove 'course:' prefix
+      if (courseSlug) {
+        return { courseSlug: courseSlug };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get course context from sessionStorage
+   * @returns {Object|null}
+   */
+  function getStoredContext() {
+    try {
+      var moduleSlug = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content;
+      if (!moduleSlug) return null;
+
+      var key = 'hh-course-context-' + moduleSlug;
+      var stored = sessionStorage.getItem(key);
+      if (stored) {
+        return JSON.parse(stored);
+      }
+    } catch (e) {
+      // Silent fail
+    }
+    return null;
+  }
+
+  /**
+   * Store course context in sessionStorage
+   * @param {Object} context - { courseSlug: string }
+   */
+  function storeContext(context) {
+    try {
+      var moduleSlug = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content;
+      if (!moduleSlug || !context) return;
+
+      var key = 'hh-course-context-' + moduleSlug;
+      sessionStorage.setItem(key, JSON.stringify(context));
+    } catch (e) {
+      // Silent fail
+    }
+  }
+
+  /**
+   * Get active course context (URL takes precedence over stored)
+   * @returns {Object|null} { courseSlug: string } or null
+   */
+  function getContext() {
+    var urlContext = parseUrlContext();
+    if (urlContext) {
+      storeContext(urlContext); // Update storage
+      return urlContext;
+    }
+    return getStoredContext();
+  }
+
+  /**
+   * Clear course context for current module
+   */
+  function clearContext() {
+    try {
+      var moduleSlug = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content;
+      if (moduleSlug) {
+        var key = 'hh-course-context-' + moduleSlug;
+        sessionStorage.removeItem(key);
+      }
+    } catch (e) {
+      // Silent fail
+    }
+  }
+
+  /**
+   * Add course context parameter to a URL
+   * @param {string} url - Base URL
+   * @param {string} courseSlug - Course slug
+   * @returns {string} URL with context parameter
+   */
+  function addContextToUrl(url, courseSlug) {
+    if (!url || !courseSlug) return url;
+
+    var separator = url.indexOf('?') === -1 ? '?' : '&';
+    return url + separator + 'from=course:' + encodeURIComponent(courseSlug);
+  }
+
+  // Public API
+  window.hhCourseContext = {
+    getContext: getContext,
+    clearContext: clearContext,
+    addContextToUrl: addContextToUrl,
+    parseUrlContext: parseUrlContext
+  };
+
+  // Debug logging
+  var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+  if (debug) {
+    var ctx = getContext();
+    console.log('[hhl] course-context.js loaded', { context: ctx });
+  }
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/course-navigation.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/course-navigation.js
@@ -1,0 +1,63 @@
+/**
+ * Hedgehog Learn – Course-Aware Navigation
+ * Updates prev/next navigation links to preserve course context
+ * Depends on: course-context.js
+ */
+(function() {
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  /**
+   * Add course context parameter to navigation links
+   * @param {string} courseSlug
+   */
+  function updateNavigationLinks(courseSlug) {
+    if (!courseSlug) return;
+
+    var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+
+    // Find all prev/next navigation links
+    var prevLink = document.querySelector('.module-nav-link.module-nav-prev');
+    var nextLink = document.querySelector('.module-nav-link.module-nav-next');
+
+    if (prevLink) {
+      var prevHref = prevLink.getAttribute('href');
+      if (prevHref && window.hhCourseContext) {
+        var newHref = window.hhCourseContext.addContextToUrl(prevHref, courseSlug);
+        prevLink.setAttribute('href', newHref);
+        if (debug) console.log('[hhl] course-navigation.js - updated prev link', newHref);
+      }
+    }
+
+    if (nextLink) {
+      var nextHref = nextLink.getAttribute('href');
+      if (nextHref && window.hhCourseContext) {
+        var newNextHref = window.hhCourseContext.addContextToUrl(nextHref, courseSlug);
+        nextLink.setAttribute('href', newNextHref);
+        if (debug) console.log('[hhl] course-navigation.js - updated next link', newNextHref);
+      }
+    }
+  }
+
+  ready(function() {
+    // Only run on module detail pages
+    var moduleSlug = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content;
+    if (!moduleSlug) return;
+
+    // Check for course context
+    if (!window.hhCourseContext) return;
+    var context = window.hhCourseContext.getContext();
+    if (!context || !context.courseSlug) return;
+
+    var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+    if (debug) console.log('[hhl] course-navigation.js - preserving context', context);
+
+    // Update navigation links to include course context
+    updateNavigationLinks(context.courseSlug);
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/courses.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/courses.js
@@ -1,0 +1,176 @@
+/**
+ * Hedgehog Learn – Courses page interactions (CSP-safe)
+ * - Shows CRM-backed progress counts and bar for authenticated users
+ * - Falls back to local storage for anonymous users
+ * - (Legacy) Enrollment beacons now handled via /learn/action-runner (Issue #245)
+ * - Exposes window.hhUpdateCourseProgress(started, completed)
+ */
+(function () {
+  function ready(fn) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn); else fn();
+  }
+
+  /**
+   * Build fetch headers with JWT token if available (Issue #251)
+   */
+  function buildAuthHeaders() {
+    var headers = { 'Content-Type': 'application/json' };
+    try {
+      var token = localStorage.getItem('hhl_auth_token');
+      if (token) {
+        headers['Authorization'] = 'Bearer ' + token;
+      }
+    } catch (e) {
+      // Ignore localStorage errors
+    }
+    return headers;
+  }
+
+  function fetchJSON(url) {
+    return fetch(url, {
+      credentials: 'omit',
+      headers: buildAuthHeaders()
+    }).then(function (r) {
+      if (!r.ok) throw new Error('Failed to load ' + url);
+      return r.json();
+    });
+  }
+
+  function getConstants() {
+    // Issue #345: Read constants from data attributes (no more CORS fetch)
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl
+    });
+  }
+
+  function getAuth() {
+    var el = document.getElementById('hhl-auth-context');
+    if (!el) return { enableCrm: false };
+    var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function') ? window.hhIdentity.get() : null;
+    var email = identity && identity.email ? identity.email : (el.getAttribute('data-email') || null);
+    var contactId = identity && identity.contactId ? identity.contactId : (el.getAttribute('data-contact-id') || null);
+    return {
+      email: email,
+      contactId: contactId,
+      enableCrm: (el.getAttribute('data-enable-crm') || 'false') === 'true'
+    };
+  }
+
+  function sendEnrollment(constants, auth, courseSlug) {
+    // Deprecated: explicit enrollment now routes through /learn/action-runner (Issue #245)
+    // We keep the session flag to avoid re-triggering legacy flows, but no network requests occur here.
+    try {
+      var key = 'hh-course-enrolled-' + courseSlug;
+      if (!sessionStorage.getItem(key)) {
+        sessionStorage.setItem(key, 'true');
+      }
+    } catch (e) {}
+  }
+
+  function getLocalProgress(courseSlug) {
+    try {
+      var raw = localStorage.getItem('hh-course-progress-' + courseSlug);
+      return raw ? JSON.parse(raw) : { started:0, completed:0 };
+    } catch(e) { return { started:0, completed:0 }; }
+  }
+
+  function fetchCRMProgress(constants, auth, courseSlug) {
+    // Return promise that resolves to progress data
+    if (!constants || !constants.TRACK_EVENTS_URL || !auth.enableCrm || (!auth.email && !auth.contactId)) {
+      return Promise.resolve(null); // Fall back to local storage
+    }
+
+    var apiBase = constants.TRACK_EVENTS_URL.replace('/events/track', '');
+    var params = new URLSearchParams({
+      type: 'course',
+      slug: courseSlug
+    });
+    if (auth.email) params.append('email', auth.email);
+    if (auth.contactId) params.append('contactId', auth.contactId);
+
+    var url = apiBase + '/progress/aggregate?' + params.toString();
+
+    return fetch(url, { credentials: 'omit' })
+      .then(function(r) {
+        if (!r.ok) throw new Error('Failed to fetch progress');
+        return r.json();
+      })
+      .then(function(data) {
+        if (data.mode === 'authenticated') {
+          return {
+            started: data.started || 0,
+            completed: data.completed || 0,
+            enrolled: data.enrolled || false
+          };
+        }
+        return null;
+      })
+      .catch(function(err) {
+        console.warn('[hhl] Failed to fetch CRM progress:', err);
+        return null;
+      });
+  }
+
+  function renderProgress(totalModules, courseSlug, progressData) {
+    var startedEl = document.getElementById('progress-started');
+    var completedEl = document.getElementById('progress-completed');
+    var barEl = document.getElementById('progress-bar');
+    var authPrompt = document.getElementById('auth-prompt');
+    if (startedEl) startedEl.textContent = progressData.started;
+    if (completedEl) completedEl.textContent = progressData.completed;
+    var pct = totalModules > 0 ? Math.round((progressData.completed / totalModules) * 100) : 0;
+    if (barEl) barEl.style.width = pct + '%';
+
+    // Only show auth prompt if using local storage AND has some progress
+    if (authPrompt && !progressData.fromCRM && (progressData.started > 0 || progressData.completed > 0)) {
+      authPrompt.style.display = 'flex';
+    }
+  }
+
+  ready(function(){
+    var node = document.querySelector('[data-course-slug]');
+    var courseSlug = node ? node.getAttribute('data-course-slug') : (window.location.pathname.split('/').filter(Boolean).pop() || 'unknown');
+    var totalNode = document.querySelector('[data-total-modules]');
+    var totalModules = totalNode ? parseInt(totalNode.getAttribute('data-total-modules')||'0',10) : 0;
+
+    Promise.all([getConstants(), Promise.resolve(getAuth())]).then(function(res){
+      var constants = res[0]; var auth = res[1];
+
+      // Try to fetch CRM progress first, fall back to local storage
+      fetchCRMProgress(constants, auth, courseSlug).then(function(crmProgress){
+        var progressData;
+        if (crmProgress) {
+          // Use CRM data
+          progressData = {
+            started: crmProgress.started,
+            completed: crmProgress.completed,
+            fromCRM: true
+          };
+        } else {
+          // Fall back to local storage
+          var localProgress = getLocalProgress(courseSlug);
+          progressData = {
+            started: localProgress.started,
+            completed: localProgress.completed,
+            fromCRM: false
+          };
+        }
+
+        renderProgress(totalModules, courseSlug, progressData);
+        sendEnrollment(constants, auth, courseSlug);
+
+        // Expose update function (for legacy compatibility)
+        window.hhUpdateCourseProgress = function(started, completed){
+          try {
+            localStorage.setItem('hh-course-progress-' + courseSlug, JSON.stringify({ started: started, completed: completed, lastUpdated: new Date().toISOString() }));
+          } catch(e) {}
+          var updatedData = { started: started, completed: completed, fromCRM: false };
+          renderProgress(totalModules, courseSlug, updatedData);
+        };
+      });
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/debug.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/debug.js
@@ -1,0 +1,254 @@
+/**
+ * HHL Debug Instrumentation Module
+ *
+ * Provides centralized debug logging and membership session instrumentation.
+ * Enable via: localStorage.setItem('HHL_DEBUG', 'true')
+ * Disable via: localStorage.removeItem('HHL_DEBUG')
+ *
+ * This module automatically logs:
+ * - Auth bootstrapper context on page load
+ * - Membership profile API responses (when available)
+ * - Cookie information (names only, no values for privacy)
+ * - HubSpot CMS membership session state
+ *
+ * Related Issues: #237, #233, #234, #235
+ */
+(function() {
+  'use strict';
+
+  // Initialize debug state
+  var enabled = localStorage.getItem('HHL_DEBUG') === 'true';
+
+  /**
+   * Global debug interface
+   * Provides consistent logging across all HHL modules
+   */
+  window.hhDebug = {
+    enabled: enabled,
+
+    /**
+     * Log a debug message
+     * @param {string} module - Module name (e.g., 'enroll', 'progress', 'auth')
+     * @param {string} message - Message to log
+     * @param {*} data - Optional data to include
+     */
+    log: function(module, message, data) {
+      if (!this.enabled) return;
+      var prefix = '[hhl:' + module + ']';
+      if (data !== undefined) {
+        console.log(prefix, message, data);
+      } else {
+        console.log(prefix, message);
+      }
+    },
+
+    /**
+     * Log a warning
+     * @param {string} module - Module name
+     * @param {string} message - Warning message
+     * @param {*} data - Optional data to include
+     */
+    warn: function(module, message, data) {
+      if (!this.enabled) return;
+      var prefix = '[hhl:' + module + ']';
+      if (data !== undefined) {
+        console.warn(prefix, message, data);
+      } else {
+        console.warn(prefix, message);
+      }
+    },
+
+    /**
+     * Log an error
+     * @param {string} module - Module name
+     * @param {string} message - Error message
+     * @param {*} data - Optional data to include
+     */
+    error: function(module, message, data) {
+      if (!this.enabled) return;
+      var prefix = '[hhl:' + module + ']';
+      if (data !== undefined) {
+        console.error(prefix, message, data);
+      } else {
+        console.error(prefix, message);
+      }
+    },
+
+    /**
+     * Log auth bootstrapper context
+     * Inspects the #hhl-auth-context div and logs all data attributes
+     */
+    bootstrapper: function() {
+      if (!this.enabled) return;
+
+      var div = document.getElementById('hhl-auth-context');
+      if (!div) {
+        this.error('bootstrap', 'Auth context element NOT FOUND - #hhl-auth-context missing from page');
+        return;
+      }
+
+      // Extract values (privacy-safe: redact actual values)
+      var email = div.getAttribute('data-email');
+      var contactId = div.getAttribute('data-contact-id');
+      var hasEmail = !!(email);
+      var hasContactId = !!(contactId);
+      var isAuthenticated = hasEmail || hasContactId;
+
+      console.group('[hhl:bootstrap] Auth Context Loaded');
+      console.log('Element found:', div);
+
+      // Log presence/absence only, not actual values (privacy-safe)
+      console.log('email:', hasEmail ? '(redacted - present)' : '(empty)');
+      console.log('contactId:', hasContactId ? '(redacted - present)' : '(empty)');
+
+      console.log('enableCrm:', div.getAttribute('data-enable-crm'));
+      console.log('constantsUrl:', div.getAttribute('data-constants-url'));
+      console.log('loginUrl:', div.getAttribute('data-login-url'));
+
+      console.log('---');
+      console.log('Authenticated:', isAuthenticated);
+      console.log('Has Email:', hasEmail);
+      console.log('Has Contact ID:', hasContactId);
+      console.groupEnd();
+    },
+
+    /**
+     * Log cookie information (names only, no values for privacy)
+     * Filters to show HubSpot-related cookies
+     */
+    cookies: function() {
+      if (!this.enabled) return;
+
+      var allCookies = document.cookie.split(';');
+      var cookieNames = allCookies.map(function(cookie) {
+        return cookie.trim().split('=')[0];
+      });
+
+      // Filter to HubSpot-related cookies
+      var hubspotCookies = cookieNames.filter(function(name) {
+        return name.indexOf('hs') === 0 ||
+               name.indexOf('hubspot') > -1 ||
+               name.indexOf('__hs') === 0;
+      });
+
+      console.group('[hhl:cookies] Cookie Information');
+      console.log('Total cookies:', cookieNames.length);
+      console.log('HubSpot cookies:', hubspotCookies.length);
+      console.log('HubSpot cookie names:', hubspotCookies);
+      console.log('All cookie names:', cookieNames);
+      console.groupEnd();
+    },
+
+    /**
+     * Attempt to fetch membership profile API
+     * Logs the response status and key fields (without exposing PII)
+     * This is the API that HubSpot uses internally for membership sessions
+     */
+    membershipProfile: function() {
+      if (!this.enabled) return;
+
+      var apiUrl = '/_hcms/api/membership/v1/profile';
+
+      this.log('membership', 'Fetching membership profile from ' + apiUrl);
+
+      fetch(apiUrl, {
+        method: 'GET',
+        credentials: 'include', // Include cookies for session
+        headers: {
+          'Accept': 'application/json'
+        }
+      })
+        .then(function(response) {
+          console.group('[hhl:membership] Profile API Response');
+          console.log('Status:', response.status, response.statusText);
+          console.log('OK:', response.ok);
+          console.log('Headers:', {
+            'content-type': response.headers.get('content-type'),
+            'cache-control': response.headers.get('cache-control')
+          });
+
+          if (response.ok) {
+            return response.json().then(function(data) {
+              console.log('Response body (keys only):', Object.keys(data || {}));
+
+              // Log non-PII fields if available
+              if (data) {
+                console.log('Has email:', !!data.email);
+                console.log('Has contact ID:', !!(data.contactId || data.vid || data.hs_object_id));
+                console.log('Logged in:', !!data.is_logged_in);
+
+                // Log structure without exposing actual values
+                if (data.email) console.log('Email present: (redacted)');
+                if (data.contactId) console.log('Contact ID present: (redacted)');
+                if (data.vid) console.log('VID present: (redacted)');
+                if (data.hs_object_id) console.log('hs_object_id present: (redacted)');
+              }
+
+              console.groupEnd();
+            });
+          } else if (response.status === 404) {
+            console.warn('Profile API returned 404 - membership session may not exist');
+            console.log('This could indicate:');
+            console.log('  1. User is not logged in via CMS membership');
+            console.log('  2. Membership feature not enabled on this portal');
+            console.log('  3. Session cookies not being sent/persisted');
+            console.groupEnd();
+          } else {
+            console.error('Profile API returned error status:', response.status);
+            console.groupEnd();
+          }
+        })
+        .catch(function(error) {
+          console.group('[hhl:membership] Profile API Error');
+          console.error('Fetch failed:', error.message);
+          console.log('This could indicate:');
+          console.log('  1. Network connectivity issue');
+          console.log('  2. CORS policy blocking the request');
+          console.log('  3. API endpoint not available');
+          console.groupEnd();
+        });
+    },
+
+    /**
+     * Run all instrumentation checks
+     * Called automatically on page load when HHL_DEBUG is enabled
+     */
+    runAll: function() {
+      if (!this.enabled) {
+        console.log('[hhl:debug] Debug mode disabled. Enable with: localStorage.setItem("HHL_DEBUG", "true")');
+        return;
+      }
+
+      console.log('%c[hhl:debug] Debug mode ENABLED', 'color: #00A4BD; font-weight: bold; font-size: 14px;');
+      console.log('[hhl:debug] Disable with: localStorage.removeItem("HHL_DEBUG")');
+      console.log('[hhl:debug] Running instrumentation checks...');
+      console.log('---');
+
+      this.bootstrapper();
+      this.cookies();
+      this.membershipProfile();
+    }
+  };
+
+  // Auto-run instrumentation on page load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() {
+      window.hhDebug.runAll();
+    });
+  } else {
+    // DOM already loaded
+    window.hhDebug.runAll();
+  }
+
+  // Expose helper for manual testing
+  window.enableHhlDebug = function() {
+    localStorage.setItem('HHL_DEBUG', 'true');
+    console.log('[hhl:debug] Debug mode enabled. Reload the page to see instrumentation.');
+  };
+
+  window.disableHhlDebug = function() {
+    localStorage.removeItem('HHL_DEBUG');
+    console.log('[hhl:debug] Debug mode disabled. Reload the page.');
+  };
+
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/enrollment.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/enrollment.js
@@ -1,0 +1,475 @@
+/**
+ * Enrollment Management for Pathways and Courses
+ * Handles explicit enrollment flows with localStorage persistence and CRM sync
+ */
+
+(function() {
+  'use strict';
+
+  var debug = localStorage.getItem('HHL_DEBUG') === 'true';
+
+  function parseBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    if (!value) return false;
+    var normalized = value.toString().trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  function waitForIdentityReady() {
+    try {
+      if (window.hhIdentity && window.hhIdentity.ready && typeof window.hhIdentity.ready.then === 'function') {
+        return window.hhIdentity.ready;
+      }
+    } catch (error) {
+      if (debug) console.warn('[hhl-enroll] Failed to read hhIdentity.ready:', error);
+    }
+    return Promise.resolve(null);
+  }
+
+  function getAuth() {
+    var el = document.getElementById('hhl-auth-context');
+    var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function')
+      ? window.hhIdentity.get()
+      : null;
+    var authenticated = identity ? !!identity.authenticated : parseBoolean(el && el.getAttribute('data-authenticated'));
+    var email = identity && identity.email ? identity.email : (el && el.getAttribute('data-email')) || null;
+    var contactId = identity && identity.contactId ? identity.contactId : (el && el.getAttribute('data-contact-id')) || null;
+    return {
+      authenticated: authenticated,
+      email: email,
+      contactId: contactId,
+      enableCrm: parseBoolean(el && el.getAttribute('data-enable-crm')),
+      trackEventsUrl: el && el.getAttribute('data-track-events-url')
+    };
+  }
+
+  function fetchEnrollmentFromCRM(constants, auth, contentType, slug) {
+    return new Promise(function(resolve) {
+      var url = buildEnrollmentsUrl(constants, auth);
+      if (!url) {
+        resolve(null);
+        return;
+      }
+      fetch(url, {
+        credentials: 'include'
+      })
+        .then(function(res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.json();
+        })
+        .then(function(data) {
+          if (!data || data.mode !== 'authenticated' || !data.enrollments) {
+            resolve(null);
+            return;
+          }
+          var list = contentType === 'pathway'
+            ? (data.enrollments.pathways || [])
+            : (data.enrollments.courses || []);
+          var match = list.find(function(entry) { return entry && entry.slug === slug; });
+          resolve(match || null);
+        })
+        .catch(function(err) {
+          if (debug) console.warn('[hhl-enroll] Failed to fetch CRM enrollment:', err);
+          resolve(null);
+        });
+    });
+  }
+
+  /**
+   * Get constants from data attributes (Issue #345 - no more CORS fetch)
+   */
+  function getConstants(auth, callback) {
+    // Return constants synchronously from data attributes
+    callback({
+      TRACK_EVENTS_URL: auth.trackEventsUrl || null,
+      ACTION_RUNNER_URL: '/learn/action-runner'
+    });
+  }
+
+  function buildEnrollmentsUrl(constants, auth) {
+    var track = (constants && constants.TRACK_EVENTS_URL) || (auth && auth.trackEventsUrl) || '';
+    if (!track) return null;
+
+    var base = track.indexOf('/events/track') >= 0
+      ? track.replace('/events/track', '/enrollments/list')
+      : track.replace(/\/?$/, '/enrollments/list');
+
+    if (!auth || (!auth.email && !auth.contactId)) return base;
+    var query = auth.contactId
+      ? 'contactId=' + encodeURIComponent(auth.contactId)
+      : 'email=' + encodeURIComponent(auth.email);
+    return base + (base.indexOf('?') >= 0 ? '&' : '?') + query;
+  }
+
+  function getActionRunnerBase(constants) {
+    if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
+    return '/learn/action-runner';
+  }
+
+  function buildRunnerUrl(base, redirectUrl, params) {
+    var runner = base || '/learn/action-runner';
+    var search = new URLSearchParams();
+    Object.keys(params || {}).forEach(function(key) {
+      var value = params[key];
+      if (value !== undefined && value !== null && value !== '') {
+        search.set(key, value);
+      }
+    });
+    if (redirectUrl) search.set('redirect_url', redirectUrl);
+    return runner + '?' + search.toString();
+  }
+
+  function deriveEnrollmentSource() {
+    var path = window.location.pathname || '';
+    if (path.indexOf('/pathways/') >= 0) return 'pathway_page';
+    if (path.indexOf('/courses/') >= 0) return 'course_page';
+    if (path.indexOf('/modules/') >= 0) return 'module_page';
+    return 'learn_page';
+  }
+
+  function bindClick(button, handler) {
+    if (!button || typeof handler !== 'function') return;
+    unbindClick(button);
+    var wrapped = function(event) {
+      if (event) event.preventDefault();
+      handler();
+    };
+    button.__hhlEnrollHandler = wrapped;
+    button.addEventListener('click', wrapped);
+  }
+
+  function unbindClick(button) {
+    if (!button) return;
+    var existing = button.__hhlEnrollHandler;
+    if (existing) {
+      button.removeEventListener('click', existing);
+      button.__hhlEnrollHandler = null;
+    }
+  }
+
+  function consumeRunnerResult(contentType, slug) {
+    try {
+      var raw = sessionStorage.getItem('hhl_last_action');
+      if (!raw) return null;
+      var data = JSON.parse(raw);
+      var expected = 'enroll_' + contentType;
+      if (!data || data.action !== expected) return null;
+      if (slug && data.params && data.params.slug && data.params.slug !== slug) return null;
+      sessionStorage.removeItem('hhl_last_action');
+      return data;
+    } catch (error) {
+      if (debug) console.warn('[hhl-enroll] Failed to parse runner result:', error);
+      try { sessionStorage.removeItem('hhl_last_action'); } catch (cleanupError) {
+        if (debug) console.warn('[hhl-enroll] Failed to clear runner result cache:', cleanupError);
+      }
+      return null;
+    }
+  }
+
+  function applyRunnerFeedback(result, contentType) {
+    if (!result) return;
+    if (result.status === 'success') {
+      if (window.hhToast) {
+        var message = contentType === 'pathway'
+          ? 'You are enrolled in this pathway.'
+          : 'Course enrollment confirmed.';
+        window.hhToast.show(message, 'success', 4200);
+      }
+    } else if (result.status === 'error') {
+      if (window.hhToast) {
+        window.hhToast.show('We could not complete your last enrollment. Please try again.', 'error', 5200);
+      }
+    }
+  }
+
+  /**
+   * Get enrollment state from localStorage
+   */
+  function getEnrollmentState(contentType, slug) {
+    var key = 'hh-enrollment-' + contentType + '-' + slug;
+    var stored = localStorage.getItem(key);
+    if (!stored) return null;
+
+    try {
+      return JSON.parse(stored);
+    } catch (error) {
+      if (debug) console.warn('[hhl-enroll] Failed to read cached enrollment state:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Set enrollment state in localStorage
+   */
+  function setEnrollmentState(contentType, slug, enrolled, enrolledAt) {
+    var key = 'hh-enrollment-' + contentType + '-' + slug;
+    var state = {
+      enrolled: enrolled,
+      enrolled_at: enrolled ? (enrolledAt || new Date().toISOString()) : null
+    };
+
+    try {
+      localStorage.setItem(key, JSON.stringify(state));
+      if (debug) console.log('[hhl-enroll] Saved state:', key, state);
+    } catch (error) {
+      if (debug) console.error('[hhl-enroll] Failed to save state:', error);
+    }
+  }
+
+  /**
+   * Update button UI based on enrollment state
+   */
+  function updateButtonUI(button, isEnrolled, contentType) {
+    if (isEnrolled) {
+      button.innerHTML = contentType === 'pathway'
+        ? '✓ Enrolled in Pathway'
+        : '✓ Enrolled in Course';
+      button.style.background = '#D1FAE5';
+      button.style.color = '#065F46';
+      button.style.border = '2px solid #6EE7B7';
+      button.disabled = true;
+      button.style.cursor = 'not-allowed';
+      button.setAttribute('aria-disabled', 'true');
+    } else {
+      button.innerHTML = contentType === 'pathway'
+        ? 'Enroll in Pathway'
+        : 'Start Course';
+      button.style.background = '#1a4e8a';
+      button.style.color = '#fff';
+      button.style.border = 'none';
+      button.disabled = false;
+      button.style.cursor = 'pointer';
+      button.setAttribute('aria-disabled', 'false');
+    }
+  }
+
+  /**
+   * Handle enrollment button click
+   */
+  function handleEnrollClick(button, contentType, slug, auth, constants) {
+    if (button.disabled) return;
+
+    var runnerBase = getActionRunnerBase(constants);
+    var redirectPath = window.location.pathname + window.location.search + window.location.hash;
+    var actionKey = 'enroll_' + contentType;
+    var source = deriveEnrollmentSource();
+
+    // Persist local enrollment flag immediately for optimistic UI
+    setEnrollmentState(contentType, slug, true, new Date().toISOString());
+
+    button.disabled = true;
+    button.innerHTML = 'Enrolling...';
+    button.style.cursor = 'wait';
+    button.setAttribute('aria-disabled', 'true');
+
+    updateButtonUI(button, true, contentType);
+    unbindClick(button);
+
+    var params = {
+      action: actionKey,
+      slug: slug,
+      source: source
+    };
+
+    var courseContext = window.hhCourseContext && window.hhCourseContext.getContext ? window.hhCourseContext.getContext() : null;
+    if (courseContext && courseContext.courseSlug) {
+      params.course_slug = courseContext.courseSlug;
+    }
+
+    setTimeout(function() {
+      if (debug) console.log('[hhl-enroll] Redirecting to action runner', params);
+      window.location.href = buildRunnerUrl(runnerBase, redirectPath, params);
+    }, 150);
+  }
+
+  /**
+   * Initialize enrollment UI for a specific content item
+   * Assumes the server already rendered the correct anonymous/authenticated CTA state.
+   */
+  function initEnrollmentUI(contentType, slug) {
+    var ctaContainer = document.getElementById('hhl-enrollment-cta');
+    var helper = document.getElementById('hhl-enroll-helper');
+    waitForIdentityReady().finally(function() {
+      var auth = getAuth();
+      var button = document.getElementById('hhl-enroll-button');
+
+      if (!button && auth && auth.authenticated && ctaContainer) {
+        var loginLink = document.getElementById('hhl-enroll-login');
+        if (loginLink) {
+          button = document.createElement('button');
+          button.type = 'button';
+          button.className = loginLink.className || 'enrollment-button';
+          button.id = 'hhl-enroll-button';
+          button.setAttribute('data-content-type', contentType);
+          if (slug) button.setAttribute('data-content-slug', slug);
+          button.textContent = contentType === 'pathway' ? 'Enroll in Pathway' : 'Start Course';
+          ctaContainer.replaceChild(button, loginLink);
+          if (helper) {
+            helper.style.display = 'none';
+            helper.textContent = '';
+          }
+          if (debug) console.log('[hhl-enroll] Upgraded login link to enrollment button via client identity');
+        }
+      }
+
+      if (!button) {
+        if (debug) console.log('[hhl-enroll] No enrollment button found; CTA remains a login link', { authenticated: auth && auth.authenticated });
+        return;
+      }
+
+      if (!auth.authenticated) {
+        if (debug) console.log('[hhl-enroll] Auth not resolved client-side; CTA handled by server');
+        return;
+      }
+
+      if (helper) {
+        helper.style.display = 'none';
+        helper.textContent = '';
+      }
+
+      var pendingResult = consumeRunnerResult(contentType, slug);
+
+      getConstants(auth, function(constants) {
+        var canCheckCrm = auth.enableCrm && (auth.email || auth.contactId);
+
+        if (!canCheckCrm) {
+          if (debug) console.warn('[hhl-enroll] CRM lookup disabled; falling back to local state');
+          finalizeWithLocalState(button, contentType, slug, auth, constants, pendingResult);
+          return;
+        }
+
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+        button.innerHTML = 'Checking enrollment...';
+
+        fetchEnrollmentFromCRM(constants, auth, contentType, slug).then(function(match) {
+          if (match) {
+            setEnrollmentState(contentType, slug, true, match.enrolled_at || undefined);
+          }
+
+          var localState = getEnrollmentState(contentType, slug);
+          var isEnrolled = !!match || (localState && localState.enrolled);
+
+          if (isEnrolled) {
+            updateButtonUI(button, true, contentType);
+            unbindClick(button);
+          } else {
+            updateButtonUI(button, false, contentType);
+            bindClick(button, function() {
+              handleEnrollClick(button, contentType, slug, auth, constants);
+            });
+          }
+
+          if (pendingResult) {
+            applyRunnerFeedback(pendingResult, contentType);
+            pendingResult = null;
+          }
+
+          if (debug) console.log('[hhl-enroll] Initialized (CRM)', { contentType: contentType, slug: slug, enrolled: isEnrolled });
+        }).catch(function() {
+          if (debug) console.warn('[hhl-enroll] CRM lookup failed; reverting to local state');
+          finalizeWithLocalState(button, contentType, slug, auth, constants, pendingResult);
+        });
+      });
+    });
+  }
+
+  function finalizeWithLocalState(button, contentType, slug, auth, constants, pendingResult) {
+    var state = getEnrollmentState(contentType, slug);
+    var fallbackEnrolled = !!(state && state.enrolled);
+    updateButtonUI(button, fallbackEnrolled, contentType);
+    if (!fallbackEnrolled) {
+      bindClick(button, function() {
+        handleEnrollClick(button, contentType, slug, auth, constants || {});
+      });
+    } else {
+      unbindClick(button);
+    }
+    if (pendingResult) {
+      applyRunnerFeedback(pendingResult, contentType);
+    }
+  }
+
+  /**
+   * Add CSS for toast animations
+   */
+  function addToastStyles() {
+    if (document.getElementById('hhl-toast-styles')) return;
+
+    var style = document.createElement('style');
+    style.id = 'hhl-toast-styles';
+    style.textContent = '@keyframes slideIn { from { transform: translateX(400px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }';
+    document.head.appendChild(style);
+  }
+
+  /**
+   * Re-initialize enrollment UI when auth state changes (Issue #345)
+   */
+  var currentContentType = null;
+  var currentSlug = null;
+
+  function detectEnrollmentContext() {
+    var cta = document.getElementById('hhl-enrollment-cta');
+    if (!cta) return null;
+    var contentType = cta.getAttribute('data-content-type') || '';
+    var slug = cta.getAttribute('data-content-slug') || '';
+
+    if (!slug) {
+      var authCtx = document.getElementById('hhl-auth-context');
+      if (authCtx) {
+        slug = authCtx.getAttribute('data-course-slug') ||
+               authCtx.getAttribute('data-pathway-slug') ||
+               authCtx.getAttribute('data-module-slug') ||
+               '';
+      }
+    }
+
+    if (!contentType) return null;
+    return { contentType: contentType, slug: slug };
+  }
+
+  function initEnrollmentUIWrapper(contentType, slug) {
+    currentContentType = contentType;
+    currentSlug = slug;
+    initEnrollmentUI(contentType, slug);
+  }
+
+  // Listen for auth state changes from cognito-auth-integration.js
+  document.addEventListener('hhl:identity', function(event) {
+    if (debug) console.log('[hhl-enroll] Auth state changed, re-initializing enrollment UI');
+    if (!currentContentType) {
+      var ctx = detectEnrollmentContext();
+      if (ctx) {
+        initEnrollmentUIWrapper(ctx.contentType, ctx.slug);
+        return;
+      }
+    }
+    if (currentContentType) {
+      initEnrollmentUI(currentContentType, currentSlug || '');
+    }
+  });
+
+  /**
+   * Initialize on DOM ready
+   */
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() {
+      addToastStyles();
+      var ctx = detectEnrollmentContext();
+      if (ctx) {
+        initEnrollmentUIWrapper(ctx.contentType, ctx.slug);
+      }
+    });
+  } else {
+    addToastStyles();
+    var ctxNow = detectEnrollmentContext();
+    if (ctxNow) {
+      initEnrollmentUIWrapper(ctxNow.contentType, ctxNow.slug);
+    }
+  }
+
+  // Expose init function globally
+  window.hhInitEnrollment = initEnrollmentUIWrapper;
+
+  if (debug) console.log('[hhl-enroll] enrollment.js loaded');
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/left-nav.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/left-nav.js
@@ -1,0 +1,56 @@
+/**
+ * Learning Left Navigation - Mobile drawer functionality
+ */
+
+(function() {
+  'use strict';
+
+  // Wait for DOM to be ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  function init() {
+    const nav = document.getElementById('learn-left-nav');
+    const toggle = document.getElementById('learn-nav-toggle');
+    const overlay = document.getElementById('learn-nav-overlay');
+
+    if (!nav || !toggle || !overlay) {
+      return; // Not a page with left nav
+    }
+
+    // Toggle nav on button click
+    toggle.addEventListener('click', function() {
+      const isActive = nav.classList.contains('active');
+      if (isActive) {
+        closeNav();
+      } else {
+        openNav();
+      }
+    });
+
+    // Close nav when clicking overlay
+    overlay.addEventListener('click', closeNav);
+
+    // Close nav on escape key
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape' && nav.classList.contains('active')) {
+        closeNav();
+      }
+    });
+
+    function openNav() {
+      nav.classList.add('active');
+      overlay.classList.add('active');
+      document.body.style.overflow = 'hidden'; // Prevent background scroll
+    }
+
+    function closeNav() {
+      nav.classList.remove('active');
+      overlay.classList.remove('active');
+      document.body.style.overflow = ''; // Restore scroll
+    }
+  }
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/login-helper.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/login-helper.js
@@ -1,0 +1,161 @@
+/**
+ * HubSpot Native Login Helper (Issue #272)
+ *
+ * Shared utility for building HubSpot native membership login URLs.
+ * This replaces the custom JWT-based login flow with HubSpot's native
+ * membership authentication, which provides better security, SSO support,
+ * and aligns with HubSpot's "golden path" for authentication.
+ *
+ * @see https://github.com/afewell/hh-learn/issues/272
+ * @see HUBSPOT-AUTH-QUICK-SUMMARY.md for research findings
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * Build native HubSpot login URL with redirect
+   *
+   * @param {string} [redirectPath=null] - Optional redirect path (defaults to current page)
+   * @returns {string} Full login URL with redirect_url parameter
+   *
+   * @example
+   * // Redirect back to current page after login
+   * window.location.href = window.hhLoginHelper.buildLoginUrl();
+   *
+   * @example
+   * // Redirect to specific page after login
+   * window.location.href = window.hhLoginHelper.buildLoginUrl('/learn/my-learning');
+   */
+  function buildLoginUrl(redirectPath) {
+    var path = redirectPath || window.location.pathname + window.location.search + window.location.hash;
+    var loginBase = '/_hcms/mem/login';
+
+    // Encode the redirect URL to prevent issues with special characters
+    var encodedPath = encodeURIComponent(path);
+
+    return loginBase + '?redirect_url=' + encodedPath;
+  }
+
+  /**
+   * Build native HubSpot logout URL with redirect
+   *
+   * @param {string} [redirectPath=null] - Optional redirect path (defaults to current page)
+   * @returns {string} Full logout URL with redirect_url parameter
+   *
+   * @example
+   * // Redirect back to current page after logout
+   * window.location.href = window.hhLoginHelper.buildLogoutUrl();
+   *
+   * @example
+   * // Redirect to home page after logout
+   * window.location.href = window.hhLoginHelper.buildLogoutUrl('/learn');
+   */
+  function buildLogoutUrl(redirectPath) {
+    var path = redirectPath || window.location.pathname + window.location.search + window.location.hash;
+    var logoutBase = '/_hcms/mem/logout';
+
+    // Encode the redirect URL to prevent issues with special characters
+    var encodedPath = encodeURIComponent(path);
+
+    return logoutBase + '?redirect_url=' + encodedPath;
+  }
+
+  /**
+   * Navigate to login page with optional redirect
+   *
+   * @param {string} [redirectPath=null] - Optional redirect path after login
+   *
+   * @example
+   * // Simple login redirect
+   * window.hhLoginHelper.login();
+   *
+   * @example
+   * // Login then redirect to specific page
+   * window.hhLoginHelper.login('/learn/courses/course-authoring-101');
+   */
+  function login(redirectPath) {
+    window.location.href = buildLoginUrl(redirectPath);
+  }
+
+  /**
+   * Navigate to logout page with optional redirect
+   *
+   * @param {string} [redirectPath=null] - Optional redirect path after logout
+   *
+   * @example
+   * // Simple logout redirect
+   * window.hhLoginHelper.logout();
+   *
+   * @example
+   * // Logout then redirect to home
+   * window.hhLoginHelper.logout('/learn');
+   */
+  function logout(redirectPath) {
+    window.location.href = buildLogoutUrl(redirectPath);
+  }
+
+  /**
+   * Check if user is authenticated (from window.hhIdentity)
+   *
+   * @returns {boolean} True if user has email or contactId, false otherwise
+   *
+   * @example
+   * if (window.hhLoginHelper.isAuthenticated()) {
+   *   console.log('User is logged in');
+   * } else {
+   *   console.log('User is anonymous');
+   * }
+   */
+  function isAuthenticated() {
+    if (!window.hhIdentity || typeof window.hhIdentity.isAuthenticated !== 'function') {
+      // Fallback: check if identity exists manually
+      var identity = window.hhIdentity && window.hhIdentity.get ? window.hhIdentity.get() : null;
+      return !!(identity && (identity.email || identity.contactId));
+    }
+
+    return window.hhIdentity.isAuthenticated();
+  }
+
+  /**
+   * Public API: window.hhLoginHelper
+   *
+   * Provides utilities for HubSpot native authentication flows
+   */
+  window.hhLoginHelper = {
+    /**
+     * Build login URL with redirect
+     * @type {Function}
+     */
+    buildLoginUrl: buildLoginUrl,
+
+    /**
+     * Build logout URL with redirect
+     * @type {Function}
+     */
+    buildLogoutUrl: buildLogoutUrl,
+
+    /**
+     * Navigate to login page
+     * @type {Function}
+     */
+    login: login,
+
+    /**
+     * Navigate to logout page
+     * @type {Function}
+     */
+    logout: logout,
+
+    /**
+     * Check if user is authenticated
+     * @type {Function}
+     */
+    isAuthenticated: isAuthenticated
+  };
+
+  if (localStorage.getItem('HHL_DEBUG') === 'true' && window.hhDebug) {
+    window.hhDebug.log('login-helper', 'HubSpot native login helper initialized');
+  }
+
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
@@ -1,0 +1,514 @@
+/**
+ * Hedgehog Learn – My Learning dashboard (CSP-safe)
+ * - Authenticated users: hydrate from CRM via GET /progress/read
+ * - Logged-out users: fall back to localStorage
+ * - Fetches module metadata from HubDB and renders In Progress and Completed sections
+ */
+(function(){
+  function ready(fn){ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', fn); else fn(); }
+  function fetchJSON(u){ return fetch(u, { credentials: 'include' }).then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); }); }
+  function getConstants(){
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl,
+      HUBDB_COURSES_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-courses-table-id')) || null,
+      HUBDB_MODULES_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-modules-table-id')) || null
+    });
+  }
+  function getAuth(){
+    // Use window.hhIdentity API for actual membership authentication
+    var identity = window.hhIdentity ? window.hhIdentity.get() : null;
+    var email = '';
+    var contactId = '';
+    if (identity) {
+      email = identity.email || '';
+      contactId = identity.contactId || '';
+    }
+    // Get enableCrm from auth context div
+    var el = document.getElementById('hhl-auth-context');
+    var enableCrm = false;
+    if (el) {
+      var enableAttr = el.getAttribute('data-enable-crm');
+      enableCrm = enableAttr && enableAttr.toString().toLowerCase() === 'true';
+    }
+    return { enableCrm: enableCrm, email: email, contactId: contactId };
+  }
+
+  function waitForIdentityReady() {
+    try {
+      if (window.hhIdentity && window.hhIdentity.ready && typeof window.hhIdentity.ready.then === 'function') {
+        return window.hhIdentity.ready;
+      }
+    } catch (error) {}
+    return Promise.resolve(null);
+  }
+  function getReadUrl(constants){
+    var track = (constants && constants.TRACK_EVENTS_URL) || '';
+    // Derive: replace /events/track with /progress/read; fallback to relative
+    if (track && track.indexOf('/events/track') >= 0) return track.replace('/events/track','/progress/read');
+    return '/progress/read';
+  }
+  function getEnrollmentsUrl(constants){
+    var track = (constants && constants.TRACK_EVENTS_URL) || '';
+    // Derive: replace /events/track with /enrollments/list; fallback to relative
+    if (track && track.indexOf('/events/track') >= 0) return track.replace('/events/track','/enrollments/list');
+    return '/enrollments/list';
+  }
+  function getAllProgress(){
+    var prog = { inProgress: new Set(), completed: new Set() };
+    try {
+      for (var i=0;i<localStorage.length;i++){
+        var key = localStorage.key(i);
+        if (key && key.startsWith('hh-module-')){
+          var slug = key.replace('hh-module-','');
+          try { var data = JSON.parse(localStorage.getItem(key)||'{}');
+            if (data.completed) prog.completed.add(slug); else if (data.started) prog.inProgress.add(slug);
+          } catch(e){}
+        }
+      }
+    } catch(e){}
+    return prog;
+  }
+  function setsFromCrm(progress){
+    var res = { inProgress: new Set(), completed: new Set() };
+    try {
+      if (!progress) return res;
+
+      // Process each top-level key
+      Object.keys(progress).forEach(function(key){
+        // Skip the 'courses' key as it's a container, not a pathway
+        if (key === 'courses') {
+          // Process courses separately - they have nested structure
+          var courses = progress.courses || {};
+          Object.keys(courses).forEach(function(courseSlug){
+            var courseModules = (courses[courseSlug] && courses[courseSlug].modules) || {};
+            Object.keys(courseModules).forEach(function(slug){
+              var m = courseModules[slug] || {};
+              if (m.completed) res.completed.add(slug);
+              else if (m.started) res.inProgress.add(slug);
+            });
+          });
+        } else {
+          // Process pathway modules
+          var modules = (progress[key] && progress[key].modules) || {};
+          Object.keys(modules).forEach(function(slug){
+            var m = modules[slug] || {};
+            if (m.completed) res.completed.add(slug);
+            else if (m.started) res.inProgress.add(slug);
+          });
+        }
+      });
+    } catch(e){}
+    return res;
+  }
+  function renderModuleCard(module, isCompleted){
+    var a = document.createElement('a');
+    a.href = '/learn/' + (module.path || module.hs_path || '');
+    a.className = 'module-card';
+    var minutes = (module.values && module.values.estimated_minutes) || module.estimated_minutes || 0;
+    var name = (module.values && module.values.hs_name) || module.hs_name || 'Untitled Module';
+    var desc = (module.values && module.values.meta_description) || module.meta_description || '';
+    a.innerHTML = '<div class="module-card-header">\
+        <span class="module-progress-badge '+(isCompleted?'completed':'')+'">'+(isCompleted?'Completed':'In Progress')+'</span>\
+        <span class="module-time">'+minutes+' min</span>\
+      </div>\
+      <h3>'+name+'</h3>' + (desc?('<p>'+desc.substring(0,150)+(desc.length>150?'...':'')+'</p>'):'') + '\
+      <span class="module-cta">'+(isCompleted?'Review Module':'Continue Learning')+' →</span>';
+    return a;
+  }
+  function q(id){ return document.getElementById(id); }
+  function showResume(last){
+    try{
+      if (!last || !last.type || !last.slug) return;
+      var panel = q('last-viewed-panel');
+      var link = q('last-viewed-link');
+      var meta = q('last-viewed-meta');
+      var href = last.type === 'course' ? ('/learn/courses/' + last.slug) : ('/learn/' + last.slug);
+      link.href = href;
+      link.textContent = (last.type==='course'?'Course: ':'Module: ') + last.slug;
+      if (last.at) meta.textContent = '· viewed ' + last.at;
+      panel.style.display = 'block';
+    }catch(e){}
+  }
+  function formatDate(isoString){
+    if (!isoString) return '';
+    try {
+      var d = new Date(isoString);
+      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    } catch(e) { return ''; }
+  }
+  function formatRelativeTime(isoString){
+    if (!isoString) return '';
+    try {
+      var now = new Date();
+      var then = new Date(isoString);
+      var diffMs = now - then;
+      var diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      if (diffDays === 0) return 'today';
+      if (diffDays === 1) return 'yesterday';
+      if (diffDays < 7) return diffDays + ' days ago';
+      if (diffDays < 30) return Math.floor(diffDays / 7) + ' weeks ago';
+      return formatDate(isoString);
+    } catch(e) { return formatDate(isoString); }
+  }
+  function renderEnrollmentCard(item, type, courseMetadata, progressData){
+    var card = document.createElement('div');
+    card.className = 'enrollment-card';
+    var slug = item.slug || '';
+    var enrolledAt = item.enrolled_at || '';
+    var source = item.enrollment_source || 'unknown';
+    var href = type === 'pathway' ? ('/learn/pathways/' + slug) : ('/learn/courses/' + slug);
+    var title = slug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
+    var sourceLabel = source.replace(/_/g, ' ');
+
+    // Build card header
+    var html = '<div class="enrollment-card-header">\
+        <h3><a href="'+href+'" style="color:#1a4e8a; text-decoration:none;">'+title+'</a></h3>\
+        <span class="enrollment-badge">'+type+'</span>\
+      </div>\
+      <div class="enrollment-meta">\
+        <div class="enrollment-date"><strong>Enrolled:</strong> '+formatDate(enrolledAt)+'</div>\
+        <div class="enrollment-source"><strong>Source:</strong> '+sourceLabel+'</div>\
+      </div>';
+
+    // Add module listings if courseMetadata is provided
+    if (courseMetadata && courseMetadata.modules && courseMetadata.modules.length > 0){
+      var modules = courseMetadata.modules;
+      var completedCount = 0;
+      var totalCount = modules.length;
+      var nextIncompleteModule = null;
+
+      // Calculate completion count and find next incomplete
+      modules.forEach(function(mod){
+        if (mod.completed) {
+          completedCount++;
+        } else if (!nextIncompleteModule && mod.started) {
+          nextIncompleteModule = mod;
+        } else if (!nextIncompleteModule && !mod.started) {
+          nextIncompleteModule = mod;
+        }
+      });
+
+      var progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+      // Add progress bar
+      html += '<div class="enrollment-progress">\
+        <div class="enrollment-progress-label">'+completedCount+' of '+totalCount+' modules complete ('+progressPercent+'%)</div>\
+        <div class="enrollment-progress-bar">\
+          <div class="enrollment-progress-fill" style="width:'+progressPercent+'%"></div>\
+        </div>\
+      </div>';
+
+      // Add collapsible module list
+      html += '<details class="enrollment-modules-toggle">\
+        <summary class="enrollment-modules-summary">View Modules</summary>\
+        <div class="enrollment-modules-list">';
+
+      modules.forEach(function(mod){
+        var modPath = mod.path || mod.hs_path || mod.slug;
+        var modName = mod.name || mod.hs_name || modPath.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
+        var modStatus = mod.completed ? '✓' : (mod.started ? '◐' : '○');
+        var modStatusClass = mod.completed ? 'completed' : (mod.started ? 'in-progress' : 'not-started');
+        html += '<div class="enrollment-module-item '+modStatusClass+'">\
+          <span class="enrollment-module-status">'+modStatus+'</span>\
+          <a href="/learn/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
+        </div>';
+      });
+
+      html += '</div></details>';
+
+      // Update "Continue" button to link to next incomplete module
+      if (nextIncompleteModule) {
+        var nextPath = nextIncompleteModule.path || nextIncompleteModule.hs_path || nextIncompleteModule.slug;
+        html += '<div class="enrollment-actions">\
+          <a href="/learn/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
+        </div>';
+      } else {
+        html += '<div class="enrollment-actions">\
+          <a href="'+href+'" class="enrollment-cta">View Course →</a>\
+        </div>';
+      }
+    } else {
+      // No module metadata, show generic "Continue Learning" button
+      html += '<div class="enrollment-actions">\
+        <a href="'+href+'" class="enrollment-cta">Continue Learning →</a>\
+      </div>';
+    }
+
+    card.innerHTML = html;
+    return card;
+  }
+  function renderEnrolledContent(enrollments, constants, progressData){
+    try {
+      var pathways = enrollments.pathways || [];
+      var courses = enrollments.courses || [];
+      var enrolledSection = q('enrolled-section');
+      var enrolledGrid = q('enrolled-grid');
+
+      if (!enrolledSection || !enrolledGrid) return;
+
+      // Clear existing content
+      enrolledGrid.innerHTML = '';
+
+      if (pathways.length === 0 && courses.length === 0){
+        enrolledSection.style.display = 'none';
+        return;
+      }
+
+      var COURSES_TABLE_ID = constants.HUBDB_COURSES_TABLE_ID;
+      var MODULES_TABLE_ID = constants.HUBDB_MODULES_TABLE_ID;
+
+      function getCourseProgress(courseSlug){
+        if (!progressData || !progressData.progress || !courseSlug) return null;
+        var prog = progressData.progress;
+        if (prog.courses && prog.courses[courseSlug]) return prog.courses[courseSlug];
+        var nested = null;
+        Object.keys(prog).forEach(function(pathwaySlug){
+          if (pathwaySlug !== 'courses' && prog[pathwaySlug] && prog[pathwaySlug].courses && prog[pathwaySlug].courses[courseSlug]) {
+            nested = prog[pathwaySlug].courses[courseSlug];
+          }
+        });
+        return nested;
+      }
+
+      function buildFallbackCourseMetadataMap(){
+        var fallback = {};
+        courses.forEach(function(course){
+          var courseSlug = (course && course.slug) || '';
+          if (!courseSlug) return;
+          var courseProgress = getCourseProgress(courseSlug);
+          var moduleProgressMap = (courseProgress && courseProgress.modules) || {};
+          var moduleSlugs = Object.keys(moduleProgressMap);
+          if (moduleSlugs.length === 0) return;
+          fallback[courseSlug] = {
+            modules: moduleSlugs.map(function(modSlug){
+              var modProgress = moduleProgressMap[modSlug] || {};
+              return {
+                slug: modSlug,
+                path: modSlug,
+                hs_path: modSlug,
+                name: modSlug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); }),
+                hs_name: modSlug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); }),
+                started: !!modProgress.started,
+                completed: !!modProgress.completed
+              };
+            })
+          };
+        });
+        return Object.keys(fallback).length ? fallback : null;
+      }
+
+      // Fetch course metadata for all enrolled courses
+      var coursePromises = courses.map(function(course){
+        var courseSlug = course.slug || '';
+        if (!COURSES_TABLE_ID || !courseSlug) return Promise.resolve(null);
+
+        return fetchJSON('/hs/api/hubdb/v3/tables/'+COURSES_TABLE_ID+'/rows?hs_path__eq='+encodeURIComponent(courseSlug))
+          .then(function(data){
+            if (!data || !data.results || data.results.length === 0) return null;
+            var courseRow = data.results[0];
+            var moduleSlugsJson = (courseRow.values && courseRow.values.module_slugs_json) || courseRow.module_slugs_json || '[]';
+            var moduleSlugs = [];
+            try {
+              moduleSlugs = JSON.parse(moduleSlugsJson);
+            } catch(e){}
+
+            return {
+              courseSlug: courseSlug,
+              moduleSlugs: moduleSlugs,
+              courseRow: courseRow
+            };
+          })
+          .catch(function(){ return null; });
+      });
+
+      // Wait for all course metadata to load
+      Promise.all(coursePromises).then(function(coursesData){
+        // Fetch module metadata for all unique module slugs
+        var allModuleSlugs = [];
+        coursesData.forEach(function(courseData){
+          if (courseData && courseData.moduleSlugs) {
+            allModuleSlugs = allModuleSlugs.concat(courseData.moduleSlugs);
+          }
+        });
+
+        // Remove duplicates
+        allModuleSlugs = Array.from(new Set(allModuleSlugs));
+
+        if (allModuleSlugs.length === 0 || !MODULES_TABLE_ID) {
+          // No HubDB module metadata available; fall back to progress state module slugs.
+          renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+          return;
+        }
+
+        // Fetch all module metadata in one batch
+        var filter = allModuleSlugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
+        fetchJSON('/hs/api/hubdb/v3/tables/'+MODULES_TABLE_ID+'/rows?'+filter+'&tags__not__icontains=archived')
+          .then(function(data){
+            var modules = (data && data.results) || [];
+
+            // Build a map of moduleSlug -> moduleData
+            var moduleMap = {};
+            modules.forEach(function(mod){
+              var slug = (mod.values && mod.values.hs_path) || mod.hs_path || mod.path;
+              if (slug) moduleMap[slug] = mod;
+            });
+
+            // Build course metadata with modules and progress
+            var courseMetadataMap = {};
+            coursesData.forEach(function(courseData){
+              if (!courseData) return;
+              var courseSlug = courseData.courseSlug;
+              var moduleSlugs = courseData.moduleSlugs;
+
+              // Get progress data for this course
+              var courseProgress = null;
+              if (progressData && progressData.progress) {
+                var prog = progressData.progress;
+                // Check in courses container
+                if (prog.courses && prog.courses[courseSlug]) {
+                  courseProgress = prog.courses[courseSlug];
+                }
+                // Also check in pathways
+                Object.keys(prog).forEach(function(pathwaySlug){
+                  if (pathwaySlug !== 'courses' && prog[pathwaySlug].courses && prog[pathwaySlug].courses[courseSlug]) {
+                    courseProgress = prog[pathwaySlug].courses[courseSlug];
+                  }
+                });
+              }
+
+              // Build module list with progress
+              var modulesWithProgress = moduleSlugs.map(function(modSlug){
+                var modData = moduleMap[modSlug] || {};
+                var modProgress = (courseProgress && courseProgress.modules && courseProgress.modules[modSlug]) || {};
+                return {
+                  slug: modSlug,
+                  path: (modData.values && modData.values.hs_path) || modData.hs_path || modSlug,
+                  hs_path: (modData.values && modData.values.hs_path) || modData.hs_path || modSlug,
+                  name: (modData.values && modData.values.hs_name) || modData.hs_name || '',
+                  hs_name: (modData.values && modData.values.hs_name) || modData.hs_name || '',
+                  started: modProgress.started || false,
+                  completed: modProgress.completed || false
+                };
+              });
+
+              courseMetadataMap[courseSlug] = {
+                modules: modulesWithProgress
+              };
+            });
+
+            renderEnrolledCards(pathways, courses, courseMetadataMap, progressData);
+          })
+          .catch(function(err){
+            console.error('[hhl-my-learning] Error fetching module metadata:', err);
+            renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+          });
+      }).catch(function(err){
+        console.error('[hhl-my-learning] Error fetching course metadata:', err);
+        renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+      });
+
+      function renderEnrolledCards(pathways, courses, courseMetadataMap, progressData){
+        // Render pathways
+        pathways.forEach(function(pathway){
+          enrolledGrid.appendChild(renderEnrollmentCard(pathway, 'pathway', null, progressData));
+        });
+
+        // Render courses with metadata
+        courses.forEach(function(course){
+          var courseMetadata = courseMetadataMap ? courseMetadataMap[course.slug] : null;
+          enrolledGrid.appendChild(renderEnrollmentCard(course, 'course', courseMetadata, progressData));
+        });
+
+        // Update count and show section
+        var totalEnrolled = pathways.length + courses.length;
+        var enrolledCount = q('enrolled-count');
+        if (enrolledCount) enrolledCount.textContent = '(' + totalEnrolled + ')';
+        enrolledSection.style.display = 'block';
+      }
+    } catch(e){
+      console.error('[hhl-my-learning] Error rendering enrolled content:', e);
+      // Show error state to user
+      var errorGrid = q('enrolled-grid');
+      if (errorGrid) {
+        errorGrid.innerHTML = '<div style="padding:20px; text-align:center; color:#666;">\
+          <p>Unable to load enrollments. Please refresh the page to try again.</p>\
+        </div>';
+      }
+    }
+  }
+
+  ready(function(){
+    waitForIdentityReady().finally(function(){
+      Promise.resolve(getConstants()).then(function(constants){
+      var MODULES_TABLE_ID = constants.HUBDB_MODULES_TABLE_ID;
+      var auth = getAuth();
+      // default: localStorage fallback
+      var localSets = getAllProgress();
+
+      function renderFromSets(sets){
+        var slugs = Array.from(new Set([].concat(Array.from(sets.inProgress), Array.from(sets.completed))));
+        function done(modules){
+          q('loading-state').style.display = 'none';
+          q('main-content-container').style.display = 'block';
+          var inProg = modules.filter(function(m){ return sets.inProgress.has(m.path); });
+          var comp = modules.filter(function(m){ return sets.completed.has(m.path); });
+          q('stat-in-progress').textContent = inProg.length;
+          q('stat-completed').textContent = comp.length;
+          if (inProg.length===0 && comp.length===0){ q('empty-state').style.display = 'block'; return; }
+          if (inProg.length>0){
+            q('in-progress-count').textContent = '('+inProg.length+')';
+            var c1 = q('in-progress-modules'); inProg.forEach(function(m){ c1.appendChild(renderModuleCard(m,false)); });
+            q('in-progress-section').style.display = 'block';
+          }
+          if (comp.length>0){
+            q('completed-count').textContent = '('+comp.length+')';
+            var c2 = q('completed-modules'); comp.forEach(function(m){ c2.appendChild(renderModuleCard(m,true)); });
+            q('completed-section').style.display = 'block';
+          }
+        }
+        if (!MODULES_TABLE_ID || slugs.length===0){ return done([]); }
+    var filter = slugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
+        fetchJSON('/hs/api/hubdb/v3/tables/'+MODULES_TABLE_ID+'/rows?'+filter+'&tags__not__icontains=archived')
+          .then(function(data){ done((data && data.results)||[]); })
+          .catch(function(){ done([]); });
+      }
+
+      if (auth.enableCrm && (auth.email || auth.contactId)){
+        var readUrl = getReadUrl(constants);
+        var enrollUrl = getEnrollmentsUrl(constants);
+        var query = auth.contactId ? ('?contactId='+encodeURIComponent(auth.contactId)) : ('?email='+encodeURIComponent(auth.email));
+
+        // Fetch both progress and enrollments in parallel
+        Promise.all([
+          fetchJSON(readUrl + query).catch(function(){ return null; }),
+          fetchJSON(enrollUrl + query).catch(function(){ return null; })
+        ]).then(function(results){
+          var progressData = results[0];
+          var enrollmentData = results[1];
+
+          // Show resume panel if available
+          if (progressData && progressData.mode === 'authenticated' && progressData.last_viewed){
+            showResume(progressData.last_viewed);
+          }
+
+          // Render enrolled content if available
+          if (enrollmentData && enrollmentData.mode === 'authenticated' && enrollmentData.enrollments){
+            renderEnrolledContent(enrollmentData.enrollments, constants, progressData);
+          }
+
+          // Render module progress
+          if (progressData && progressData.mode === 'authenticated' && progressData.progress){
+            return renderFromSets(setsFromCrm(progressData.progress));
+          }
+          renderFromSets(localSets);
+        }).catch(function(){ renderFromSets(localSets); });
+      } else {
+        renderFromSets(localSets);
+      }
+    });
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/pageview.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/pageview.js
@@ -1,0 +1,80 @@
+/**
+ * Hedgehog Learn – Pageview beacon (CSP-safe)
+ * Sends a lightweight 'learning_page_viewed' event for module/course detail pages
+ * Only sends when CRM sync is enabled and the user is logged in (email or contactId present)
+ */
+(function(){
+  function ready(fn){ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', fn); else fn(); }
+  function fetchJSON(u){ return fetch(u, { credentials:'omit' }).then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); }); }
+  function getConstants(){
+    // Issue #345: Read constants from data attributes (no more CORS fetch)
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl
+    });
+  }
+  function getAuth(){
+    // Use window.hhIdentity API for actual membership authentication
+    var identity = window.hhIdentity ? window.hhIdentity.get() : null;
+    var email = '';
+    var contactId = '';
+    if (identity) {
+      email = identity.email || '';
+      contactId = identity.contactId || '';
+    }
+    // Get enableCrm from auth context div
+    var el = document.getElementById('hhl-auth-context');
+    var enableCrm = false;
+    if (el) {
+      var enableAttr = el.getAttribute('data-enable-crm');
+      enableCrm = (enableAttr || '').toString().toLowerCase() === 'true';
+    }
+    return { enableCrm: enableCrm, email: email, contactId: contactId };
+  }
+  function send(constants, auth, payload){
+    if (!constants || !constants.TRACK_EVENTS_ENABLED || !constants.TRACK_EVENTS_URL) return;
+    if (!auth.enableCrm || (!auth.email && !auth.contactId)) return;
+    var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+    var body = { eventName:'learning_page_viewed', payload: payload, contactIdentifier:{} };
+    if (auth.email) body.contactIdentifier.email = auth.email;
+    if (auth.contactId) body.contactIdentifier.contactId = auth.contactId;
+    try{
+      if (debug) console.log('[hhl] pageview', body);
+      if (navigator.sendBeacon){
+        var blob = new Blob([JSON.stringify(body)], { type:'application/json' });
+        navigator.sendBeacon(constants.TRACK_EVENTS_URL, blob);
+      } else {
+        fetch(constants.TRACK_EVENTS_URL, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body), keepalive:true }).catch(function(){});
+      }
+    }catch(e){/* no-op */}
+  }
+  function detect(){
+    // Module detail emits <meta name="hhl:module_slug">; course detail emits <meta name="hhl:course_slug">
+    var m = document.querySelector('meta[name="hhl:module_slug"]');
+    var c = document.querySelector('meta[name="hhl:course_slug"]');
+    if (m && m.content) return { type:'module', slug: m.content };
+    if (c && c.content) return { type:'course', slug: c.content };
+    return null;
+  }
+  ready(function(){
+    var info = detect();
+    if (!info) return; // Only detail pages
+    Promise.all([getConstants(), Promise.resolve(getAuth())]).then(function(res){
+      var constants = res[0];
+      var auth = res[1];
+      var payload = { content_type: info.type, slug: info.slug, ts: new Date().toISOString() };
+
+      // Add course context if viewing a module from a course
+      if (info.type === 'module' && window.hhCourseContext) {
+        var context = window.hhCourseContext.getContext();
+        if (context && context.courseSlug) {
+          payload.course_slug = context.courseSlug;
+        }
+      }
+
+      send(constants, auth, payload);
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/pathways.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/pathways.js
@@ -1,0 +1,174 @@
+/**
+ * Hedgehog Learn – Pathways page interactions (CSP-safe)
+ * - Shows local progress counts and bar
+ * - (Legacy) Enrollment beacons now handled via /learn/action-runner (Issue #245)
+ * - Exposes window.hhUpdatePathwayProgress(started, completed)
+ */
+(function () {
+  function ready(fn) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn); else fn();
+  }
+
+  /**
+   * Build fetch headers with JWT token if available (Issue #251)
+   */
+  function buildAuthHeaders() {
+    var headers = { 'Content-Type': 'application/json' };
+    try {
+      var token = localStorage.getItem('hhl_auth_token');
+      if (token) {
+        headers['Authorization'] = 'Bearer ' + token;
+      }
+    } catch (e) {
+      // Ignore localStorage errors
+    }
+    return headers;
+  }
+
+  function fetchJSON(url) {
+    return fetch(url, {
+      credentials: 'omit',
+      headers: buildAuthHeaders()
+    }).then(function (r) {
+      if (!r.ok) throw new Error('Failed to load ' + url);
+      return r.json();
+    });
+  }
+
+  function getConstants() {
+    // Issue #345: Read constants from data attributes (no more CORS fetch)
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl
+    });
+  }
+
+  function getAuth() {
+    var el = document.getElementById('hhl-auth-context');
+    if (!el) return { enableCrm: false };
+    var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function') ? window.hhIdentity.get() : null;
+    var email = identity && identity.email ? identity.email : (el.getAttribute('data-email') || null);
+    var contactId = identity && identity.contactId ? identity.contactId : (el.getAttribute('data-contact-id') || null);
+    return {
+      email: email,
+      contactId: contactId,
+      enableCrm: (el.getAttribute('data-enable-crm') || 'false') === 'true'
+    };
+  }
+
+  function sendEnrollment(constants, auth, pathwaySlug) {
+    // Deprecated: explicit enrollment now routes through /learn/action-runner (Issue #245).
+    try {
+      var key = 'hh-pathway-enrolled-' + pathwaySlug;
+      if (!sessionStorage.getItem(key)) {
+        sessionStorage.setItem(key, 'true');
+      }
+    } catch (e) {}
+  }
+
+  function getLocalProgress(pathwaySlug) {
+    try {
+      var raw = localStorage.getItem('hh-pathway-progress-' + pathwaySlug);
+      return raw ? JSON.parse(raw) : { started:0, completed:0 };
+    } catch(e) { return { started:0, completed:0 }; }
+  }
+
+  function fetchCRMProgress(constants, auth, pathwaySlug) {
+    // Return promise that resolves to progress data
+    if (!constants || !constants.TRACK_EVENTS_URL || !auth.enableCrm || (!auth.email && !auth.contactId)) {
+      return Promise.resolve(null); // Fall back to local storage
+    }
+
+    var apiBase = constants.TRACK_EVENTS_URL.replace('/events/track', '');
+    var params = new URLSearchParams({
+      type: 'pathway',
+      slug: pathwaySlug
+    });
+    if (auth.email) params.append('email', auth.email);
+    if (auth.contactId) params.append('contactId', auth.contactId);
+
+    var url = apiBase + '/progress/aggregate?' + params.toString();
+
+    return fetch(url, { credentials: 'omit' })
+      .then(function(r) {
+        if (!r.ok) throw new Error('Failed to fetch progress');
+        return r.json();
+      })
+      .then(function(data) {
+        if (data.mode === 'authenticated') {
+          return {
+            started: data.started || 0,
+            completed: data.completed || 0,
+            enrolled: data.enrolled || false
+          };
+        }
+        return null;
+      })
+      .catch(function(err) {
+        console.warn('[hhl] Failed to fetch CRM progress:', err);
+        return null;
+      });
+  }
+
+  function renderProgress(totalModules, pathwaySlug, progressData) {
+    var startedEl = document.getElementById('progress-started');
+    var completedEl = document.getElementById('progress-completed');
+    var barEl = document.getElementById('progress-bar');
+    var authPrompt = document.getElementById('auth-prompt');
+    if (startedEl) startedEl.textContent = progressData.started;
+    if (completedEl) completedEl.textContent = progressData.completed;
+    var pct = totalModules > 0 ? Math.round((progressData.completed / totalModules) * 100) : 0;
+    if (barEl) barEl.style.width = pct + '%';
+
+    // Only show auth prompt if using local storage AND has some progress
+    if (authPrompt && !progressData.fromCRM && (progressData.started > 0 || progressData.completed > 0)) {
+      authPrompt.style.display = 'flex';
+    }
+  }
+
+  ready(function(){
+    var node = document.querySelector('[data-pathway-slug]');
+    var pathwaySlug = node ? node.getAttribute('data-pathway-slug') : (window.location.pathname.split('/').filter(Boolean).pop() || 'unknown');
+    var totalNode = document.querySelector('[data-total-modules]');
+    var totalModules = totalNode ? parseInt(totalNode.getAttribute('data-total-modules')||'0',10) : 0;
+
+    Promise.all([getConstants(), Promise.resolve(getAuth())]).then(function(res){
+      var constants = res[0]; var auth = res[1];
+
+      // Try to fetch CRM progress first, fall back to local storage
+      fetchCRMProgress(constants, auth, pathwaySlug).then(function(crmProgress){
+        var progressData;
+        if (crmProgress) {
+          // Use CRM data
+          progressData = {
+            started: crmProgress.started,
+            completed: crmProgress.completed,
+            fromCRM: true
+          };
+        } else {
+          // Fall back to local storage
+          var localProgress = getLocalProgress(pathwaySlug);
+          progressData = {
+            started: localProgress.started,
+            completed: localProgress.completed,
+            fromCRM: false
+          };
+        }
+
+        renderProgress(totalModules, pathwaySlug, progressData);
+        sendEnrollment(constants, auth, pathwaySlug);
+
+        // Expose update function (for legacy compatibility)
+        window.hhUpdatePathwayProgress = function(started, completed){
+          try {
+            localStorage.setItem('hh-pathway-progress-' + pathwaySlug, JSON.stringify({ started: started, completed: completed, lastUpdated: new Date().toISOString() }));
+          } catch(e) {}
+          var updatedData = { started: started, completed: completed, fromCRM: false };
+          renderProgress(totalModules, pathwaySlug, updatedData);
+        };
+      });
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/progress.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/progress.js
@@ -1,0 +1,262 @@
+/**
+ * Hedgehog Learn – Progress interactions (CSP-safe)
+ * - Attaches click handlers for Mark Started / Mark Complete
+ * - Sends beacons to the /events/track endpoint
+ * - Reads auth context from a data element rendered by the template
+ * - Fetches constants.json directly (no inline JS required)
+ */
+
+(function () {
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn);
+    } else {
+      fn();
+    }
+  }
+
+  function fetchJSON(url) {
+    return fetch(url, {
+      credentials: 'include'
+    }).then(function (r) {
+      if (!r.ok) throw new Error('Failed to load ' + url);
+      return r.json();
+    });
+  }
+
+  function getConstants() {
+    // Issue #345: Read constants from data attributes (no more CORS fetch)
+    var ctx = document.getElementById('hhl-auth-context');
+    var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
+    return Promise.resolve({
+      TRACK_EVENTS_URL: trackEventsUrl || null,
+      TRACK_EVENTS_ENABLED: !!trackEventsUrl
+    })
+      .then(function (json) {
+        return json || {};
+      })
+      .catch(function () {
+        // Hard fallback to known API gateway used by this project
+        return {
+          TRACK_EVENTS_ENABLED: true,
+          TRACK_EVENTS_URL: 'https://api.hedgehog.cloud/events/track',
+          ENABLE_CRM_PROGRESS: true,
+          ACTION_RUNNER_URL: '/learn/action-runner'
+        };
+      });
+  }
+
+  function getAuthContext() {
+    // Use window.hhIdentity API for actual membership authentication
+    var identity = window.hhIdentity ? window.hhIdentity.get() : null;
+    var email = null;
+    var contactId = null;
+    if (identity) {
+      email = identity.email || null;
+      contactId = identity.contactId || null;
+    }
+    // Get enableCrm from auth context div
+    var el = document.getElementById('hhl-auth-context');
+    var enableCrm = false;
+    if (el) {
+      var enableAttr = el.getAttribute('data-enable-crm');
+      enableCrm = (enableAttr || '').toString().toLowerCase() === 'true';
+    }
+    return { email: email, contactId: contactId, enableCrm: enableCrm };
+  }
+
+  function getActionRunnerBase(constants) {
+    if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
+    return '/learn/action-runner';
+  }
+
+  function buildRunnerUrl(base, redirectUrl, params) {
+    var runner = base || '/learn/action-runner';
+    var search = new URLSearchParams();
+    Object.keys(params || {}).forEach(function(key) {
+      var value = params[key];
+      if (value !== undefined && value !== null && value !== '') {
+        search.set(key, value);
+      }
+    });
+    if (redirectUrl) search.set('redirect_url', redirectUrl);
+    return runner + '?' + search.toString();
+  }
+
+  function deriveRedirectPath() {
+    return window.location.pathname + window.location.search + window.location.hash;
+  }
+
+  function setModuleState(slug, started, completed) {
+    if (!slug) return;
+    try {
+      sessionStorage.setItem('hhl-module-state-' + slug, JSON.stringify({
+        started: !!started,
+        completed: !!completed,
+        ts: new Date().toISOString()
+      }));
+    } catch {
+      // ignore storage write failures
+    }
+  }
+
+  function getModuleState(slug) {
+    if (!slug) return null;
+    try {
+      var raw = sessionStorage.getItem('hhl-module-state-' + slug);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  function consumeProgressResult(slug) {
+    try {
+      var raw = sessionStorage.getItem('hhl_last_action');
+      if (!raw) return null;
+      var data = JSON.parse(raw);
+      if (!data || data.action !== 'record_progress') return null;
+      if (slug && data.params && data.params.module_slug && data.params.module_slug !== slug) return null;
+      sessionStorage.removeItem('hhl_last_action');
+      return data;
+    } catch {
+      try { sessionStorage.removeItem('hhl_last_action'); } catch {}
+      return null;
+    }
+  }
+
+  function applyProgressFeedback(result, moduleSlug, startBtn, completeBtn, startText, completeText) {
+    if (!result) return;
+    var status = result.status || 'success';
+    if (status === 'success') {
+      var progressStatus = result.params && result.params.status;
+      if (progressStatus === 'completed') {
+        setModuleState(moduleSlug, true, true);
+        if (completeBtn) {
+          updateButtonState(completeBtn, 'success', completeText);
+        }
+        if (startBtn) {
+          updateButtonState(startBtn, 'success', startText);
+        }
+        if (window.hhToast) {
+          window.hhToast.show('Module marked complete!', 'success', 4200);
+        }
+      } else {
+        setModuleState(moduleSlug, true, false);
+        if (startBtn) {
+          updateButtonState(startBtn, 'success', startText);
+        }
+        if (window.hhToast) {
+          window.hhToast.show('Module marked as started!', 'success', 4000);
+        }
+      }
+    } else if (status === 'error' && window.hhToast) {
+      window.hhToast.show('We could not save your progress. Please try again.', 'error', 5200);
+    }
+  }
+
+  function updateButtonState(button, state, originalText) {
+    var states = {
+      loading: { text: 'Saving...', disabled: true, style: 'opacity: 0.6; cursor: wait;' },
+      success: { text: '✓ Saved', disabled: true, style: 'background: #D1FAE5; color: #065F46; border: 2px solid #6EE7B7;' },
+      default: { text: originalText, disabled: false, style: '' }
+    };
+
+    var config = states[state] || states.default;
+    button.textContent = config.text;
+    button.disabled = config.disabled;
+    button.style.cssText += config.style;
+  }
+
+  ready(function () {
+    var startBtn = document.getElementById('hhl-mark-started');
+    var completeBtn = document.getElementById('hhl-mark-complete');
+
+    if (!startBtn && !completeBtn) return;
+
+    // Store original button text
+    var startBtnText = startBtn ? startBtn.textContent : '';
+    var completeBtnText = completeBtn ? completeBtn.textContent : '';
+
+    Promise.all([getConstants(), Promise.resolve(getAuthContext())]).then(function (res) {
+      var constants = res[0];
+      var auth = res[1];
+      var debug = (localStorage.getItem('HHL_DEBUG') === 'true');
+      if (debug) console.log('[hhl] progress.js attached', { constants, auth, hasStart: !!startBtn, hasComplete: !!completeBtn });
+
+      var moduleSlugKey = (document.querySelector('meta[name="hhl:module_slug"]') || {}).content || window.location.pathname.split('/').filter(Boolean).pop();
+      var pendingResult = consumeProgressResult(moduleSlugKey);
+      var storedState = getModuleState(moduleSlugKey);
+
+      if (storedState) {
+        if (storedState.completed && completeBtn) {
+          updateButtonState(completeBtn, 'success', completeBtnText);
+        }
+        if (storedState.started && startBtn) {
+          updateButtonState(startBtn, 'success', startBtnText);
+        }
+      }
+
+      function track(button, started, completed, originalText) {
+        // The module/page should expose these as meta tags or data attributes; if not available, we try to infer from URL
+        var moduleSlug = moduleSlugKey;
+        var pathwaySlug = (document.querySelector('meta[name="hhl:pathway_slug"]') || {}).content || null;
+        var courseSlug = (window.hhCourseContext && window.hhCourseContext.getContext()) ? window.hhCourseContext.getContext().courseSlug : null;
+        var status = completed ? 'completed' : 'started';
+
+        // Show loading state
+        updateButtonState(button, 'loading', originalText);
+
+        // Show loading toast if hhToast is available
+        var toast = null;
+        if (window.hhToast) {
+          var loadingMessage = completed ? 'Marking module complete...' : 'Marking module started...';
+          toast = window.hhToast.show(loadingMessage, 'loading', 0);
+        }
+
+        setModuleState(moduleSlug, started, completed);
+
+        var runnerBase = getActionRunnerBase(constants);
+        var params = {
+          action: 'record_progress',
+          module_slug: moduleSlug,
+          status: status
+        };
+        if (pathwaySlug) params.pathway_slug = pathwaySlug;
+        if (courseSlug) params.course_slug = courseSlug;
+
+        updateButtonState(button, 'success', originalText);
+        if (completed && startBtn) {
+          updateButtonState(startBtn, 'success', startBtnText);
+        }
+
+        if (toast && window.hhToast) {
+          var successMessage = completed ? 'Module marked complete!' : 'Module marked as started!';
+          window.hhToast.update(toast, successMessage, 'success');
+        }
+
+        setTimeout(function () {
+          var redirectTarget = deriveRedirectPath();
+          if (debug) console.log('[hhl] progress runner redirect', params);
+          window.location.href = buildRunnerUrl(runnerBase, redirectTarget, params);
+        }, 200);
+      }
+
+      if (startBtn) {
+        startBtn.addEventListener('click', function () {
+          track(startBtn, 1, 0, startBtnText);
+        });
+      }
+      if (completeBtn) {
+        completeBtn.addEventListener('click', function () {
+          track(completeBtn, 1, 1, completeBtnText);
+        });
+      }
+
+      if (pendingResult) {
+        applyProgressFeedback(pendingResult, moduleSlugKey, startBtn, completeBtn, startBtnText, completeBtnText);
+      }
+    });
+  });
+})();

--- a/clean-x-hedgehog-templates/assets/shadow/js/toast.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/toast.js
@@ -1,0 +1,159 @@
+/**
+ * Toast Notification Utility for Hedgehog Learn
+ * Provides accessible, CSP-safe toast notifications with auto-dismiss
+ */
+
+(function() {
+  'use strict';
+
+  /**
+   * Initialize toast styles (singleton pattern)
+   */
+  function initToastStyles() {
+    if (document.getElementById('hhl-toast-styles')) return;
+
+    var style = document.createElement('style');
+    style.id = 'hhl-toast-styles';
+    style.textContent = '@keyframes slideIn { from { transform: translateX(400px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }';
+    document.head.appendChild(style);
+  }
+
+  /**
+   * Show toast notification
+   * @param {string} message - The message to display
+   * @param {string} type - Type of toast: 'success', 'info', 'error', or 'loading'
+   * @param {number} duration - Duration in milliseconds (0 = no auto-dismiss)
+   * @returns {HTMLElement} The toast element (useful for manual dismissal)
+   */
+  function showToast(message, type, duration) {
+    type = type || 'info';
+    duration = duration !== undefined ? duration : 3000;
+
+    // Ensure styles are initialized
+    initToastStyles();
+
+    // Check if toast container exists, create if not
+    var container = document.getElementById('hhl-toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'hhl-toast-container';
+      container.setAttribute('role', 'region');
+      container.setAttribute('aria-live', 'polite');
+      container.setAttribute('aria-label', 'Notifications');
+      container.style.cssText = 'position: fixed; top: 20px; right: 20px; z-index: 10000;';
+      document.body.appendChild(container);
+    }
+
+    // Create toast element
+    var toast = document.createElement('div');
+    toast.className = 'hhl-toast hhl-toast-' + type;
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+
+    // Define colors based on type
+    var colors = {
+      success: { bg: '#D1FAE5', border: '#6EE7B7', text: '#065F46', icon: '✓' },
+      info: { bg: '#FEF3C7', border: '#FCD34D', text: '#92400E', icon: 'ℹ️' },
+      error: { bg: '#FEE2E2', border: '#FCA5A5', text: '#991B1B', icon: '✕' },
+      loading: { bg: '#E0E7FF', border: '#A5B4FC', text: '#3730A3', icon: '⟳' }
+    };
+
+    var color = colors[type] || colors.info;
+
+    toast.style.cssText = [
+      'background: ' + color.bg,
+      'border: 1px solid ' + color.border,
+      'color: ' + color.text,
+      'padding: 12px 20px',
+      'border-radius: 8px',
+      'margin-bottom: 10px',
+      'box-shadow: 0 4px 12px rgba(0,0,0,0.15)',
+      'min-width: 250px',
+      'font-size: 0.875rem',
+      'font-weight: 500',
+      'display: flex',
+      'align-items: center',
+      'gap: 8px',
+      'animation: slideIn 0.3s ease-out'
+    ].join(';');
+
+    toast.innerHTML = '<span style="font-size:1.2em" aria-hidden="true">' + color.icon + '</span><span>' + message + '</span>';
+
+    container.appendChild(toast);
+
+    // Auto-remove after duration (if not loading and duration > 0)
+    if (type !== 'loading' && duration > 0) {
+      setTimeout(function() {
+        removeToast(toast);
+      }, duration);
+    }
+
+    return toast;
+  }
+
+  /**
+   * Remove a toast element with fade animation
+   * @param {HTMLElement} toast - The toast element to remove
+   */
+  function removeToast(toast) {
+    if (!toast || !toast.parentNode) return;
+
+    toast.style.opacity = '0';
+    toast.style.transition = 'opacity 0.3s ease-out';
+    setTimeout(function() {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
+  }
+
+  /**
+   * Update an existing toast's message and type
+   * @param {HTMLElement} toast - The toast element to update
+   * @param {string} message - New message
+   * @param {string} type - New type
+   */
+  function updateToast(toast, message, type) {
+    if (!toast) return;
+
+    var colors = {
+      success: { bg: '#D1FAE5', border: '#6EE7B7', text: '#065F46', icon: '✓' },
+      info: { bg: '#FEF3C7', border: '#FCD34D', text: '#92400E', icon: 'ℹ️' },
+      error: { bg: '#FEE2E2', border: '#FCA5A5', text: '#991B1B', icon: '✕' },
+      loading: { bg: '#E0E7FF', border: '#A5B4FC', text: '#3730A3', icon: '⟳' }
+    };
+
+    var color = colors[type] || colors.info;
+
+    // Update styling
+    toast.style.background = color.bg;
+    toast.style.borderColor = color.border;
+    toast.style.color = color.text;
+    toast.className = 'hhl-toast hhl-toast-' + type;
+
+    // Update content
+    toast.innerHTML = '<span style="font-size:1.2em" aria-hidden="true">' + color.icon + '</span><span>' + message + '</span>';
+
+    // Auto-remove if not loading
+    if (type !== 'loading') {
+      setTimeout(function() {
+        removeToast(toast);
+      }, 3000);
+    }
+  }
+
+  // Expose globally
+  window.hhToast = {
+    show: showToast,
+    remove: removeToast,
+    update: updateToast
+  };
+
+  // Initialize on load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initToastStyles);
+  } else {
+    initToastStyles();
+  }
+
+})();

--- a/clean-x-hedgehog-templates/learn-shadow/action-runner.html
+++ b/clean-x-hedgehog-templates/learn-shadow/action-runner.html
@@ -1,0 +1,237 @@
+<!--
+  templateType: page
+  isAvailableForNewContent: true
+  label: Action Runner (Private)
+  description: Private action runner that executes enrollment and progress actions with membership context before redirecting back to the originating page. Issue #245.
+-->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Processing your request…</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: linear-gradient(135deg, #1a4e8a 0%, #2563eb 100%);
+        color: #fff;
+      }
+      .runner-container {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 16px;
+        padding: 48px 40px;
+        max-width: 540px;
+        width: min(540px, calc(100% - 32px));
+        text-align: center;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+      }
+      .runner-spinner {
+        border: 4px solid rgba(255, 255, 255, 0.2);
+        border-radius: 50%;
+        border-top: 4px solid #fff;
+        width: 48px;
+        height: 48px;
+        margin: 0 auto 24px;
+        animation: runner-spin 1s linear infinite;
+      }
+      @keyframes runner-spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+      h1 {
+        font-size: 1.75rem;
+        margin: 0 0 12px 0;
+      }
+      p {
+        margin: 0;
+        font-size: 1rem;
+        opacity: 0.9;
+      }
+      .runner-details {
+        margin-top: 24px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        opacity: 0.95;
+      }
+      .runner-actions {
+        display: none;
+        margin-top: 32px;
+        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .runner-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 12px 20px;
+        border-radius: 999px;
+        border: none;
+        text-decoration: none;
+        font-weight: 600;
+        font-size: 0.95rem;
+        transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+      }
+      .runner-button.primary {
+        background: #fff;
+        color: #1a4e8a;
+      }
+      .runner-button.primary:hover {
+        transform: translateY(-1px);
+        background: #e0ecff;
+      }
+      .runner-button.secondary {
+        background: rgba(255, 255, 255, 0.12);
+        color: #f8fafc;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+      }
+      .runner-button.secondary:hover {
+        background: rgba(255, 255, 255, 0.22);
+      }
+      .runner-icon {
+        font-size: 2rem;
+        margin-bottom: 16px;
+      }
+      .runner-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 6px;
+        background: rgba(15, 23, 42, 0.35);
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 999px;
+        padding: 6px 12px;
+        margin-bottom: 16px;
+        font-size: 0.8rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+    </style>
+  </head>
+  <body>
+    {{ standard_header_includes }}
+    {#
+      Issue #326 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+      HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+      Source: clean-x-hedgehog-templates/config/constants.json
+    #}
+    {% set constants = {
+      'HUBDB_MODULES_TABLE_ID': '135621904',
+      'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+      'HUBDB_COURSES_TABLE_ID': '135381433',
+      'HUBDB_CATALOG_TABLE_ID': '136199186',
+      'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+      'ENABLE_CRM_PROGRESS': true,
+      'LOGOUT_URL': '/_hcms/mem/logout',
+      'LOGIN_URL': '/_hcms/mem/login',
+      'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+      'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+      'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+      'TRACK_EVENTS_ENABLED': true,
+      'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+      'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+    } %}
+    {% set login_url = constants.AUTH_LOGIN_URL %}
+    {% set is_editor_mode = is_in_editor or is_in_page_preview or request.query_dict.hs_preview or request.query_dict.hs_builder %}
+
+    {# Resolve membership identity using request_contact with personalization_token fallback (Issue #276) #}
+    {% set runner_email = '' %}
+    {% set runner_contact_id = '' %}
+    {% if request_contact.is_logged_in %}
+      {% set runner_email = request_contact.email|default('', true) %}
+      {% set runner_contact_id = request_contact.hs_object_id|default(request_contact.vid, true) %}
+    {% endif %}
+
+    {% if not runner_email %}
+      {% set runner_email = personalization_token('contact.email', '') %}
+    {% endif %}
+
+    {% if not runner_contact_id %}
+      {% set runner_contact_id = personalization_token('contact.hs_object_id', '') %}
+    {% endif %}
+
+    {% set is_logged_in = request_contact.is_logged_in or runner_email %}
+
+    <div class="runner-container" id="action-runner-container">
+      <div id="runner-icon" class="runner-icon">⚙️</div>
+      <div class="runner-badge" id="runner-badge">
+        Secure Action Runner
+      </div>
+      <div class="runner-spinner" id="action-runner-spinner"></div>
+      <h1 id="action-runner-title">Processing your request…</h1>
+      <p id="action-runner-message">Hold tight while we securely complete your action.</p>
+      <div class="runner-details" id="action-runner-details"></div>
+      <div class="runner-actions" id="action-runner-actions">
+        <a href="/learn" class="runner-button primary" id="action-runner-primary">Return to Learn</a>
+        <a href="#" class="runner-button secondary" id="action-runner-secondary">Back to previous page</a>
+      </div>
+    </div>
+
+    <!-- Cognito Auth Context -->
+    <div id="hhl-auth-context"
+         data-auth-me-url="{{ constants.AUTH_ME_URL|default('https://api.hedgehog.cloud/auth/me') if constants else 'https://api.hedgehog.cloud/auth/me' }}"
+         data-auth-login-url="{{ constants.AUTH_LOGIN_URL|default('https://api.hedgehog.cloud/auth/login') if constants else 'https://api.hedgehog.cloud/auth/login' }}"
+         data-auth-logout-url="{{ constants.AUTH_LOGOUT_URL|default('https://api.hedgehog.cloud/auth/logout') if constants else 'https://api.hedgehog.cloud/auth/logout' }}"
+         data-track-events-url="https://api.hedgehog.cloud/events/track"
+         data-enable-crm="true"
+         style="display:none">
+    </div>
+
+    {% set action_config = {
+      'enroll_pathway': {
+        'event': 'learning_pathway_enrolled',
+        'required': ['slug'],
+        'optional': ['source', 'course_slug']
+      },
+      'enroll_course': {
+        'event': 'learning_course_enrolled',
+        'required': ['slug'],
+        'optional': ['source', 'pathway_slug']
+      },
+      'record_progress': {
+        'event': 'learning_module_progress',
+        'required': ['module_slug', 'status'],
+        'optional': ['pathway_slug', 'course_slug']
+      }
+    } %}
+    <div
+      id="hhl-action-runner"
+      data-is-editor="{{ 'true' if is_editor_mode else 'false' }}"
+      data-is-logged-in="{{ 'true' if is_logged_in else 'false' }}"
+      data-email="{{ runner_email|escapejs if runner_email else '' }}"
+      data-contact-id="{{ runner_contact_id|escapejs if runner_contact_id else '' }}"
+      data-track-url="{{ constants.TRACK_EVENTS_URL }}"
+      data-login-url="{{ login_url }}"
+      data-actions="{{ action_config|tojson|escape_attr }}"
+    ></div>
+
+    {% if is_editor_mode %}
+      <script>
+        (function(){
+          var title = document.getElementById('action-runner-title');
+          var message = document.getElementById('action-runner-message');
+          var spinner = document.getElementById('action-runner-spinner');
+          if (spinner) spinner.style.display = 'none';
+          if (title) title.textContent = 'Editor Preview: Action Runner Disabled';
+          if (message) {
+            message.textContent = 'This private page executes enrollment and progress actions for signed-in learners. Redirect logic is paused while editing so you can update copy or layout safely.';
+          }
+          var badge = document.getElementById('runner-badge');
+          if (badge) badge.textContent = 'Editor Preview';
+        })();
+      </script>
+    {% else %}
+      <!-- Cognito auth must load BEFORE action-runner -->
+      <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+      <!-- Action runner depends on window.hhIdentity -->
+      <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/action-runner.js') }}"></script>
+    {% endif %}
+    {{ standard_footer_includes }}
+  </body>
+</html>

--- a/clean-x-hedgehog-templates/learn-shadow/action-runner.html
+++ b/clean-x-hedgehog-templates/learn-shadow/action-runner.html
@@ -168,7 +168,7 @@
       <p id="action-runner-message">Hold tight while we securely complete your action.</p>
       <div class="runner-details" id="action-runner-details"></div>
       <div class="runner-actions" id="action-runner-actions">
-        <a href="/learn" class="runner-button primary" id="action-runner-primary">Return to Learn</a>
+        <a href="/learn-shadow" class="runner-button primary" id="action-runner-primary">Return to Learn</a>
         <a href="#" class="runner-button secondary" id="action-runner-secondary">Back to previous page</a>
       </div>
     </div>

--- a/clean-x-hedgehog-templates/learn-shadow/assets/js/cognito-auth-integration.js
+++ b/clean-x-hedgehog-templates/learn-shadow/assets/js/cognito-auth-integration.js
@@ -102,11 +102,11 @@
 
     window.getActionRunnerBase = window.getActionRunnerBase || function(constants) {
       if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
-      return '/learn/action-runner';
+      return '/learn-shadow/action-runner';
     };
 
     window.buildRunnerUrl = window.buildRunnerUrl || function(base, redirectUrl, params) {
-      var runner = base || '/learn/action-runner';
+      var runner = base || '/learn-shadow/action-runner';
       var search = new URLSearchParams();
       Object.keys(params || {}).forEach(function(key) {
         var value = params[key];

--- a/clean-x-hedgehog-templates/learn-shadow/assets/js/cognito-auth-integration.js
+++ b/clean-x-hedgehog-templates/learn-shadow/assets/js/cognito-auth-integration.js
@@ -1,0 +1,504 @@
+/**
+ * HHL Cognito OAuth Frontend Integration (Issue #306 - Phase 6)
+ *
+ * This module integrates AWS Cognito OAuth authentication with the HubSpot CMS frontend.
+ * It replaces JWT-based authentication with Cognito OAuth using httpOnly cookies.
+ *
+ * ## Features
+ * - Fetches user profile from `/auth/me` endpoint (uses httpOnly cookies automatically)
+ * - Emits `hhl:identity` custom event when authentication state is resolved
+ * - Provides backward-compatible `window.hhIdentity` API
+ * - Gracefully handles anonymous sessions (401 responses)
+ * - Supports Cognito OAuth login/logout flows
+ *
+ * ## Authentication Flow
+ * 1. Page loads → calls `/auth/me` to check authentication status
+ * 2. If cookies present and valid → returns user profile → authenticated state
+ * 3. If no cookies or invalid → returns 401 → anonymous state
+ * 4. Login: redirect to `/auth/login?redirect_url=<current_page>`
+ * 5. Logout: redirect to `/auth/logout` → clears cookies
+ *
+ * ## API Compatibility
+ * This module maintains backward compatibility with existing code that uses:
+ * - `window.hhIdentity.ready` (Promise)
+ * - `window.hhIdentity.get()` (returns identity object)
+ * - `window.hhIdentity.isAuthenticated()` (returns boolean)
+ * - `hhl:identity` custom event
+ *
+ * @see https://github.com/afewell-hh/hh-learn/issues/306
+ * @see docs/specs/issue-299-external-sso-spec.md
+ *
+ * @module cognito-auth-integration
+ */
+(function() {
+  'use strict';
+
+  // Prevent double-loading
+  if (window.hhCognitoAuth && window.hhCognitoAuth.__initialized) {
+    console.warn('[cognito-auth] Already initialized, skipping');
+    return;
+  }
+
+  var debug = localStorage.getItem('HHL_DEBUG') === 'true';
+
+  /**
+   * Get constants configuration from DOM (Issue #345 - no more constants.json fetch)
+   */
+  function getConfig() {
+    var authDiv = document.getElementById('hhl-auth-context');
+    var config = {
+      authMeUrl: '/auth/me',
+      authLoginUrl: '/auth/login',
+      authLogoutUrl: '/auth/logout',
+    };
+
+    if (authDiv) {
+      config.authMeUrl = authDiv.getAttribute('data-auth-me-url') || config.authMeUrl;
+      config.authLoginUrl = authDiv.getAttribute('data-auth-login-url') || config.authLoginUrl;
+      config.authLogoutUrl = authDiv.getAttribute('data-auth-logout-url') || config.authLogoutUrl;
+    }
+
+    // Return config synchronously (no fetch)
+    return Promise.resolve(config);
+  }
+
+  function ensureEnrollmentHelpers() {
+    if (typeof window.waitForIdentityReady === 'function' && typeof window.getAuth === 'function') {
+      return;
+    }
+
+    function parseBoolean(value) {
+      if (typeof value === 'boolean') return value;
+      if (!value) return false;
+      var normalized = value.toString().trim().toLowerCase();
+      return normalized === 'true' || normalized === '1' || normalized === 'yes';
+    }
+
+    window.waitForIdentityReady = window.waitForIdentityReady || function() {
+      try {
+        if (window.hhIdentity && window.hhIdentity.ready && typeof window.hhIdentity.ready.then === 'function') {
+          return window.hhIdentity.ready;
+        }
+      } catch (error) {}
+      return Promise.resolve(null);
+    };
+
+    window.getAuth = window.getAuth || function() {
+      var el = document.getElementById('hhl-auth-context');
+      var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function')
+        ? window.hhIdentity.get()
+        : null;
+      var authenticated = identity ? !!identity.authenticated : parseBoolean(el && el.getAttribute('data-authenticated'));
+      var email = identity && identity.email ? identity.email : (el && el.getAttribute('data-email')) || null;
+      var contactId = identity && identity.contactId ? identity.contactId : (el && el.getAttribute('data-contact-id')) || null;
+      return {
+        authenticated: authenticated,
+        email: email,
+        contactId: contactId,
+        enableCrm: parseBoolean(el && el.getAttribute('data-enable-crm')),
+        trackEventsUrl: el && el.getAttribute('data-track-events-url')
+      };
+    };
+
+    window.getActionRunnerBase = window.getActionRunnerBase || function(constants) {
+      if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
+      return '/learn/action-runner';
+    };
+
+    window.buildRunnerUrl = window.buildRunnerUrl || function(base, redirectUrl, params) {
+      var runner = base || '/learn/action-runner';
+      var search = new URLSearchParams();
+      Object.keys(params || {}).forEach(function(key) {
+        var value = params[key];
+        if (value !== undefined && value !== null && value !== '') {
+          search.set(key, value);
+        }
+      });
+      if (redirectUrl) search.set('redirect_url', redirectUrl);
+      return runner + '?' + search.toString();
+    };
+
+    window.deriveEnrollmentSource = window.deriveEnrollmentSource || function() {
+      var path = window.location.pathname || '';
+      if (path.indexOf('/pathways/') >= 0) return 'pathway_page';
+      if (path.indexOf('/courses/') >= 0) return 'course_page';
+      if (path.indexOf('/modules/') >= 0) return 'module_page';
+      return 'learn_page';
+    };
+
+    window.bindClick = window.bindClick || function(button, handler) {
+      if (!button || typeof handler !== 'function') return;
+      window.unbindClick && window.unbindClick(button);
+      var wrapped = function(event) {
+        if (event) event.preventDefault();
+        handler();
+      };
+      button.__hhlEnrollHandler = wrapped;
+      button.addEventListener('click', wrapped);
+    };
+
+    window.unbindClick = window.unbindClick || function(button) {
+      if (!button) return;
+      var existing = button.__hhlEnrollHandler;
+      if (existing) {
+        button.removeEventListener('click', existing);
+        button.__hhlEnrollHandler = null;
+      }
+    };
+  }
+
+  ensureEnrollmentHelpers();
+
+  /**
+   * Fetch user profile from /auth/me endpoint
+   * Uses httpOnly cookies automatically via credentials: 'include'
+   *
+   * @returns {Promise<Object|null>} User profile or null if not authenticated
+   */
+  function fetchAuthMe(authMeUrl) {
+    if (debug) {
+      console.log('[cognito-auth] Fetching user profile from', authMeUrl);
+    }
+
+    return fetch(authMeUrl, {
+      method: 'GET',
+      credentials: 'include', // Include httpOnly cookies
+      headers: {
+        'Accept': 'application/json',
+      },
+    })
+      .then(function(response) {
+        if (response.ok) {
+          return response.json().then(function(data) {
+            if (debug) {
+              console.log('[cognito-auth] Authenticated user profile received', {
+                hasEmail: !!data.email,
+                hasUserId: !!data.userId,
+              });
+            }
+            return data;
+          });
+        } else if (response.status === 401) {
+          // Not authenticated (no valid cookies)
+          if (debug) {
+            console.log('[cognito-auth] Not authenticated (401) - anonymous session');
+          }
+          return null;
+        } else {
+          // Other error status
+          if (debug) {
+            console.warn('[cognito-auth] /auth/me returned status:', response.status);
+          }
+          return null;
+        }
+      })
+      .catch(function(error) {
+        // Network error or other fetch failure
+        if (debug) {
+          console.error('[cognito-auth] Failed to fetch /auth/me:', error.message);
+        }
+        return null;
+      });
+  }
+
+  /**
+   * Transform /auth/me response to window.hhIdentity format
+   * Maps Cognito profile fields to legacy format for compatibility
+   */
+  function transformProfile(profile) {
+    if (!profile) {
+      return {
+        email: '',
+        contactId: '',
+        userId: '',
+        displayName: '',
+        firstname: '',
+        lastname: '',
+        authenticated: false,
+      };
+    }
+
+    return {
+      email: profile.email || '',
+      contactId: profile.hubspotContactId || '', // HubSpot CRM sync creates this
+      userId: profile.userId || '',
+      displayName: profile.displayName || profile.email || '',
+      firstname: profile.givenName || '',
+      lastname: profile.familyName || '',
+      authenticated: true,
+      // Include raw Cognito data for advanced use cases
+      _cognitoProfile: profile,
+    };
+  }
+
+  /**
+   * Update DOM with auth context data
+   */
+  function updateAuthContextDom(identity) {
+    var node = document.getElementById('hhl-auth-context');
+    if (!node) return;
+
+    try {
+      node.setAttribute('data-email', identity.email || '');
+      node.setAttribute('data-contact-id', identity.contactId || '');
+      node.setAttribute('data-user-id', identity.userId || '');
+      node.setAttribute('data-authenticated', identity.authenticated ? 'true' : 'false');
+
+      if (identity.firstname) {
+        node.setAttribute('data-firstname', identity.firstname);
+      } else {
+        node.removeAttribute('data-firstname');
+      }
+
+      if (identity.lastname) {
+        node.setAttribute('data-lastname', identity.lastname);
+      } else {
+        node.removeAttribute('data-lastname');
+      }
+
+      if (debug) {
+        console.log('[cognito-auth] Updated DOM auth context');
+      }
+    } catch (err) {
+      if (debug) {
+        console.warn('[cognito-auth] Failed to update DOM:', err.message);
+      }
+    }
+  }
+
+  /**
+   * Toggle UI elements based on auth state
+   * Shows/hides elements with data-auth-state="authenticated|anonymous"
+   */
+  function applyAuthState(identity) {
+    var state = identity && identity.authenticated ? 'authenticated' : 'anonymous';
+    var nodes = document.querySelectorAll('[data-auth-state]');
+
+    nodes.forEach(function(node) {
+      var expectedState = node.getAttribute('data-auth-state');
+      if (expectedState === state) {
+        node.style.display = '';  // Show matching state
+      } else {
+        node.style.display = 'none';  // Hide non-matching state
+      }
+    });
+
+    // Update user greeting if authenticated
+    if (state === 'authenticated') {
+      var greetingNode = document.getElementById('auth-user-greeting');
+      if (greetingNode && identity.firstname) {
+        greetingNode.textContent = 'Hi, ' + identity.firstname + '!';
+      } else if (greetingNode) {
+        greetingNode.textContent = 'Hi there!';
+      }
+    }
+
+    if (debug) {
+      console.log('[cognito-auth] Applied auth state:', state);
+    }
+  }
+
+  /**
+   * Emit hhl:identity event for downstream consumers
+   */
+  function emitIdentityEvent(identity) {
+    try {
+      if (typeof CustomEvent === 'function') {
+        var event = new CustomEvent('hhl:identity', {
+          detail: identity,
+          bubbles: true,
+          cancelable: false,
+        });
+        document.dispatchEvent(event);
+
+        if (debug) {
+          console.log('[cognito-auth] Dispatched hhl:identity event');
+        }
+      }
+    } catch (e) {
+      if (debug) {
+        console.warn('[cognito-auth] Failed to dispatch event:', e.message);
+      }
+    }
+  }
+
+  /**
+   * Initialize Cognito authentication
+   * Fetches user profile and updates identity state
+   */
+  function initCognitoAuth() {
+    return getConfig().then(function(config) {
+      return fetchAuthMe(config.authMeUrl).then(function(profile) {
+        var identity = transformProfile(profile);
+
+        // Update DOM
+        updateAuthContextDom(identity);
+
+        // Toggle UI elements based on auth state
+        applyAuthState(identity);
+
+        // Emit event
+        emitIdentityEvent(identity);
+
+        // Update global identity object
+        if (window.hhIdentity) {
+          window.hhIdentity._identity = identity;
+          window.hhIdentity._resolved = true;
+          // Ensure legacy hhIdentity variants expose the full Cognito API.
+          window.hhIdentity.get = function() {
+            return this._identity;
+          };
+          window.hhIdentity.isAuthenticated = function() {
+            return !!(this._identity && this._identity.authenticated);
+          };
+          window.hhIdentity.isReady = function() {
+            return !!this._resolved;
+          };
+          window.hhIdentity.login = function(redirectPath) {
+            return login(redirectPath);
+          };
+          window.hhIdentity.logout = function(redirectPath) {
+            return logout(redirectPath);
+          };
+          if (!window.hhIdentity.ready || typeof window.hhIdentity.ready.then !== 'function') {
+            window.hhIdentity.ready = Promise.resolve(identity);
+          }
+        }
+
+        if (debug) {
+          console.log('[cognito-auth] Identity resolved:', {
+            authenticated: identity.authenticated,
+            email: identity.email,
+          });
+        }
+
+        return identity;
+      });
+    });
+  }
+
+  /**
+   * Redirect to Cognito login
+   */
+  function login(redirectPath) {
+    return getConfig().then(function(config) {
+      var path = redirectPath || window.location.pathname + window.location.search + window.location.hash;
+      var loginUrl = config.authLoginUrl + '?redirect_url=' + encodeURIComponent(path);
+
+      if (debug) {
+        console.log('[cognito-auth] Redirecting to login:', loginUrl);
+      }
+
+      window.location.href = loginUrl;
+    });
+  }
+
+  /**
+   * Redirect to Cognito logout
+   */
+  function logout(redirectPath) {
+    return getConfig().then(function(config) {
+      var logoutUrl = config.authLogoutUrl;
+
+      if (redirectPath) {
+        logoutUrl += '?redirect_url=' + encodeURIComponent(redirectPath);
+      }
+
+      if (debug) {
+        console.log('[cognito-auth] Redirecting to logout:', logoutUrl);
+      }
+
+      window.location.href = logoutUrl;
+    });
+  }
+
+  /**
+   * Backward-compatible window.hhIdentity API
+   * Maintains compatibility with existing code
+   */
+  if (!window.hhIdentity) {
+    window.hhIdentity = {
+      _identity: null,
+      _resolved: false,
+      ready: null,
+
+      get: function() {
+        return this._identity;
+      },
+
+      isAuthenticated: function() {
+        return !!(this._identity && this._identity.authenticated);
+      },
+
+      isReady: function() {
+        return this._resolved;
+      },
+
+      // Cognito OAuth login (replaces JWT login)
+      login: function(redirectPath) {
+        return login(redirectPath);
+      },
+
+      // Cognito OAuth logout
+      logout: function(redirectPath) {
+        return logout(redirectPath);
+      },
+    };
+
+    // Initialize and set ready promise
+    window.hhIdentity.ready = initCognitoAuth();
+  } else {
+    // hhIdentity already exists (from auth-context.js)
+    // Override with Cognito auth
+    if (debug) {
+      console.log('[cognito-auth] Replacing existing hhIdentity with Cognito auth');
+    }
+
+    var existingIdentity = window.hhIdentity;
+
+    // Preserve any existing state
+    window.hhIdentity = {
+      _identity: existingIdentity._identity || null,
+      _resolved: false,
+      ready: initCognitoAuth(),
+
+      get: function() {
+        return this._identity;
+      },
+
+      isAuthenticated: function() {
+        return !!(this._identity && this._identity.authenticated);
+      },
+
+      isReady: function() {
+        return this._resolved;
+      },
+
+      login: function(redirectPath) {
+        return login(redirectPath);
+      },
+
+      logout: function(redirectPath) {
+        return logout(redirectPath);
+      },
+    };
+  }
+
+  /**
+   * Public API: window.hhCognitoAuth
+   */
+  window.hhCognitoAuth = {
+    __initialized: true,
+    login: login,
+    logout: logout,
+    refresh: initCognitoAuth,
+  };
+
+  if (window.hhIdentity && (typeof window.hhIdentity.login !== 'function' || typeof window.hhIdentity.logout !== 'function')) {
+    initCognitoAuth();
+  }
+
+  if (debug) {
+    console.log('[cognito-auth] Cognito OAuth integration initialized');
+  }
+})();

--- a/clean-x-hedgehog-templates/learn-shadow/catalog.html
+++ b/clean-x-hedgehog-templates/learn-shadow/catalog.html
@@ -1,0 +1,187 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+{% from "/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html" import learning_left_nav %}
+
+{% block head %}
+  {{ super() }}
+
+  {# Left nav + Catalog CSS/JS via require_* to ensure correct hub_generated paths #}
+  {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css')) }}
+  {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css')) }}
+  {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js'), { position: 'footer', defer: true }) }}
+  {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/catalog-filters.js'), { position: 'footer', defer: true }) }}
+
+  {# SEO metadata #}
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'LOGOUT_URL': '/_hcms/mem/logout',
+    'LOGIN_URL': '/_hcms/mem/login',
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+  {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
+
+  {# Auth URLs for Cognito integration #}
+  {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+  {% set login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+  {% set logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+  {% set constants_url = get_asset_url('/CLEAN x HEDGEHOG/templates/config/constants.json') %}
+
+  <title>Learning Catalog - Browse All Content - Learn Hedgehog</title>
+  <meta name="description" content="Browse all learning content in one place - modules, courses, and pathways. Filter by type, difficulty, tags, and duration to find exactly what you need.">
+  <link rel="canonical" href="https://{{ request.domain }}/learn/catalog">
+
+  {# Open Graph tags #}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Learning Catalog - Browse All Content">
+  <meta property="og:description" content="Browse all learning content in one place - modules, courses, and pathways. Filter by type, difficulty, tags, and duration.">
+  <meta property="og:url" content="https://{{ request.domain }}/learn/catalog">
+  <meta property="og:image" content="{{ social_image }}">
+
+  {# Twitter Card tags #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Learning Catalog - Browse All Content">
+  <meta name="twitter:description" content="Browse all learning content in one place - modules, courses, and pathways.">
+  <meta name="twitter:image" content="{{ social_image }}">
+{% endblock head %}
+
+{% block body %}
+<main id="main-content">
+  <section class="learn-header-section">
+    <div class="learn-header-content">
+      <h1 class="learn-page-title">Learning Catalog</h1>
+      <p class="learn-page-subtitle">Browse all modules, courses, and pathways in one unified view</p>
+    </div>
+  </section>
+
+  <div class="learn-layout-with-nav">
+        {{ learning_left_nav('catalog', show_filters=true) }}
+
+    {# Main content area #}
+    <div class="learn-main-content">
+      {# Get catalog table ID from constants #}
+      {#
+        Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+        HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+        Source: clean-x-hedgehog-templates/config/constants.json
+      #}
+      
+      {% set catalog_table_id = dynamic_page_hubdb_table_id %}
+      {% if not catalog_table_id and constants %}
+        {% set catalog_table_id = constants.HUBDB_CATALOG_TABLE_ID if constants.HUBDB_CATALOG_TABLE_ID else none %}
+      {% endif %}
+
+      {# Debug info #}
+      {% if request.query_dict.debug == '1' %}
+        <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px; font-family:monospace; font-size:0.875rem;">
+          <strong>🔍 Debug Info (Catalog):</strong><br>
+          catalog_table_id: {{ catalog_table_id if catalog_table_id else "n/a" }}<br>
+          dynamic_page_hubdb_table_id: {{ dynamic_page_hubdb_table_id if dynamic_page_hubdb_table_id else "n/a" }}<br>
+          constants.HUBDB_CATALOG_TABLE_ID: {{ constants.HUBDB_CATALOG_TABLE_ID if constants and constants.HUBDB_CATALOG_TABLE_ID else "n/a" }}
+        </div>
+      {% endif %}
+
+      <div id="catalog-container">
+        {% if catalog_table_id %}
+          {% set catalog_items = hubdb_table_rows(catalog_table_id, "published__eq=true&orderBy=sort_order") %}
+          {% if catalog_items %}
+            <div class="catalog-grid" id="catalog-grid">
+              {% for item in catalog_items %}
+                {% set type_name = (item.type.name if item.type and item.type.name else item.type)|default('') %}
+                {% set level_name = (item.level.name if item.level and item.level.name else item.level)|default('') %}
+                {# Build dynamic URL based on type + slug extracted from url_path #}
+                {% set base_path = 
+                  ( '/learn/modules' if type_name == 'module' else 
+                    ( '/learn/courses' if type_name == 'course' else '/learn/pathways' ) ) %}
+                {% set raw = item.url_path|default('') %}
+                {% set segments = raw|split('/') %}
+                {% set slug = segments[segments|length - 1] if raw else '' %}
+                {% set href = '/learn/' ~ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) ~ '/' ~ slug %}
+                <article class="catalog-card"
+                         data-type="{{ type_name }}"
+                         data-level="{{ level_name|lower }}"
+                         data-duration="{{ item.duration|int }}"
+                         data-tags="{{ item.tags|lower }}"
+                         data-title="{{ item.title|lower }}">
+                  <div class="catalog-card-header">
+                    <span class="catalog-type-badge catalog-type-{{ type_name }}">
+                      {{ type_name|capitalize }}
+                    </span>
+                    {% if level_name %}
+                      <span class="catalog-level-badge">{{ level_name|capitalize }}</span>
+                    {% endif %}
+                  </div>
+
+                  <h2 class="catalog-card-title">
+                    <a href="https://{{ request.domain }}/learn/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}">{{ item.title }}</a>
+                  </h2>
+
+                  {% if item.summary %}
+                    <div class="catalog-card-summary">
+                      {{ item.summary|striptags|truncate(150) }}
+                    </div>
+                  {% endif %}
+
+                  <div class="catalog-card-meta">
+                    {% if item.duration %}
+                      <span class="catalog-meta-item">
+                        <span aria-hidden="true">⏱️</span> {{ item.duration }} min
+                      </span>
+                    {% endif %}
+                    {% if item.tags %}
+                      <span class="catalog-meta-item">
+                        <span aria-hidden="true">🏷️</span> {{ item.tags }}
+                      </span>
+                    {% endif %}
+                  </div>
+
+                  <a href="https://{{ request.domain }}/learn/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}" class="catalog-card-cta">
+                    Start Learning →
+                  </a>
+                </article>
+              {% endfor %}
+            </div>
+
+            {# No results message (hidden by default) #}
+            <div id="no-results" class="no-results" style="display:none;">
+              <p>No items match your current filters. Try adjusting your selections.</p>
+            </div>
+          {% else %}
+            <p>The catalog is currently empty. Please check back soon!</p>
+          {% endif %}
+        {% else %}
+          <p><em>Bind this page to the Catalog table in the HubSpot page settings, or set HUBDB_CATALOG_TABLE_ID in constants.</em></p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <!-- Cognito Auth Integration -->
+  <div id="hhl-auth-context"
+       data-auth-me-url="{{ auth_me_url }}"
+       data-auth-login-url="{{ login_url }}"
+       data-auth-logout-url="{{ logout_url }}"
+       data-track-events-url="https://api.hedgehog.cloud/events/track"
+       data-enable-crm="true"
+       style="display:none">
+  </div>
+  <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+</main>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/catalog.html
+++ b/clean-x-hedgehog-templates/learn-shadow/catalog.html
@@ -8,6 +8,9 @@
 {% block head %}
   {{ super() }}
 
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
   {# Left nav + Catalog CSS/JS via require_* to ensure correct hub_generated paths #}
   {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css')) }}
   {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css')) }}
@@ -46,13 +49,13 @@
 
   <title>Learning Catalog - Browse All Content - Learn Hedgehog</title>
   <meta name="description" content="Browse all learning content in one place - modules, courses, and pathways. Filter by type, difficulty, tags, and duration to find exactly what you need.">
-  <link rel="canonical" href="https://{{ request.domain }}/learn/catalog">
+  <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/catalog">
 
   {# Open Graph tags #}
   <meta property="og:type" content="website">
   <meta property="og:title" content="Learning Catalog - Browse All Content">
   <meta property="og:description" content="Browse all learning content in one place - modules, courses, and pathways. Filter by type, difficulty, tags, and duration.">
-  <meta property="og:url" content="https://{{ request.domain }}/learn/catalog">
+  <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/catalog">
   <meta property="og:image" content="{{ social_image }}">
 
   {# Twitter Card tags #}
@@ -108,12 +111,12 @@
                 {% set level_name = (item.level.name if item.level and item.level.name else item.level)|default('') %}
                 {# Build dynamic URL based on type + slug extracted from url_path #}
                 {% set base_path = 
-                  ( '/learn/modules' if type_name == 'module' else 
-                    ( '/learn/courses' if type_name == 'course' else '/learn/pathways' ) ) %}
+                  ( '/learn-shadow/modules' if type_name == 'module' else 
+                    ( '/learn-shadow/courses' if type_name == 'course' else '/learn-shadow/pathways' ) ) %}
                 {% set raw = item.url_path|default('') %}
                 {% set segments = raw|split('/') %}
                 {% set slug = segments[segments|length - 1] if raw else '' %}
-                {% set href = '/learn/' ~ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) ~ '/' ~ slug %}
+                {% set href = '/learn-shadow/' ~ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) ~ '/' ~ slug %}
                 <article class="catalog-card"
                          data-type="{{ type_name }}"
                          data-level="{{ level_name|lower }}"
@@ -130,7 +133,7 @@
                   </div>
 
                   <h2 class="catalog-card-title">
-                    <a href="https://{{ request.domain }}/learn/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}">{{ item.title }}</a>
+                    <a href="https://{{ request.domain }}/learn-shadow/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}">{{ item.title }}</a>
                   </h2>
 
                   {% if item.summary %}
@@ -152,7 +155,7 @@
                     {% endif %}
                   </div>
 
-                  <a href="https://{{ request.domain }}/learn/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}" class="catalog-card-cta">
+                  <a href="https://{{ request.domain }}/learn-shadow/{{ ( 'modules' if type_name == 'module' else ( 'courses' if type_name == 'course' else 'pathways' ) ) }}/{{ slug }}" class="catalog-card-cta">
                     Start Learning →
                   </a>
                 </article>

--- a/clean-x-hedgehog-templates/learn-shadow/courses-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/courses-page.html
@@ -1,0 +1,1022 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+{% from "/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html" import learning_left_nav %}
+
+{% block head %}
+  {{ super() }}
+
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Defined in shared scope so both detail and list views can access.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'LOGOUT_URL': '/_hcms/mem/logout',
+    'LOGIN_URL': '/_hcms/mem/login',
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+
+  {% if dynamic_page_hubdb_row %}
+    {# SEO metadata for course detail pages #}
+    {% set page_title = dynamic_page_hubdb_row.hs_name ~ " - Courses - Learn Hedgehog" %}
+    {% set meta_desc = dynamic_page_hubdb_row.meta_description|striptags|truncate(160) if dynamic_page_hubdb_row.meta_description else (dynamic_page_hubdb_row.summary_markdown|striptags|truncate(160) if dynamic_page_hubdb_row.summary_markdown else "Learn " ~ dynamic_page_hubdb_row.hs_name) %}
+    {% set canonical_url = "https://" ~ request.domain ~ "/learn/courses/" ~ dynamic_page_hubdb_row.hs_path %}
+    {% set social_image = dynamic_page_hubdb_row.social_image_url if dynamic_page_hubdb_row.social_image_url else constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    <title>{{ page_title }}</title>
+    <meta name="description" content="{{ meta_desc }}">
+    <link rel="canonical" href="{{ canonical_url }}">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ page_title }}">
+    <meta property="og:description" content="{{ meta_desc }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ page_title }}">
+    <meta name="twitter:description" content="{{ meta_desc }}">
+    <meta name="twitter:image" content="{{ social_image }}">
+    {# HHL pageview meta for JS beacon #}
+    <meta name="hhl:course_slug" content="{{ dynamic_page_hubdb_row.hs_path }}">
+
+    {# JSON-LD structured data for course detail #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Course",
+      "name": {{ dynamic_page_hubdb_row.hs_name|tojson }},
+      {% if dynamic_page_hubdb_row.meta_description or dynamic_page_hubdb_row.summary_markdown %}
+      "description": {{ meta_desc|tojson }},
+      {% endif %}
+      "url": "https://{{ request.domain }}/learn/courses/{{ dynamic_page_hubdb_row.hs_path }}",
+      {% if dynamic_page_hubdb_row.estimated_minutes %}
+      "timeRequired": "PT{{ dynamic_page_hubdb_row.estimated_minutes }}M",
+      {% endif %}
+      "provider": {
+        "@type": "Organization",
+        "name": "Hedgehog"
+      },
+      {% if dynamic_page_hubdb_row.module_slugs_json or dynamic_page_hubdb_row.content_blocks_json %}
+        {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID %}
+        {% if modules_table_id %}
+          {# Collect all module slugs for JSON-LD #}
+          {% set all_module_slugs = [] %}
+          {% if dynamic_page_hubdb_row.content_blocks_json %}
+            {% set blocks = dynamic_page_hubdb_row.content_blocks_json|fromjson %}
+            {% for block in blocks %}
+              {% if block.type == 'module_ref' and block.module_slug %}
+                {% set _ = all_module_slugs.append(block.module_slug) %}
+              {% endif %}
+            {% endfor %}
+          {% elif dynamic_page_hubdb_row.module_slugs_json %}
+            {% set all_module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+          {% endif %}
+
+          {# Fetch each module individually since HubL doesn't support hs_path__in #}
+          {# NOTE: Query by 'hs_path__eq=' which filters on hs_path column (Page Path) in HubDB #}
+          {% set modules_by_slug_jsonld = {} %}
+          {% for slug in all_module_slugs %}
+            {% set module_rows = hubdb_table_rows(modules_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+            {% if module_rows and module_rows|length > 0 %}
+              {% set _ = modules_by_slug_jsonld.update({slug: module_rows[0]}) %}
+            {% endif %}
+          {% endfor %}
+
+      "hasPart": [
+          {% for slug in all_module_slugs %}
+            {% set module = modules_by_slug_jsonld[slug] %}
+            {% if module %}
+        {
+          "@type": "LearningResource",
+          "name": {{ module.hs_name|tojson }},
+      "url": "https://{{ request.domain }}/learn/modules/{{ module.hs_path }}",
+          "position": {{ loop.index }}
+        }{% if not loop.last %},{% endif %}
+            {% endif %}
+          {% endfor %}
+      ],
+        {% endif %}
+      {% endif %}
+      "inLanguage": "en-US"
+    }
+    </script>
+
+    {# BreadcrumbList JSON-LD #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Learn",
+          "item": "https://{{ request.domain }}/learn"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Courses",
+          "item": "https://{{ request.domain }}/learn/courses"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": {{ dynamic_page_hubdb_row.hs_name|tojson }}
+        }
+      ]
+    }
+    </script>
+  {% else %}
+    {# SEO metadata for courses list page #}
+    {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    {# Left nav CSS and JS for list pages #}
+    {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css')) }}
+    {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js'), { position: 'footer', defer: true }) }}
+
+    <title>Courses - Learn Hedgehog AI Networking</title>
+    <meta name="description" content="Structured learning courses that combine multiple modules into comprehensive, narrative-driven experiences for mastering Hedgehog AI networking.">
+    <link rel="canonical" href="https://{{ request.domain }}/learn/courses">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Courses - Learn Hedgehog AI Networking">
+    <meta property="og:description" content="Structured learning courses that combine multiple modules into comprehensive, narrative-driven experiences for mastering Hedgehog AI networking.">
+    <meta property="og:url" content="https://{{ request.domain }}/learn/courses">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Courses - Learn Hedgehog AI Networking">
+    <meta name="twitter:description" content="Structured learning courses that combine multiple modules into comprehensive, narrative-driven experiences for mastering Hedgehog AI networking.">
+    <meta name="twitter:image" content="{{ social_image }}">
+
+    {# JSON-LD structured data for courses list #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": "Learning Courses",
+      "description": "Hedgehog AI Networking courses",
+      "itemListElement": [
+        {# Prefer dynamic table binding; fallback to constants #}
+        {% set courses_table_id = dynamic_page_hubdb_table_id %}
+        {% if not courses_table_id %}
+          {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID %}
+        {% endif %}
+        {% if courses_table_id %}
+          {% set courses = hubdb_table_rows(courses_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% for course in courses %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "item": {
+            "@type": "Course",
+            "name": {{ course.hs_name|tojson }},
+            "url": "https://{{ request.domain }}/learn/courses/{{ course.hs_path }}"
+            {% if course.summary_markdown %}
+            ,"description": {{ course.summary_markdown|striptags|truncate(160)|tojson }}
+            {% endif %}
+          }
+        }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        {% endif %}
+      ]
+    }
+    </script>
+  {% endif %}
+{% endblock head %}
+
+{% block body %}
+<style>
+  /* Header section styling */
+  .learn-header-section {
+    width: 100vw;
+    background: #1a4e8a url('https://hedgehog.cloud/hubfs/hh-clouds.webp') center center/cover no-repeat;
+    color: #fff;
+    padding: 96px 0 64px 0;
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+  .learn-header-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+  }
+  .learn-page-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -1px;
+  }
+  .learn-page-subtitle {
+    font-size: 1.2rem;
+    font-weight: 400;
+    margin: 0;
+    opacity: 0.9;
+  }
+  .learn-header-nav {
+    display: flex;
+    gap: 24px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .learn-header-nav a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: background 0.2s;
+  }
+  .learn-header-nav a:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
+  .auth-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .user-greeting {
+    color: #fff;
+    font-size: 0.875rem;
+    opacity: 0.9;
+  }
+  .auth-link {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 6px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 6px;
+    transition: all 0.2s;
+  }
+  .auth-link:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+
+  /* Main content section */
+  .learn-main-section {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0;
+    min-height: 60vh;
+  }
+  .learn-container {
+    max-width: 1600px;
+    width: 100%;
+    background: #fff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 2px 24px rgba(26,78,138,0.06);
+    min-height: 60vh;
+  }
+
+  /* Course grid (list view) */
+  .courses-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 32px;
+  }
+  .course-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+  }
+  .course-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .course-card h2 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+  }
+  .course-card-summary {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .course-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    color: #666;
+    font-size: 0.875rem;
+    margin-bottom: 16px;
+  }
+  .course-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .course-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Course detail view */
+  .course-detail {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  .course-breadcrumbs {
+    padding: 16px 0;
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .course-breadcrumbs a {
+    color: #0066CC;
+    text-decoration: none;
+  }
+  .course-detail-header {
+    margin: 32px 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #E5E7EB;
+  }
+  .course-detail-header h1 {
+    margin: 0 0 16px 0;
+    color: #1a4e8a;
+  }
+  .course-summary {
+    line-height: 1.8;
+    font-size: 1.0625rem;
+    margin: 32px 0;
+    padding: 24px;
+    background: #F9FAFB;
+    border-left: 4px solid #1a4e8a;
+    border-radius: 4px;
+  }
+
+  /* Content blocks styling */
+  .content-blocks-section {
+    margin-top: 48px;
+  }
+  .content-block {
+    margin-bottom: 32px;
+  }
+  .content-block-text,
+  .content-block-callout {
+    padding: 24px;
+    border-radius: 8px;
+    line-height: 1.8;
+  }
+  .content-block-text {
+    background: #FFFFFF;
+  }
+  .content-block-text h2,
+  .content-block-callout h2 {
+    margin: 0 0 16px 0;
+    font-size: 1.5rem;
+    color: #111827;
+  }
+  .content-block-callout {
+    background: #FEF3C7;
+    border: 1px solid #FCD34D;
+    border-left: 4px solid #F59E0B;
+  }
+
+  /* Module cards in content blocks */
+  .modules-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
+  }
+  .module-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+    position: relative;
+  }
+  .module-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .module-card-number {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: #1a4e8a;
+    color: #fff;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.875rem;
+  }
+  .module-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+    padding-right: 40px;
+  }
+  .module-card p {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .module-time {
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .module-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Enrollment CTA Block */
+  .enrollment-cta-block {
+    background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+    border: 2px solid #0284c7;
+    border-radius: 12px;
+    padding: 24px;
+    margin: 24px 0;
+    text-align: center;
+  }
+  .enrollment-cta-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #0c4a6e;
+    margin: 0 0 12px 0;
+  }
+  .enrollment-cta-description {
+    font-size: 0.9375rem;
+    color: #0369a1;
+    margin: 0 0 20px 0;
+    line-height: 1.6;
+  }
+  .enrollment-button {
+    display: inline-block;
+    background: #1a4e8a;
+    color: #fff;
+    padding: 14px 32px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1rem;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+    text-decoration: none;
+  }
+  .enrollment-button:hover:not(:disabled) {
+    background: #154171;
+    transform: translateY(-2px);
+  }
+  .enrollment-button:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 900px) {
+    .learn-header-content, .learn-container {
+      padding: 0 16px;
+    }
+    .courses-grid, .modules-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+<main id="main-content">
+  {% if dynamic_page_hubdb_row %}
+    {# Detail mode - showing a single course #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        {# Omit a visible H1 in the hero on detail pages to avoid duplicates #}
+      </div>
+    </section>
+
+    <section class="learn-main-section">
+      <div class="learn-container">
+
+      {# TEMP: Add left nav to test request_contact.is_logged_in on detail pages #}
+      {{ learning_left_nav('courses', show_filters=false) }}
+
+      <div class="course-detail">
+          <!-- Breadcrumbs -->
+          <nav class="course-breadcrumbs">
+            <a href="/learn/courses">← Back to Courses</a>
+          </nav>
+
+          <!-- Course Header -->
+          <header class="course-detail-header">
+            <h1>{{ dynamic_page_hubdb_row.hs_name }}</h1>
+            <div class="course-meta">
+              {% if dynamic_page_hubdb_row.module_slugs_json %}
+                {% set module_count = dynamic_page_hubdb_row.module_slugs_json|fromjson|length %}
+                <span class="course-meta-item">
+                  <strong>{{ module_count }}</strong> module{% if module_count != 1 %}s{% endif %}
+                </span>
+              {% endif %}
+              {% if dynamic_page_hubdb_row.estimated_minutes %}
+                <span class="course-meta-item">
+                  <strong>{{ dynamic_page_hubdb_row.estimated_minutes }}</strong> minutes total
+                </span>
+              {% endif %}
+            </div>
+          </header>
+
+          {# Enrollment CTA Block #}
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {# Issue #345: Always render login link - Cognito JS upgrades to button if authenticated #}
+          {% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+          <div class="enrollment-cta-block" id="hhl-enrollment-cta" data-content-type="course" data-build-id="cta-v3-20251028">
+            <div class="enrollment-cta-title">Ready to Start This Course?</div>
+            <div class="enrollment-cta-description">
+              Enroll to track your progress and access personalized learning resources as you complete each module.
+            </div>
+            {# Server always renders login link; enrollment.js upgrades to button if Cognito authenticated #}
+            <a class="enrollment-button"
+               id="hhl-enroll-login"
+               href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}">
+              Sign in to start course
+            </a>
+            <p class="enrollment-cta-helper" id="hhl-enroll-helper" aria-live="polite">
+              Already registered? <a href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}">Sign in</a> to continue.
+            </p>
+          </div>
+
+          <!-- Progress Tracker -->
+          <div class="course-progress" id="course-progress" style="background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%); border: 1px solid #bae6fd; border-radius: 8px; padding: 20px 24px; margin: 24px 0;">
+            <div class="progress-header" style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+              <div class="progress-title" style="font-size: 0.875rem; font-weight: 600; color: #0c4a6e; text-transform: uppercase; letter-spacing: 0.5px;">Your Progress</div>
+              <div class="progress-stats" style="display: flex; gap: 16px; font-size: 0.875rem; color: #0369a1;">
+                <div class="progress-stat" style="display: flex; align-items: center; gap: 4px;">
+                  <span>Started: <strong id="progress-started" style="font-weight: 700; color: #0c4a6e;">0</strong></span>
+                </div>
+                <div class="progress-stat" style="display: flex; align-items: center; gap: 4px;">
+                  <span>Completed: <strong id="progress-completed" style="font-weight: 700; color: #0c4a6e;">0</strong></span>
+                </div>
+              </div>
+            </div>
+            <div class="progress-bar-container" style="background: #ffffff; border-radius: 8px; height: 8px; overflow: hidden; box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);">
+              <div class="progress-bar" id="progress-bar" style="background: linear-gradient(90deg, #0ea5e9 0%, #0284c7 100%); height: 100%; border-radius: 8px; transition: width 0.3s ease; width: 0%;"></div>
+            </div>
+            {#
+              Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+              HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+              Source: clean-x-hedgehog-templates/config/constants.json
+            #}
+            
+            {% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+            <div class="progress-auth-prompt" style="display: none; margin-top: 12px; padding: 12px 16px; background: #fffbeb; border: 1px solid #fde68a; border-radius: 6px; font-size: 0.875rem; color: #78350f; align-items: center; gap: 8px;" id="auth-prompt">
+              ℹ️ Progress is saved locally. <a href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}" style="color: #92400e; font-weight: 600; text-decoration: underline;">Sign in</a> to sync across devices.
+            </div>
+          </div>
+
+          {# Auth context for JS (Issue #345 - Cognito auth with inlined constants) #}
+          {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+          {% set auth_logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+          <div id="hhl-auth-context"
+               data-auth-me-url="{{ auth_me_url }}"
+               data-auth-login-url="{{ auth_login_url }}"
+               data-auth-logout-url="{{ auth_logout_url }}"
+               data-enable-crm="true"
+               data-track-events-url="https://api.hedgehog.cloud/events/track"
+               data-course-slug="{{ dynamic_page_hubdb_row.hs_path }}"
+               data-total-modules="{% if dynamic_page_hubdb_row.module_slugs_json %}{{ dynamic_page_hubdb_row.module_slugs_json|fromjson|length }}{% else %}0{% endif %}"
+               style="display:none"></div>
+
+          <!-- Course Summary -->
+          {% if dynamic_page_hubdb_row.summary_markdown %}
+            <div class="course-summary">
+              {{ dynamic_page_hubdb_row.summary_markdown|safe }}
+            </div>
+          {% endif %}
+
+          <!-- Archived warning -->
+          {% set is_archived = false %}
+          {% if dynamic_page_hubdb_row.tags %}
+            {% set tag_list = dynamic_page_hubdb_row.tags|lower|split(',') %}
+            {% for tag in tag_list %}
+              {% if tag|trim == 'archived' %}
+                {% set is_archived = true %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+          {% if is_archived %}
+            <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px;">
+              This course is archived and may be out of date.
+            </div>
+          {% endif %}
+
+          {# Debug banner for course detail - only show when ?debug=1 is present #}
+          {% if request.query_dict.debug == '1' %}
+            <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px; font-family:monospace; font-size:0.875rem;">
+              <strong>🔍 Debug Info (Course Detail):</strong><br>
+              Course: {{ dynamic_page_hubdb_row.hs_name }}<br>
+              {#
+                Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+                HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+                Source: clean-x-hedgehog-templates/config/constants.json
+              #}
+              
+              {% set modules_table_id_debug = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else 135621904 %}
+              modules_table_id: {{ modules_table_id_debug }}<br>
+              constants.HUBDB_MODULES_TABLE_ID: {{ constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "n/a" }}<br>
+              has content_blocks_json: {{ "yes" if dynamic_page_hubdb_row.content_blocks_json else "no" }}<br>
+              has module_slugs_json: {{ "yes" if dynamic_page_hubdb_row.module_slugs_json else "no" }}
+            </div>
+          {% endif %}
+
+          <!-- Course Content: Prefer content_blocks_json if present, otherwise fallback to module_slugs_json -->
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else 135621904 %}
+
+          {# OPTIMIZATION: Fetch all modules needed for this course ONCE, then reuse the cache #}
+          {# This prevents hitting HubSpot's 10-call limit per page #}
+          {% set modules_by_slug = {} %}
+          {% if modules_table_id %}
+            {% set all_slugs = [] %}
+            {# Collect slugs from content_blocks if present #}
+            {% if dynamic_page_hubdb_row.content_blocks_json %}
+              {% set blocks = dynamic_page_hubdb_row.content_blocks_json|fromjson %}
+              {% for block in blocks %}
+                {% if block.type == 'module_ref' and block.module_slug %}
+                  {% set _ = all_slugs.append(block.module_slug) %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+            {# Also collect from module_slugs_json as fallback #}
+            {% if dynamic_page_hubdb_row.module_slugs_json %}
+              {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+              {% for slug in module_slugs %}
+                {% if slug not in all_slugs %}
+                  {% set _ = all_slugs.append(slug) %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+            {# Now fetch each module once and cache it #}
+            {# NOTE: Query by 'hs_path__eq=' which filters on Page Path in HubDB #}
+            {% for slug in all_slugs %}
+              {% set module_rows = hubdb_table_rows(modules_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+              {% if (not module_rows or module_rows|length == 0) %}
+                {# Fallback for hubs that expose 'path' instead of 'hs_path' in filters #}
+                {% set module_rows = hubdb_table_rows(modules_table_id, "path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+              {% endif %}
+              {% if module_rows and module_rows|length > 0 %}
+                {% set _ = modules_by_slug.update({slug: module_rows[0]}) %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          {% if dynamic_page_hubdb_row.content_blocks_json %}
+            {# Render content blocks (narrative-driven course) #}
+            {# Modules are already cached in modules_by_slug from above #}
+            {% set blocks = dynamic_page_hubdb_row.content_blocks_json|fromjson %}
+
+            <section class="content-blocks-section">
+              {% set module_index = 0 %}
+              {% set rendered_module_slugs = [] %}
+              {% for block in blocks %}
+                {% if block.type == 'text' %}
+                  <div class="content-block content-block-text">
+                    {% if block.title %}
+                      <h2>{{ block.title }}</h2>
+                    {% endif %}
+                    {% if block.body_markdown %}
+                      {{ block.body_markdown|safe }}
+                    {% endif %}
+                  </div>
+                {% elif block.type == 'callout' %}
+                  <div class="content-block content-block-callout">
+                    {% if block.title %}
+                      <h2>{{ block.title }}</h2>
+                    {% endif %}
+                    {% if block.body_markdown %}
+                      {{ block.body_markdown|safe }}
+                    {% endif %}
+                  </div>
+                {% elif block.type == 'module_ref' and block.module_slug %}
+                  {% set module_index = module_index + 1 %}
+                  {# Track this slug as rendered to avoid duplicates in fallback section #}
+                  {% set _ = rendered_module_slugs.append(block.module_slug) %}
+                  {# Lookup module from batch-fetched dictionary #}
+                  {% set module = modules_by_slug[block.module_slug] %}
+                  {% if module %}
+                    <div class="content-block">
+                      <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                        <div class="module-card-number">{{ module_index }}</div>
+                        <h3>{{ module.hs_name }}</h3>
+
+                        {% if module.meta_description %}
+                          <p>{{ module.meta_description|striptags|truncate(150) }}</p>
+                        {% endif %}
+
+                        <div class="module-time">
+                          {{ module.estimated_minutes }} minutes
+                        </div>
+
+                        <div style="margin-top: 16px;">
+                          <span class="module-cta">Start Module →</span>
+                        </div>
+                      </a>
+                    </div>
+                  {% else %}
+                    {# Defensive: render minimal card using the slug #}
+                    <div class="content-block">
+                      <a href="/learn/modules/{{ block.module_slug }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                        <div class="module-card-number">{{ module_index }}</div>
+                        <h3>{{ block.module_slug|replace('-',' ')|title }}</h3>
+                        <div style="margin-top: 16px;">
+                          <span class="module-cta">Start Module →</span>
+                        </div>
+                      </a>
+                    </div>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            </section>
+
+            {# GUARANTEED FALLBACK: Show any modules from module_slugs_json that weren't rendered in content_blocks #}
+            {% if dynamic_page_hubdb_row.module_slugs_json and modules_table_id %}
+              {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+              {% set unrendered_modules = [] %}
+              {% for slug in module_slugs %}
+                {% if slug not in rendered_module_slugs %}
+                  {% set _ = unrendered_modules.append(slug) %}
+                {% endif %}
+              {% endfor %}
+
+              {% if unrendered_modules|length > 0 %}
+                <section class="content-blocks-section" style="margin-top: 48px;">
+                  <h2>Course Modules</h2>
+                  <div class="modules-grid">
+                    {% for slug in unrendered_modules %}
+                      {% set module = modules_by_slug[slug] %}
+                      {% set module_index = module_index + 1 %}
+                      {% if not module %}
+                        {% set module = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
+                      {% endif %}
+                      <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                        <div class="module-card-number">{{ module_index }}</div>
+                        <h3>{{ module.hs_name }}</h3>
+                        {% if module.meta_description %}
+                          <p>{{ module.meta_description|striptags|truncate(150) }}</p>
+                        {% endif %}
+                        {% if module.estimated_minutes %}
+                        <div class="module-time">
+                          {{ module.estimated_minutes }} minutes
+                        </div>
+                        {% endif %}
+                        <div style="margin-top: 16px;">
+                          <span class="module-cta">Start Module →</span>
+                        </div>
+                      </a>
+                    {% endfor %}
+                  </div>
+                </section>
+              {% endif %}
+            {% endif %}
+
+          {% elif dynamic_page_hubdb_row.module_slugs_json and modules_table_id %}
+            {# Fallback: Render modules list #}
+            {# Modules are already cached in modules_by_slug from above #}
+            {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+
+            <section class="content-blocks-section">
+              <h2>Course Modules</h2>
+              <div class="modules-grid">
+                {% for slug in module_slugs %}
+                  {% set module = modules_by_slug[slug] %}
+                  {% if not module %}
+                    {# Defensive fallback: create a minimal object if lookup failed #}
+                    {% set module = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
+                  {% endif %}
+                    <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                      <div class="module-card-number">{{ loop.index }}</div>
+                      <h3>{{ module.hs_name }}</h3>
+
+                      {% if module.meta_description %}
+                        <p>{{ module.meta_description|striptags|truncate(150) }}</p>
+                      {% endif %}
+
+                      <div class="module-time">
+                        {{ module.estimated_minutes }} minutes
+                      </div>
+
+                      <div style="margin-top: 16px;">
+                        <span class="module-cta">Start Module →</span>
+                      </div>
+                    </a>
+                {% endfor %}
+              </div>
+            </section>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+    <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/login-helper.js') }}"></script>
+    {# REMOVED: Legacy auth-context.js replaced by cognito-auth-integration.js (Issue #318) #}
+    <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+    <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/courses.js') }}"></script>
+    <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/pageview.js') }}"></script>
+    <script>
+      (function() {
+        if (typeof window.waitForIdentityReady === 'function' && typeof window.getAuth === 'function') {
+          return;
+        }
+
+        function parseBoolean(value) {
+          if (typeof value === 'boolean') return value;
+          if (!value) return false;
+          var normalized = value.toString().trim().toLowerCase();
+          return normalized === 'true' || normalized === '1' || normalized === 'yes';
+        }
+
+        window.waitForIdentityReady = window.waitForIdentityReady || function() {
+          try {
+            if (window.hhIdentity && window.hhIdentity.ready && typeof window.hhIdentity.ready.then === 'function') {
+              return window.hhIdentity.ready;
+            }
+          } catch (error) {}
+          return Promise.resolve(null);
+        };
+
+        window.getAuth = window.getAuth || function() {
+          var el = document.getElementById('hhl-auth-context');
+          var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function')
+            ? window.hhIdentity.get()
+            : null;
+          var authenticated = identity ? !!identity.authenticated : parseBoolean(el && el.getAttribute('data-authenticated'));
+          var email = identity && identity.email ? identity.email : (el && el.getAttribute('data-email')) || null;
+          var contactId = identity && identity.contactId ? identity.contactId : (el && el.getAttribute('data-contact-id')) || null;
+          return {
+            authenticated: authenticated,
+            email: email,
+            contactId: contactId,
+            enableCrm: parseBoolean(el && el.getAttribute('data-enable-crm')),
+            trackEventsUrl: el && el.getAttribute('data-track-events-url')
+          };
+        };
+      })();
+    </script>
+    <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/enrollment.js') }}"></script>
+    <script>
+      // Initialize enrollment UI after DOM is ready; init handles login-link fallback
+      document.addEventListener('DOMContentLoaded', function() {
+        if (window.hhInitEnrollment) {
+          window.hhInitEnrollment('course', '{{ dynamic_page_hubdb_row.hs_path }}');
+        }
+      });
+    </script>
+
+  {% else %}
+    {# List mode - showing all courses #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        <h1 class="learn-page-title">Courses</h1>
+        <p class="learn-page-subtitle">Structured learning units that combine multiple modules into comprehensive, narrative-driven courses.</p>
+      </div>
+    </section>
+
+    <div class="learn-layout-with-nav">
+      {# Left navigation with filters #}
+      {{ learning_left_nav('courses', show_filters=true) }}
+
+      {# Main content area #}
+      <div class="learn-main-content">
+        {# Prefer dynamic table binding; fallback to constants #}
+        {% set courses_table_id = dynamic_page_hubdb_table_id %}
+        {% if not courses_table_id %}
+          {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID %}
+        {% endif %}
+        {# Debug banner - only show when ?debug=1 is present #}
+        {% if request.query_dict.debug == '1' %}
+          <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px; font-family:monospace; font-size:0.875rem;">
+            <strong>🔍 Debug Info (Courses List):</strong><br>
+            courses_table_id: {{ courses_table_id if courses_table_id else "n/a" }}<br>
+            dynamic_page_hubdb_table_id: {{ dynamic_page_hubdb_table_id if dynamic_page_hubdb_table_id else "n/a" }}<br>
+            constants.HUBDB_COURSES_TABLE_ID: {{ constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else "n/a" }}
+          </div>
+        {% endif %}
+        {% if courses_table_id %}
+          {% set courses = hubdb_table_rows(courses_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% if courses %}
+            <div class="courses-grid">
+              {% for course in courses %}
+                {% set is_archived = false %}
+                {% if course.tags %}
+                  {% set tag_list = course.tags|lower|split(',') %}
+                  {% for tag in tag_list %}
+                    {% if tag|trim == 'archived' %}
+                      {% set is_archived = true %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+                {% if not is_archived %}
+                <a href="{{ request.path }}/{{ course.hs_path }}" class="course-card">
+                  <h2>{{ course.hs_name }}</h2>
+
+                  {% if course.summary_markdown %}
+                    <p class="course-card-summary">{{ course.summary_markdown|striptags|truncate(150) }}</p>
+                  {% endif %}
+
+                  <div class="course-meta">
+                    {% if course.module_slugs_json %}
+                      {% set module_count = course.module_slugs_json|fromjson|length %}
+                      <span class="course-meta-item">
+                        <strong>{{ module_count }}</strong> module{% if module_count != 1 %}s{% endif %}
+                      </span>
+                    {% endif %}
+                    {% if course.estimated_minutes %}
+                      <span class="course-meta-item">
+                        <strong>{{ course.estimated_minutes }}</strong> minutes
+                      </span>
+                    {% endif %}
+                  </div>
+
+                  <span class="course-cta">View Course →</span>
+                </a>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% else %}
+            <p>No courses have been added yet.</p>
+          {% endif %}
+        {% else %}
+          <p><em>Bind this page to the Courses table in the HubSpot page settings.</em></p>
+        {% endif %}
+      </div>
+    </div>
+    {# Cognito auth context for nav auth state on list pages #}
+    {#
+      Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+      HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+      Source: clean-x-hedgehog-templates/config/constants.json
+    #}
+    
+    {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+    {% set login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+    {% set logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+    <div
+      id="hhl-auth-context"
+      data-auth-me-url="{{ auth_me_url }}"
+      data-auth-login-url="{{ login_url }}"
+      data-auth-logout-url="{{ logout_url }}"
+      data-track-events-url="https://api.hedgehog.cloud/events/track"
+      data-enable-crm="true"
+      style="display:none"
+    ></div>
+    <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+  {% endif %}
+</main>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/courses-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/courses-page.html
@@ -8,6 +8,9 @@
 {% block head %}
   {{ super() }}
 
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
   {#
     Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
     HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
@@ -35,7 +38,7 @@
     {# SEO metadata for course detail pages #}
     {% set page_title = dynamic_page_hubdb_row.hs_name ~ " - Courses - Learn Hedgehog" %}
     {% set meta_desc = dynamic_page_hubdb_row.meta_description|striptags|truncate(160) if dynamic_page_hubdb_row.meta_description else (dynamic_page_hubdb_row.summary_markdown|striptags|truncate(160) if dynamic_page_hubdb_row.summary_markdown else "Learn " ~ dynamic_page_hubdb_row.hs_name) %}
-    {% set canonical_url = "https://" ~ request.domain ~ "/learn/courses/" ~ dynamic_page_hubdb_row.hs_path %}
+    {% set canonical_url = "https://" ~ request.domain ~ "/learn-shadow/courses/" ~ dynamic_page_hubdb_row.hs_path %}
     {% set social_image = dynamic_page_hubdb_row.social_image_url if dynamic_page_hubdb_row.social_image_url else constants.DEFAULT_SOCIAL_IMAGE_URL %}
 
     <title>{{ page_title }}</title>
@@ -66,7 +69,7 @@
       {% if dynamic_page_hubdb_row.meta_description or dynamic_page_hubdb_row.summary_markdown %}
       "description": {{ meta_desc|tojson }},
       {% endif %}
-      "url": "https://{{ request.domain }}/learn/courses/{{ dynamic_page_hubdb_row.hs_path }}",
+      "url": "https://{{ request.domain }}/learn-shadow/courses/{{ dynamic_page_hubdb_row.hs_path }}",
       {% if dynamic_page_hubdb_row.estimated_minutes %}
       "timeRequired": "PT{{ dynamic_page_hubdb_row.estimated_minutes }}M",
       {% endif %}
@@ -107,7 +110,7 @@
         {
           "@type": "LearningResource",
           "name": {{ module.hs_name|tojson }},
-      "url": "https://{{ request.domain }}/learn/modules/{{ module.hs_path }}",
+      "url": "https://{{ request.domain }}/learn-shadow/modules/{{ module.hs_path }}",
           "position": {{ loop.index }}
         }{% if not loop.last %},{% endif %}
             {% endif %}
@@ -135,7 +138,7 @@
           "@type": "ListItem",
           "position": 2,
           "name": "Courses",
-          "item": "https://{{ request.domain }}/learn/courses"
+          "item": "https://{{ request.domain }}/learn-shadow/courses"
         },
         {
           "@type": "ListItem",
@@ -155,13 +158,13 @@
 
     <title>Courses - Learn Hedgehog AI Networking</title>
     <meta name="description" content="Structured learning courses that combine multiple modules into comprehensive, narrative-driven experiences for mastering Hedgehog AI networking.">
-    <link rel="canonical" href="https://{{ request.domain }}/learn/courses">
+    <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/courses">
 
     {# Open Graph tags #}
     <meta property="og:type" content="website">
     <meta property="og:title" content="Courses - Learn Hedgehog AI Networking">
     <meta property="og:description" content="Structured learning courses that combine multiple modules into comprehensive, narrative-driven experiences for mastering Hedgehog AI networking.">
-    <meta property="og:url" content="https://{{ request.domain }}/learn/courses">
+    <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/courses">
     <meta property="og:image" content="{{ social_image }}">
 
     {# Twitter Card tags #}
@@ -192,7 +195,7 @@
           "item": {
             "@type": "Course",
             "name": {{ course.hs_name|tojson }},
-            "url": "https://{{ request.domain }}/learn/courses/{{ course.hs_path }}"
+            "url": "https://{{ request.domain }}/learn-shadow/courses/{{ course.hs_path }}"
             {% if course.summary_markdown %}
             ,"description": {{ course.summary_markdown|striptags|truncate(160)|tojson }}
             {% endif %}
@@ -543,7 +546,7 @@
       <div class="course-detail">
           <!-- Breadcrumbs -->
           <nav class="course-breadcrumbs">
-            <a href="/learn/courses">← Back to Courses</a>
+            <a href="/learn-shadow/courses">← Back to Courses</a>
           </nav>
 
           <!-- Course Header -->
@@ -753,7 +756,7 @@
                   {% set module = modules_by_slug[block.module_slug] %}
                   {% if module %}
                     <div class="content-block">
-                      <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                      <a href="/learn-shadow/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
                         <div class="module-card-number">{{ module_index }}</div>
                         <h3>{{ module.hs_name }}</h3>
 
@@ -773,7 +776,7 @@
                   {% else %}
                     {# Defensive: render minimal card using the slug #}
                     <div class="content-block">
-                      <a href="/learn/modules/{{ block.module_slug }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                      <a href="/learn-shadow/modules/{{ block.module_slug }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
                         <div class="module-card-number">{{ module_index }}</div>
                         <h3>{{ block.module_slug|replace('-',' ')|title }}</h3>
                         <div style="margin-top: 16px;">
@@ -806,7 +809,7 @@
                       {% if not module %}
                         {% set module = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
                       {% endif %}
-                      <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                      <a href="/learn-shadow/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
                         <div class="module-card-number">{{ module_index }}</div>
                         <h3>{{ module.hs_name }}</h3>
                         {% if module.meta_description %}
@@ -841,7 +844,7 @@
                     {# Defensive fallback: create a minimal object if lookup failed #}
                     {% set module = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
                   {% endif %}
-                    <a href="/learn/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
+                    <a href="/learn-shadow/modules/{{ module.hs_path }}?from=course:{{ dynamic_page_hubdb_row.hs_path }}" class="module-card">
                       <div class="module-card-number">{{ loop.index }}</div>
                       <h3>{{ module.hs_name }}</h3>
 

--- a/clean-x-hedgehog-templates/learn-shadow/debug-hubdb.html
+++ b/clean-x-hedgehog-templates/learn-shadow/debug-hubdb.html
@@ -2,6 +2,8 @@
 <html>
 <head>
     <title>HubDB Query Debug</title>
+    {# Shadow environment: prevent search indexing #}
+    <meta name="robots" content="noindex, nofollow">
 </head>
 <body>
     <h1>HubDB Query Debug</h1>

--- a/clean-x-hedgehog-templates/learn-shadow/debug-hubdb.html
+++ b/clean-x-hedgehog-templates/learn-shadow/debug-hubdb.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>HubDB Query Debug</title>
+</head>
+<body>
+    <h1>HubDB Query Debug</h1>
+
+    <h2>Test 1: Query modules by path__eq=</h2>
+    {% set modules_table_id = "135621904" %}
+    {% set test_slug = "authoring-basics" %}
+    {% set result_by_hs_path = hubdb_table_rows(modules_table_id, "hs_path__eq=" ~ test_slug) %}
+    <p><strong>Query:</strong> hubdb_table_rows("135621904", "hs_path__eq=authoring-basics")</p>
+    <p><strong>Results count:</strong> {{ result_by_hs_path|length }}</p>
+    {% if result_by_hs_path|length > 0 %}
+        <pre>{{ result_by_hs_path[0]|pprint }}</pre>
+    {% else %}
+        <p style="color: red;">NO RESULTS RETURNED</p>
+    {% endif %}
+
+    <hr>
+
+    <h2>Test 3: Get ALL modules (no filter)</h2>
+    {% set all_modules = hubdb_table_rows(modules_table_id) %}
+    <p><strong>Query:</strong> hubdb_table_rows("135621904")</p>
+    <p><strong>Results count:</strong> {{ all_modules|length }}</p>
+    {% if all_modules|length > 0 %}
+        <p>First module:</p>
+        <pre>{{ all_modules[0]|pprint }}</pre>
+        <p>Looking for "authoring-basics" in results...</p>
+        {% for module in all_modules %}
+            {% if module.hs_path and ("authoring-basics" in module.hs_path|lower) %}
+                <p style="color: green;">FOUND: {{ module.hs_name }} - hs_path={{ module.hs_path }}</p>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+</body>
+</html>

--- a/clean-x-hedgehog-templates/learn-shadow/get-started.html
+++ b/clean-x-hedgehog-templates/learn-shadow/get-started.html
@@ -8,6 +8,9 @@
 {% block head %}
   {{ super() }}
 
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
   {# CSS dependencies - reuse catalog and landing styles #}
   {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css')) }}
   {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/learn-landing.css')) }}
@@ -23,13 +26,13 @@
   {# SEO metadata #}
   <title>Get Started with Hedgehog Learn - Your First Steps</title>
   <meta name="description" content="New to Hedgehog? Start here. Explore our flagship Network Like a Hyperscaler pathway and discover curated topics for modern infrastructure teams.">
-  <link rel="canonical" href="https://{{ request.domain }}/learn/get-started">
+  <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/get-started">
 
   {# Open Graph tags #}
   <meta property="og:type" content="website">
   <meta property="og:title" content="Get Started with Hedgehog Learn">
   <meta property="og:description" content="Your orientation guide to mastering Kubernetes-native networking with Hedgehog's curated learning pathways.">
-  <meta property="og:url" content="https://{{ request.domain }}/learn/get-started">
+  <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/get-started">
   <meta property="og:image" content="{{ social_image }}">
 
   {# Twitter Card tags #}
@@ -55,8 +58,8 @@
 
       {# Primary CTA to flagship pathway #}
       <div class="hero-ctas">
-        <a href="/learn/pathways/network-like-hyperscaler" class="button button-primary">Start Network Like a Hyperscaler →</a>
-        <a href="/learn/catalog" class="button button-secondary">Browse Full Catalog</a>
+        <a href="/learn-shadow/pathways/network-like-hyperscaler" class="button button-primary">Start Network Like a Hyperscaler →</a>
+        <a href="/learn-shadow/catalog" class="button button-secondary">Browse Full Catalog</a>
       </div>
     </div>
   </section>
@@ -112,7 +115,7 @@
                       {% endif %}
                     </div>
                     <h3 class="catalog-card-title">
-                      <a href="/learn/courses/{{ course.hs_path }}">{{ course.hs_name }}</a>
+                      <a href="/learn-shadow/courses/{{ course.hs_path }}">{{ course.hs_name }}</a>
                     </h3>
                     <p class="catalog-card-summary">
                       {{ course.summary_markdown|striptags|truncate(160, true, '...') if course.summary_markdown else 'Build hands-on skills through this focused course curriculum.' }}
@@ -131,7 +134,7 @@
                         </span>
                       {% endif %}
                     </div>
-                    <a href="/learn/courses/{{ course.hs_path }}" class="catalog-card-cta">
+                    <a href="/learn-shadow/courses/{{ course.hs_path }}" class="catalog-card-cta">
                       Start Course →
                     </a>
                   </article>
@@ -142,14 +145,14 @@
             {# Fallback if course_slugs_json is missing #}
             <div class="empty-state">
               <p>Featured topics are being curated. Check out the full pathway to get started.</p>
-              <a href="/learn/pathways/network-like-hyperscaler" class="button button-secondary">View Full Pathway</a>
+              <a href="/learn-shadow/pathways/network-like-hyperscaler" class="button button-secondary">View Full Pathway</a>
             </div>
           {% endif %}
         {% else %}
           {# Graceful fallback when pathway not found #}
           <div class="empty-state">
             <p>Featured topics are being curated. Check out the full pathway to get started.</p>
-            <a href="/learn/catalog" class="button button-secondary">Browse All Content</a>
+            <a href="/learn-shadow/catalog" class="button button-secondary">Browse All Content</a>
           </div>
         {% endif %}
       {% else %}
@@ -172,21 +175,21 @@
           <div class="level-icon">📖</div>
           <h3 class="level-card-title">Browse Full Catalog</h3>
           <p class="level-card-description">Discover all available modules, courses, and pathways. Filter by type, level, and duration to find the perfect next step for your learning goals.</p>
-          <a href="/learn/catalog" class="catalog-card-cta">Explore Catalog →</a>
+          <a href="/learn-shadow/catalog" class="catalog-card-cta">Explore Catalog →</a>
         </article>
 
         <article class="level-card level-card-intermediate">
           <div class="level-icon">🎯</div>
           <h3 class="level-card-title">View All Pathways</h3>
           <p class="level-card-description">Explore curated learning pathways designed to take you from fundamentals to mastery in Kubernetes-native networking and fabric operations.</p>
-          <a href="/learn/pathways" class="catalog-card-cta">Browse Pathways →</a>
+          <a href="/learn-shadow/pathways" class="catalog-card-cta">Browse Pathways →</a>
         </article>
 
         <article class="level-card level-card-advanced">
           <div class="level-icon">🌱</div>
           <h3 class="level-card-title">Start with Basics</h3>
           <p class="level-card-description">New to cloud networking? Filter the catalog to show only beginner-level content and build your foundation with guided, step-by-step modules.</p>
-          <a href="/learn/catalog?level=beginner" class="catalog-card-cta">View Beginner Content →</a>
+          <a href="/learn-shadow/catalog?level=beginner" class="catalog-card-cta">View Beginner Content →</a>
         </article>
       </div>
     </section>
@@ -197,7 +200,7 @@
         <h2 class="cta-title">Ready to Begin?</h2>
         <p class="cta-subtitle">Join infrastructure teams worldwide mastering Kubernetes-native networking with Hedgehog Learn.</p>
         <div class="cta-buttons">
-          <a href="/learn/pathways/network-like-hyperscaler" class="button button-primary button-large">Start Your Journey</a>
+          <a href="/learn-shadow/pathways/network-like-hyperscaler" class="button button-primary button-large">Start Your Journey</a>
         </div>
       </div>
     </section>

--- a/clean-x-hedgehog-templates/learn-shadow/get-started.html
+++ b/clean-x-hedgehog-templates/learn-shadow/get-started.html
@@ -1,0 +1,212 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+  label: Get Started - Orientation Page
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+
+{% block head %}
+  {{ super() }}
+
+  {# CSS dependencies - reuse catalog and landing styles #}
+  {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css')) }}
+  {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/learn-landing.css')) }}
+
+  {# JS dependencies - analytics and auth context #}
+  {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/pageview.js'), { position: 'footer', defer: true }) }}
+  {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/auth-context.js'), { position: 'footer', defer: true }) }}
+
+  {# Load constants for HubDB table IDs and configuration #}
+  {% set constants = get_asset_url("/CLEAN x HEDGEHOG/templates/config/constants.json")|request_json %}
+  {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
+
+  {# SEO metadata #}
+  <title>Get Started with Hedgehog Learn - Your First Steps</title>
+  <meta name="description" content="New to Hedgehog? Start here. Explore our flagship Network Like a Hyperscaler pathway and discover curated topics for modern infrastructure teams.">
+  <link rel="canonical" href="https://{{ request.domain }}/learn/get-started">
+
+  {# Open Graph tags #}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Get Started with Hedgehog Learn">
+  <meta property="og:description" content="Your orientation guide to mastering Kubernetes-native networking with Hedgehog's curated learning pathways.">
+  <meta property="og:url" content="https://{{ request.domain }}/learn/get-started">
+  <meta property="og:image" content="{{ social_image }}">
+
+  {# Twitter Card tags #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Get Started with Hedgehog Learn">
+  <meta name="twitter:description" content="Your orientation guide to mastering Kubernetes-native networking with Hedgehog's curated learning pathways.">
+  <meta name="twitter:image" content="{{ social_image }}">
+{% endblock head %}
+
+{% block body %}
+{# Re-declare constants for body block scope (HubL variables are block-scoped) #}
+{% set constants = get_asset_url("/CLEAN x HEDGEHOG/templates/config/constants.json")|request_json %}
+{% set pathways_table_id = constants.HUBDB_PATHWAYS_TABLE_ID if constants and constants.HUBDB_PATHWAYS_TABLE_ID else "135381504" %}
+{% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else "135381433" %}
+
+<main id="main-content" class="learn-landing">
+
+  {# ==================== HERO SECTION ==================== #}
+  <section class="learn-header-section">
+    <div class="learn-header-content">
+      <h1 class="learn-page-title">Welcome to Hedgehog Learn</h1>
+      <p class="learn-page-subtitle">Transform your network operations with our flagship pathway. Learn to provision, monitor, and troubleshoot Kubernetes-native datacenter fabrics through hands-on labs and real-world scenarios—whether you're new to networking or new to Kubernetes.</p>
+
+      {# Primary CTA to flagship pathway #}
+      <div class="hero-ctas">
+        <a href="/learn/pathways/network-like-hyperscaler" class="button button-primary">Start Network Like a Hyperscaler →</a>
+        <a href="/learn/catalog" class="button button-secondary">Browse Full Catalog</a>
+      </div>
+    </div>
+  </section>
+
+  {# ==================== MAIN CONTENT CONTAINER ==================== #}
+  <div class="landing-content-container">
+
+    {# ==================== KEY TOPICS SECTION ==================== #}
+    {#
+      Data Strategy: Query HubDB for "network-like-hyperscaler" pathway,
+      then display its courses as curated topic cards.
+
+      This keeps content dynamic and manageable through HubDB while
+      maintaining clear configuration in the pathway JSON source.
+
+      See: /content/pathways/network-like-hyperscaler.json
+    #}
+    <section class="landing-section">
+      <div class="section-header">
+        <h2 class="section-title">Start with These Key Topics</h2>
+        <p class="section-subtitle">Master the essentials through our curated Network Like a Hyperscaler pathway</p>
+      </div>
+
+      {% if pathways_table_id and courses_table_id %}
+        {# Query for the flagship pathway by slug #}
+        {% set flagship_pathway = hubdb_table_rows(
+          pathways_table_id,
+          "hs_path__eq=network-like-hyperscaler"
+        ) %}
+
+        {% if flagship_pathway and flagship_pathway|length > 0 %}
+          {% set pathway = flagship_pathway[0] %}
+
+          {# Parse course slugs from JSON and fetch course data #}
+          {% if pathway.course_slugs_json %}
+            {% set course_slugs = pathway.course_slugs_json|fromjson %}
+
+            {# Fetch all courses to build a lookup map #}
+
+            <div class="catalog-grid">
+              {% for course_slug in course_slugs %}
+                {% set course_result = hubdb_table_rows(
+                  courses_table_id,
+                  "hs_path__eq=" ~ course_slug ~ "&tags__not__icontains=archived"
+                ) %}
+                {% set course = course_result[0] if course_result and course_result|length > 0 else None %}
+                {% if course %}
+                  <article class="catalog-card">
+                    <div class="catalog-card-header">
+                      <span class="catalog-type-badge catalog-type-course">Course</span>
+                      {% if course.difficulty %}
+                        <span class="catalog-level-badge">{{ course.difficulty }}</span>
+                      {% endif %}
+                    </div>
+                    <h3 class="catalog-card-title">
+                      <a href="/learn/courses/{{ course.hs_path }}">{{ course.hs_name }}</a>
+                    </h3>
+                    <p class="catalog-card-summary">
+                      {{ course.summary_markdown|striptags|truncate(160, true, '...') if course.summary_markdown else 'Build hands-on skills through this focused course curriculum.' }}
+                    </p>
+                    <div class="catalog-card-meta">
+                      {% if course.module_count %}
+                        <span class="catalog-meta-item">
+                          <span>📚</span>
+                          <span>{{ course.module_count }} modules</span>
+                        </span>
+                      {% endif %}
+                      {% if course.estimated_minutes %}
+                        <span class="catalog-meta-item">
+                          <span>⏱️</span>
+                          <span>{{ (course.estimated_minutes / 60)|round(1) }} hours</span>
+                        </span>
+                      {% endif %}
+                    </div>
+                    <a href="/learn/courses/{{ course.hs_path }}" class="catalog-card-cta">
+                      Start Course →
+                    </a>
+                  </article>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% else %}
+            {# Fallback if course_slugs_json is missing #}
+            <div class="empty-state">
+              <p>Featured topics are being curated. Check out the full pathway to get started.</p>
+              <a href="/learn/pathways/network-like-hyperscaler" class="button button-secondary">View Full Pathway</a>
+            </div>
+          {% endif %}
+        {% else %}
+          {# Graceful fallback when pathway not found #}
+          <div class="empty-state">
+            <p>Featured topics are being curated. Check out the full pathway to get started.</p>
+            <a href="/learn/catalog" class="button button-secondary">Browse All Content</a>
+          </div>
+        {% endif %}
+      {% else %}
+        {# Fallback when constants not available #}
+        <div class="empty-state">
+          <p>Featured topics are loading.</p>
+        </div>
+      {% endif %}
+    </section>
+
+    {# ==================== NEXT STEPS SECTION ==================== #}
+    <section class="landing-section">
+      <div class="section-header">
+        <h2 class="section-title">Continue Your Learning Journey</h2>
+        <p class="section-subtitle">Explore more ways to build your skills and confidence</p>
+      </div>
+
+      <div class="level-cards">
+        <article class="level-card level-card-beginner">
+          <div class="level-icon">📖</div>
+          <h3 class="level-card-title">Browse Full Catalog</h3>
+          <p class="level-card-description">Discover all available modules, courses, and pathways. Filter by type, level, and duration to find the perfect next step for your learning goals.</p>
+          <a href="/learn/catalog" class="catalog-card-cta">Explore Catalog →</a>
+        </article>
+
+        <article class="level-card level-card-intermediate">
+          <div class="level-icon">🎯</div>
+          <h3 class="level-card-title">View All Pathways</h3>
+          <p class="level-card-description">Explore curated learning pathways designed to take you from fundamentals to mastery in Kubernetes-native networking and fabric operations.</p>
+          <a href="/learn/pathways" class="catalog-card-cta">Browse Pathways →</a>
+        </article>
+
+        <article class="level-card level-card-advanced">
+          <div class="level-icon">🌱</div>
+          <h3 class="level-card-title">Start with Basics</h3>
+          <p class="level-card-description">New to cloud networking? Filter the catalog to show only beginner-level content and build your foundation with guided, step-by-step modules.</p>
+          <a href="/learn/catalog?level=beginner" class="catalog-card-cta">View Beginner Content →</a>
+        </article>
+      </div>
+    </section>
+
+    {# ==================== FINAL CTA SECTION ==================== #}
+    <section class="landing-cta-section">
+      <div class="cta-content">
+        <h2 class="cta-title">Ready to Begin?</h2>
+        <p class="cta-subtitle">Join infrastructure teams worldwide mastering Kubernetes-native networking with Hedgehog Learn.</p>
+        <div class="cta-buttons">
+          <a href="/learn/pathways/network-like-hyperscaler" class="button button-primary button-large">Start Your Journey</a>
+        </div>
+      </div>
+    </section>
+
+  </div>
+  {# End landing-content-container #}
+
+  {# Build timestamp marker for deployment verification (Issue #293) #}
+  <div class="hhl-build" data-build="2025-11-06T02:55Z"></div>
+
+</main>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
+++ b/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
@@ -18,19 +18,19 @@
           <span class="learn-nav-icon" aria-hidden="true">🏠</span>
           <span class="learn-nav-text">Catalog</span>
         </a>
-        <a href="/learn/modules" class="learn-nav-link {% if current_page == 'modules' %}active{% endif %}" {% if current_page == 'modules' %}aria-current="page"{% endif %}>
+        <a href="/learn-shadow/modules" class="learn-nav-link {% if current_page == 'modules' %}active{% endif %}" {% if current_page == 'modules' %}aria-current="page"{% endif %}>
           <span class="learn-nav-icon" aria-hidden="true">📚</span>
           <span class="learn-nav-text">Modules</span>
         </a>
-        <a href="/learn/courses" class="learn-nav-link {% if current_page == 'courses' %}active{% endif %}" {% if current_page == 'courses' %}aria-current="page"{% endif %}>
+        <a href="/learn-shadow/courses" class="learn-nav-link {% if current_page == 'courses' %}active{% endif %}" {% if current_page == 'courses' %}aria-current="page"{% endif %}>
           <span class="learn-nav-icon" aria-hidden="true">🎓</span>
           <span class="learn-nav-text">Courses</span>
         </a>
-        <a href="/learn/pathways" class="learn-nav-link {% if current_page == 'pathways' %}active{% endif %}" {% if current_page == 'pathways' %}aria-current="page"{% endif %}>
+        <a href="/learn-shadow/pathways" class="learn-nav-link {% if current_page == 'pathways' %}active{% endif %}" {% if current_page == 'pathways' %}aria-current="page"{% endif %}>
           <span class="learn-nav-icon" aria-hidden="true">🗺️</span>
           <span class="learn-nav-text">Pathways</span>
         </a>
-        <a href="/learn/my-learning" class="learn-nav-link {% if current_page == 'my-learning' %}active{% endif %}" {% if current_page == 'my-learning' %}aria-current="page"{% endif %}>
+        <a href="/learn-shadow/my-learning" class="learn-nav-link {% if current_page == 'my-learning' %}active{% endif %}" {% if current_page == 'my-learning' %}aria-current="page"{% endif %}>
           <span class="learn-nav-icon" aria-hidden="true">📊</span>
           <span class="learn-nav-text">My Learning</span>
         </a>
@@ -53,7 +53,7 @@
         </div>
 
         <div data-auth-state="anonymous">
-          <a href="/learn/register" class="learn-auth-link" aria-label="Create a Hedgehog Learn account">
+          <a href="/learn-shadow/register" class="learn-auth-link" aria-label="Create a Hedgehog Learn account">
             <span class="learn-nav-icon" aria-hidden="true">📝</span>
             <span class="learn-nav-text">Register</span>
           </a>

--- a/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
+++ b/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
@@ -1,0 +1,154 @@
+{# Left-side navigation and filter panel for learning list pages #}
+{% macro learning_left_nav(current_page, show_filters=true) %}
+  {# Inline constants (Issue #327/#345 fix: request_json doesn't exist in HubL) #}
+  {% set constants = {
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me'
+  } %}
+  {% set login_url = constants.AUTH_LOGIN_URL %}
+  {% set logout_url = constants.AUTH_LOGOUT_URL %}
+
+  {# Issue #345: Auth state managed by Cognito client-side, no server-side HubSpot membership check #}
+  <aside class="learn-left-nav" id="learn-left-nav" role="navigation" aria-label="Learning navigation">
+    <div class="learn-left-nav-content">
+      {# Navigation Links #}
+      <nav class="learn-nav-links" aria-label="Learning sections">
+        <a href="/learn" class="learn-nav-link {% if current_page == 'catalog' %}active{% endif %}" {% if current_page == 'catalog' %}aria-current="page"{% endif %}>
+          <span class="learn-nav-icon" aria-hidden="true">🏠</span>
+          <span class="learn-nav-text">Catalog</span>
+        </a>
+        <a href="/learn/modules" class="learn-nav-link {% if current_page == 'modules' %}active{% endif %}" {% if current_page == 'modules' %}aria-current="page"{% endif %}>
+          <span class="learn-nav-icon" aria-hidden="true">📚</span>
+          <span class="learn-nav-text">Modules</span>
+        </a>
+        <a href="/learn/courses" class="learn-nav-link {% if current_page == 'courses' %}active{% endif %}" {% if current_page == 'courses' %}aria-current="page"{% endif %}>
+          <span class="learn-nav-icon" aria-hidden="true">🎓</span>
+          <span class="learn-nav-text">Courses</span>
+        </a>
+        <a href="/learn/pathways" class="learn-nav-link {% if current_page == 'pathways' %}active{% endif %}" {% if current_page == 'pathways' %}aria-current="page"{% endif %}>
+          <span class="learn-nav-icon" aria-hidden="true">🗺️</span>
+          <span class="learn-nav-text">Pathways</span>
+        </a>
+        <a href="/learn/my-learning" class="learn-nav-link {% if current_page == 'my-learning' %}active{% endif %}" {% if current_page == 'my-learning' %}aria-current="page"{% endif %}>
+          <span class="learn-nav-icon" aria-hidden="true">📊</span>
+          <span class="learn-nav-text">My Learning</span>
+        </a>
+      </nav>
+
+      {# Divider #}
+      <div class="learn-nav-divider"></div>
+
+      {# Build absolute redirect URL for OAuth flow #}
+      {% set absolute_redirect = 'https://' ~ request.domain ~ request.path_and_query %}
+
+      {# Auth Links - Server renders both states; client-side JS toggles visibility based on Cognito #}
+      <div class="learn-nav-auth" role="region" aria-label="User authentication">
+        <div data-auth-state="authenticated" style="display:none;">
+          <div class="learn-user-greeting" id="auth-user-greeting" aria-live="polite">Hi there!</div>
+          <a href="{{ logout_url }}?redirect_url={{ absolute_redirect|urlencode }}" class="learn-auth-link" aria-label="Sign out of your account">
+            <span class="learn-nav-icon" aria-hidden="true">🚪</span>
+            <span class="learn-nav-text">Sign Out</span>
+          </a>
+        </div>
+
+        <div data-auth-state="anonymous">
+          <a href="/learn/register" class="learn-auth-link" aria-label="Create a Hedgehog Learn account">
+            <span class="learn-nav-icon" aria-hidden="true">📝</span>
+            <span class="learn-nav-text">Register</span>
+          </a>
+<a href="{{ login_url }}?redirect_url={{ absolute_redirect|urlencode }}" class="learn-auth-link" aria-label="Sign in to your account">
+            <span class="learn-nav-icon" aria-hidden="true">🔐</span>
+            <span class="learn-nav-text">Sign In</span>
+          </a>
+        </div>
+      </div>
+
+      {# Filter Panel (optional) #}
+      {% if show_filters %}
+        <div class="learn-nav-divider" role="separator"></div>
+
+        <div class="learn-filters" role="region" aria-label="Content filters">
+          <h3 class="learn-filters-title" id="filters-heading">Filters</h3>
+
+          {# Results Count #}
+          <div class="learn-filter-results" role="status" aria-live="polite">
+            Showing <strong><span id="visible-count">0</span></strong> of <strong><span id="total-count">0</span></strong> items
+          </div>
+
+          {# Search #}
+          <div class="learn-filter-group">
+            <label class="learn-filter-label" for="filter-search">Search</label>
+            <input type="text" id="filter-search" class="learn-filter-search" placeholder="Search titles and tags..." aria-label="Search by title or tags">
+          </div>
+
+          {# Type #}
+          <div class="learn-filter-group">
+            <fieldset>
+              <legend class="learn-filter-label">Type</legend>
+              <div class="learn-filter-options">
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="type" value="all" id="type-all" checked> All
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="type" value="module" checked> Modules
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="type" value="course" checked> Courses
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="type" value="pathway" checked> Pathways
+                </label>
+              </div>
+            </fieldset>
+          </div>
+
+          {# Level #}
+          <div class="learn-filter-group">
+            <fieldset>
+              <legend class="learn-filter-label">Level</legend>
+              <div class="learn-filter-options">
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="level" value="all" id="level-all" checked> All
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="level" value="beginner" checked> Beginner
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="level" value="intermediate" checked> Intermediate
+                </label>
+                <label class="learn-filter-checkbox">
+                  <input type="checkbox" name="level" value="advanced" checked> Advanced
+                </label>
+              </div>
+            </fieldset>
+          </div>
+
+          {# Duration #}
+          <div class="learn-filter-group">
+            <label class="learn-filter-label" for="filter-duration">Duration</label>
+            <select id="filter-duration" class="learn-filter-select" aria-label="Filter by duration">
+              <option value="all">Any duration</option>
+              <option value="0-30">Under 30 min</option>
+              <option value="30-60">30-60 min</option>
+              <option value="60-999">Over 60 min</option>
+            </select>
+          </div>
+
+          {# Clear Filters Button #}
+          <button type="button" id="clear-filters" class="learn-filter-clear" aria-label="Clear all filters">
+            Clear Filters
+          </button>
+        </div>
+      {% endif %}
+    </div>
+  </aside>
+
+  {# Mobile overlay #}
+  <div class="learn-nav-overlay" id="learn-nav-overlay"></div>
+
+  {# Mobile toggle button #}
+  <button class="learn-nav-toggle" id="learn-nav-toggle" aria-label="Toggle navigation">
+    <span class="learn-nav-toggle-icon">☰</span>
+  </button>
+{% endmacro %}

--- a/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
+++ b/clean-x-hedgehog-templates/learn-shadow/macros/left-nav.html
@@ -14,7 +14,7 @@
     <div class="learn-left-nav-content">
       {# Navigation Links #}
       <nav class="learn-nav-links" aria-label="Learning sections">
-        <a href="/learn" class="learn-nav-link {% if current_page == 'catalog' %}active{% endif %}" {% if current_page == 'catalog' %}aria-current="page"{% endif %}>
+        <a href="/learn-shadow" class="learn-nav-link {% if current_page == 'catalog' %}active{% endif %}" {% if current_page == 'catalog' %}aria-current="page"{% endif %}>
           <span class="learn-nav-icon" aria-hidden="true">🏠</span>
           <span class="learn-nav-text">Catalog</span>
         </a>

--- a/clean-x-hedgehog-templates/learn-shadow/module-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/module-page.html
@@ -684,7 +684,7 @@
         <div class="module-detail">
           <!-- Breadcrumbs -->
           <nav class="module-breadcrumbs" id="hhl-breadcrumbs">
-            <a href="/learn">← Back to Learning Portal</a>
+            <a href="/learn-shadow">← Back to Learning Portal</a>
             <span id="hhl-course-position" style="display:none; margin-left:12px; color:#666; font-size:0.875rem;"></span>
           </nav>
 

--- a/clean-x-hedgehog-templates/learn-shadow/module-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/module-page.html
@@ -1,0 +1,1087 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+{% from "/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html" import learning_left_nav %}
+
+{% block head %}
+  {{ super() }}
+
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
+  {# Left nav CSS and JS for list pages #}
+  <link rel="stylesheet" href="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css') }}">
+  <link rel="stylesheet" href="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/module-media.css') }}">
+  <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js') }}" defer></script>
+
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Defined in shared scope so both detail and list views can access.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'LOGOUT_URL': '/_hcms/mem/logout',
+    'LOGIN_URL': '/_hcms/mem/login',
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+
+  {% if dynamic_page_hubdb_row %}
+    {# SEO metadata for detail pages #}
+    {% set page_title = dynamic_page_hubdb_row.hs_name ~ " - Learn Hedgehog" %}
+    {% set meta_desc = dynamic_page_hubdb_row.meta_description|striptags|truncate(160) if dynamic_page_hubdb_row.meta_description else "Learn " ~ dynamic_page_hubdb_row.hs_name %}
+    {% set canonical_url = "https://" ~ request.domain ~ "/learn-shadow/modules/" ~ dynamic_page_hubdb_row.hs_path %}
+    {% set social_image = dynamic_page_hubdb_row.social_image_url if dynamic_page_hubdb_row.social_image_url else constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    <title>{{ page_title }}</title>
+    <meta name="description" content="{{ meta_desc }}">
+    <link rel="canonical" href="{{ canonical_url }}">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ page_title }}">
+    <meta property="og:description" content="{{ meta_desc }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ page_title }}">
+    <meta name="twitter:description" content="{{ meta_desc }}">
+    <meta name="twitter:image" content="{{ social_image }}">
+    {# HHL pageview meta for JS beacon #}
+    <meta name="hhl:module_slug" content="{{ dynamic_page_hubdb_row.hs_path }}">
+  {% else %}
+    {# SEO metadata for list pages #}
+    {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    <title>Learning Modules - Learn Hedgehog</title>
+    <meta name="description" content="Browse all learning modules. Build high-performance AI networks on open Ethernet and OCP hardware with hands-on learning content.">
+    <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/modules">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Learning Modules - Learn Hedgehog">
+    <meta property="og:description" content="Browse all learning modules. Build high-performance AI networks on open Ethernet and OCP hardware with hands-on learning content.">
+    <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/modules">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Learning Modules - Learn Hedgehog">
+    <meta name="twitter:description" content="Browse all learning modules. Build high-performance AI networks on open Ethernet and OCP hardware with hands-on learning content.">
+    <meta name="twitter:image" content="{{ social_image }}">
+  {% endif %}
+
+  {% if dynamic_page_hubdb_row %}
+    {# Compute prev/next early for head tags - using same logic as navigation #}
+    {% set head_prev_module = none %}
+    {% set head_next_module = none %}
+    {% set head_current_slug = dynamic_page_hubdb_row.hs_path %}
+    {#
+      Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+      HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+      Source: clean-x-hedgehog-templates/config/constants.json
+    #}
+    
+    {% set head_pathways_table_id = head_constants.HUBDB_PATHWAYS_TABLE_ID if head_constants else none %}
+    {% set head_modules_table_id = head_constants.HUBDB_MODULES_TABLE_ID if head_constants else dynamic_page_hubdb_table_id %}
+    {% set head_in_pathway = false %}
+
+    {% if head_pathways_table_id %}
+      {% set head_all_pathways = hubdb_table_rows(head_pathways_table_id, "tags__not__icontains=archived") %}
+      {% for pathway in head_all_pathways %}
+        {% if pathway.module_slugs_json and not head_in_pathway %}
+          {% set head_module_slugs = pathway.module_slugs_json|fromjson %}
+          {% if head_module_slugs and head_current_slug in head_module_slugs %}
+            {% set head_in_pathway = true %}
+            {% for slug in head_module_slugs %}
+              {% if slug == head_current_slug %}
+                {% set head_current_index = loop.index0 %}
+                {% if head_current_index > 0 %}
+                  {% set head_prev_slug = head_module_slugs[head_current_index - 1] %}
+                  {% set head_prev_rows = hubdb_table_rows(head_modules_table_id, "path__eq=" ~ head_prev_slug ~ "&tags__not__icontains=archived") %}
+                  {% if head_prev_rows and head_prev_rows|length > 0 %}
+                    {% set head_prev_module = head_prev_rows[0] %}
+                  {% endif %}
+                {% endif %}
+                {% if head_current_index < (head_module_slugs|length - 1) %}
+                  {% set head_next_slug = head_module_slugs[head_current_index + 1] %}
+                  {% set head_next_rows = hubdb_table_rows(head_modules_table_id, "path__eq=" ~ head_next_slug ~ "&tags__not__icontains=archived") %}
+                  {% if head_next_rows and head_next_rows|length > 0 %}
+                    {% set head_next_module = head_next_rows[0] %}
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {% if not head_in_pathway and head_modules_table_id %}
+      {% set head_all_modules = hubdb_table_rows(head_modules_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+      {% for module in head_all_modules %}
+        {% if module.hs_path == head_current_slug %}
+          {% set head_current_index = loop.index0 %}
+          {% if head_current_index > 0 %}
+            {% set head_prev_module = head_all_modules[head_current_index - 1] %}
+          {% endif %}
+          {% if head_current_index < (head_all_modules|length - 1) %}
+            {% set head_next_module = head_all_modules[head_current_index + 1] %}
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+
+    {# Add SEO/browser hint rel links #}
+    {% if head_prev_module %}
+  <link rel="prev" href="/learn-shadow/modules/{{ head_prev_module.hs_path }}">
+    {% endif %}
+    {% if head_next_module %}
+  <link rel="next" href="/learn-shadow/modules/{{ head_next_module.hs_path }}">
+    {% endif %}
+
+    {# JSON-LD structured data for detail pages #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "LearningResource",
+      "name": {{ dynamic_page_hubdb_row.hs_name|tojson }},
+      {% if dynamic_page_hubdb_row.meta_description %}
+      "description": {{ dynamic_page_hubdb_row.meta_description|striptags|tojson }},
+      {% endif %}
+      "url": "https://{{ request.domain }}/learn-shadow/modules/{{ dynamic_page_hubdb_row.hs_path }}",
+      {% if dynamic_page_hubdb_row.estimated_minutes %}
+      "timeRequired": "PT{{ dynamic_page_hubdb_row.estimated_minutes }}M",
+      {% endif %}
+      {% if dynamic_page_hubdb_row.difficulty %}
+      "educationalLevel": {{ dynamic_page_hubdb_row.difficulty.label|tojson }},
+      {% endif %}
+      {% if dynamic_page_hubdb_row.tags %}
+      "about": [
+        {% set tag_list = dynamic_page_hubdb_row.tags.split(',') %}
+        {% for tag in tag_list %}
+          {% if tag|trim|lower != 'archived' %}
+        { "@type": "Thing", "name": {{ tag|trim|tojson }} }{% if not loop.last %},{% endif %}
+          {% endif %}
+        {% endfor %}
+      ],
+      {% endif %}
+      "learningResourceType": "Module",
+      "inLanguage": "en-US"
+    }
+    </script>
+
+    {# BreadcrumbList JSON-LD #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Learn",
+          "item": "https://{{ request.domain }}/learn"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": {{ dynamic_page_hubdb_row.hs_name|tojson }}
+        }
+      ]
+    }
+    </script>
+  {% else %}
+    {# JSON-LD structured data for list page #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": "Learning Modules",
+      "description": "Hedgehog AI Networking learning modules",
+      "itemListElement": [
+        {% if dynamic_page_hubdb_table_id %}
+          {% set modules = hubdb_table_rows(dynamic_page_hubdb_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% for module in modules %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "item": {
+            "@type": "LearningResource",
+            "name": {{ module.hs_name|tojson }},
+            "url": "https://{{ request.domain }}/learn-shadow/modules/{{ module.hs_path }}"
+            {% if module.meta_description %}
+            ,"description": {{ module.meta_description|striptags|tojson }}
+            {% endif %}
+          }
+        }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        {% endif %}
+      ]
+    }
+    </script>
+  {% endif %}
+{% endblock head %}
+
+{% block body %}
+<style>
+  /* Header section styling */
+  .learn-header-section {
+    width: 100vw;
+    background: #1a4e8a url('https://hedgehog.cloud/hubfs/hh-clouds.webp') center center/cover no-repeat;
+    color: #fff;
+    padding: 96px 0 64px 0;
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+  .learn-header-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+  }
+  .learn-page-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -1px;
+  }
+  .learn-page-subtitle {
+    font-size: 1.2rem;
+    font-weight: 400;
+    margin: 0;
+    opacity: 0.9;
+  }
+  .learn-header-nav {
+    display: flex;
+    gap: 24px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .learn-header-nav a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: background 0.2s;
+  }
+  .learn-header-nav a:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
+  .auth-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .user-greeting {
+    color: #fff;
+    font-size: 0.875rem;
+    opacity: 0.9;
+  }
+  .auth-link {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 6px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 6px;
+    transition: all 0.2s;
+  }
+  .auth-link:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+
+  /* Main content section */
+  .learn-main-section {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0;
+    min-height: 60vh;
+  }
+  .learn-container {
+    max-width: 1600px;
+    width: 100%;
+    background: #fff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 2px 24px rgba(26,78,138,0.06);
+    min-height: 60vh;
+  }
+
+  /* Module grid (list view) */
+  .modules-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 32px;
+  }
+  .module-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+  }
+  .module-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .module-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+  .difficulty-badge {
+    background: #EFF6FF;
+    color: #0066CC;
+    padding: 6px 12px;
+    border-radius: 12px;
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+  .module-time {
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .module-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+  }
+  .module-card p {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .module-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .module-tag {
+    background: #F3F4F6;
+    color: #374151;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+  }
+  .module-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Module detail view */
+  .module-detail {
+    max-width: 900px;
+    margin: 0 auto;
+  }
+  .module-breadcrumbs {
+    padding: 16px 0;
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .module-breadcrumbs a {
+    color: #0066CC;
+    text-decoration: none;
+  }
+  .module-detail-header {
+    margin: 32px 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #E5E7EB;
+  }
+  .module-detail-header h1 {
+    margin: 0 0 16px 0;
+    color: #1a4e8a;
+  }
+  .module-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+  }
+  .module-content {
+    line-height: 1.8;
+    font-size: 1.0625rem;
+  }
+  .module-content h2 {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    font-size: 1.75rem;
+    color: #111827;
+  }
+  .module-content h3 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    font-size: 1.375rem;
+    color: #111827;
+  }
+  .module-content code {
+    background: #F3F4F6;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Courier New', monospace;
+    font-size: 0.875em;
+    color: #E83E8C;
+  }
+  .module-content pre {
+    background: #1E293B;
+    color: #F1F5F9;
+    padding: 16px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 16px 0;
+  }
+  .module-content pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+  }
+
+  /* Hide a duplicate leading H1 inside rendered module content */
+  .module-content > h1:first-child {
+    display: none;
+  }
+
+  /* Prerequisites section */
+  .module-prerequisites {
+    margin: 24px 0;
+    padding: 20px;
+    background: #F9FAFB;
+    border-left: 4px solid #1a4e8a;
+    border-radius: 8px;
+  }
+  .module-prerequisites h2 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+  }
+  .module-prerequisites ul {
+    margin: 0;
+    padding-left: 24px;
+    list-style-type: disc;
+  }
+  .module-prerequisites li {
+    margin: 8px 0;
+    line-height: 1.6;
+  }
+  .module-prerequisites a {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .module-prerequisites a:hover {
+    text-decoration: underline;
+  }
+
+  /* Prev/Next Navigation */
+  .module-nav {
+    margin: 24px 0;
+    padding: 20px 0;
+    border-top: 1px solid #E5E7EB;
+    border-bottom: 1px solid #E5E7EB;
+  }
+  .module-nav-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 16px;
+  }
+  .module-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px 20px;
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    text-decoration: none;
+    transition: all 0.2s;
+    background: #F9FAFB;
+    flex: 1;
+    max-width: 48%;
+  }
+  .module-nav-link:hover {
+    background: #EFF6FF;
+    border-color: #1a4e8a;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(26,78,138,0.15);
+  }
+  .module-nav-link:focus {
+    outline: 2px solid #1a4e8a;
+    outline-offset: 2px;
+  }
+  .module-nav-prev {
+    justify-content: flex-start;
+  }
+  .module-nav-next {
+    justify-content: flex-end;
+    margin-left: auto;
+  }
+  .module-nav-arrow {
+    font-size: 1.5rem;
+    color: #1a4e8a;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .module-nav-content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+  .module-nav-next .module-nav-content {
+    align-items: flex-end;
+    text-align: right;
+  }
+  .module-nav-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #666;
+    font-weight: 600;
+  }
+  .module-nav-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: #1a4e8a;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .module-nav-spacer {
+    flex: 1;
+    max-width: 48%;
+  }
+
+  /* Pathways band */
+  .pathways-band {
+    max-width: 1600px;
+    margin: 32px auto;
+    padding: 0 40px;
+  }
+  .pathways-band-content {
+    background: linear-gradient(135deg, #EFF6FF 0%, #DBEAFE 100%);
+    border: 1px solid #BFDBFE;
+    border-radius: 12px;
+    padding: 32px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+  }
+  .pathways-band-text {
+    flex: 1;
+  }
+  .pathways-band-text h2 {
+    margin: 0 0 8px 0;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #1a4e8a;
+  }
+  .pathways-band-text p {
+    margin: 0;
+    font-size: 1rem;
+    color: #374151;
+  }
+  .pathways-band-cta {
+    flex-shrink: 0;
+  }
+  .pathways-cta-button {
+    display: inline-block;
+    background: #1a4e8a;
+    color: #fff;
+    padding: 12px 24px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: background 0.2s, transform 0.2s;
+  }
+  .pathways-cta-button:hover {
+    background: #154171;
+    transform: translateY(-2px);
+  }
+
+  @media (max-width: 900px) {
+    .learn-header-content, .learn-container {
+      padding: 0 16px;
+    }
+    .modules-grid {
+      grid-template-columns: 1fr;
+    }
+    .pathways-band {
+      padding: 0 16px;
+    }
+    .pathways-band-content {
+      flex-direction: column;
+      align-items: flex-start;
+      padding: 24px;
+    }
+    .pathways-band-cta {
+      width: 100%;
+    }
+    .pathways-cta-button {
+      display: block;
+      text-align: center;
+      width: 100%;
+    }
+    /* Mobile prev/next navigation */
+    .module-nav-container {
+      flex-direction: column;
+      gap: 12px;
+    }
+    .module-nav-link {
+      max-width: 100%;
+    }
+    .module-nav-title {
+      white-space: normal;
+      line-height: 1.4;
+    }
+  }
+</style>
+
+<main id="main-content">
+  {% if dynamic_page_hubdb_row %}
+    {# Detail view - showing a single module #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        {# Omit a visible H1 in the hero on detail pages to avoid duplicates #}
+      </div>
+    </section>
+
+    <section class="learn-main-section">
+      <div class="learn-container">
+        <div class="module-detail">
+          <!-- Breadcrumbs -->
+          <nav class="module-breadcrumbs" id="hhl-breadcrumbs">
+            <a href="/learn">← Back to Learning Portal</a>
+            <span id="hhl-course-position" style="display:none; margin-left:12px; color:#666; font-size:0.875rem;"></span>
+          </nav>
+
+          <!-- Module Header -->
+          <header class="module-detail-header">
+            <h1>{{ dynamic_page_hubdb_row.hs_name }}</h1>
+            <div class="module-meta">
+              <span class="difficulty-badge">
+                {{ dynamic_page_hubdb_row.difficulty.label }}
+              </span>
+              <span class="module-time">
+                {{ dynamic_page_hubdb_row.estimated_minutes }} minutes
+              </span>
+              {% if dynamic_page_hubdb_row.tags %}
+                <div class="module-tags">
+                  {% set tag_list = dynamic_page_hubdb_row.tags.split(',') %}
+                  {% for tag in tag_list %}
+                    <span class="module-tag">{{ tag|trim }}</span>
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+
+            {# Auth context for JS (Issue #345 - Cognito auth with inlined constants) #}
+            {#
+              Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+              HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+              Source: clean-x-hedgehog-templates/config/constants.json
+            #}
+            {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+            {% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+            {% set auth_logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+            <div id="hhl-auth-context"
+                 data-auth-me-url="{{ auth_me_url }}"
+                 data-auth-login-url="{{ auth_login_url }}"
+                 data-auth-logout-url="{{ auth_logout_url }}"
+                 data-enable-crm="true"
+                 data-track-events-url="https://api.hedgehog.cloud/events/track"
+                 style="display:none"></div>
+            <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+
+            <div class="module-progress-cta" role="region" aria-label="Module progress" style="margin-top:16px; display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+              <button type="button" class="pathways-cta-button" id="hhl-mark-started" aria-label="Mark module as started" style="padding:8px 14px;">
+                Mark as started
+              </button>
+              <button type="button" class="pathways-cta-button" id="hhl-mark-complete" aria-label="Mark module as complete" style="padding:8px 14px;">
+                Mark complete
+              </button>
+              <a id="hhl-back-to-pathway" href="#" style="display:none; color:#0066CC; text-decoration:none; font-weight:600;">← Back to pathway</a>
+            </div>
+            {# Load external JS to avoid inline script CSP issues #}
+            <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/toast.js') }}"></script>
+            <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/course-context.js') }}"></script>
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/login-helper.js') }}"></script>
+            {# Line 737 - auth-context.js REMOVED (Issue #345: Cognito-only auth) #}
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/course-breadcrumbs.js') }}"></script>
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/course-navigation.js') }}"></script>
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/progress.js') }}"></script>
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/pageview.js') }}"></script>
+          </header>
+
+          {% set module_media = [] %}
+          {% set raw_media = dynamic_page_hubdb_row.media_json %}
+          {% if raw_media %}
+            {% if raw_media is string %}
+              {% set parsed_media = raw_media|fromjson %}
+            {% else %}
+              {% set parsed_media = raw_media %}
+            {% endif %}
+            {% if parsed_media %}
+              {% if parsed_media.items is defined %}
+                {% set module_media = parsed_media.items %}
+              {% else %}
+                {% set module_media = parsed_media %}
+              {% endif %}
+            {% endif %}
+          {% endif %}
+
+          {% if module_media and module_media|length > 0 %}
+            <section class="module-media-gallery" aria-label="Module media">
+              <div class="module-media-grid">
+                {% for item in module_media %}
+                  {% if item.type == 'image' %}
+                    <figure class="module-media-card">
+                      <img src="{{ item.url }}" alt="{{ item.alt }}" loading="lazy">
+                      {% if item.caption or item.credit %}
+                        <figcaption>
+                          {% if item.caption %}<span class="module-media-caption">{{ item.caption }}</span>{% endif %}
+                          {% if item.credit %}<span class="module-media-credit">{{ item.credit }}</span>{% endif %}
+                        </figcaption>
+                      {% endif %}
+                    </figure>
+                  {% elif item.type == 'video' %}
+                    <figure class="module-media-card module-media-card--video">
+                      <video controls preload="metadata" {% if item.thumbnail_url %}poster="{{ item.thumbnail_url }}"{% endif %} aria-label="{{ item.alt }}">
+                        <source src="{{ item.url }}">
+                        Your browser does not support the video tag. <a href="{{ item.url }}" target="_blank" rel="noopener">Download the video</a>.
+                      </video>
+                      {% if item.caption or item.credit %}
+                        <figcaption>
+                          {% if item.caption %}<span class="module-media-caption">{{ item.caption }}</span>{% endif %}
+                          {% if item.credit %}<span class="module-media-credit">{{ item.credit }}</span>{% endif %}
+                        </figcaption>
+                      {% endif %}
+                    </figure>
+                  {% endif %}
+                {% endfor %}
+              </div>
+            </section>
+          {% endif %}
+
+          {# Prerequisites Section #}
+          {% if dynamic_page_hubdb_row.prerequisites_json %}
+            {% set prerequisites = dynamic_page_hubdb_row.prerequisites_json|fromjson %}
+
+            {% if prerequisites and prerequisites|length > 0 %}
+              <section class="module-prerequisites" id="prerequisites" role="region" aria-label="Prerequisites">
+                <h2>Prerequisites</h2>
+                <ul>
+                  {% for prereq in prerequisites %}
+                    {% if prereq is string %}
+                      {# Internal module slug - resolve to link #}
+                      {% set prereq_slug = prereq %}
+                      {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID or dynamic_page_hubdb_table_id %}
+                      {% if modules_table_id %}
+                        {% set prereq_rows = hubdb_table_rows(modules_table_id, "path__eq=" ~ prereq_slug ~ "&tags__not__icontains=archived") %}
+                        {% if prereq_rows and prereq_rows|length > 0 %}
+                          <li><a href="/learn-shadow/{{ prereq_rows[0].hs_path }}">{{ prereq_rows[0].hs_name }}</a></li>
+                        {% else %}
+                          {# Module not found - render as plain text with warning comment #}
+                          <li>{{ prereq_slug }}<!-- Warning: prerequisite module "{{ prereq_slug }}" not found in HubDB --></li>
+                        {% endif %}
+                      {% else %}
+                        {# No table ID available - render as plain text #}
+                        <li>{{ prereq_slug }}<!-- Warning: modules table ID not available --></li>
+                      {% endif %}
+                    {% elif prereq is mapping %}
+                      {# External resource with title and URL #}
+                      {% if prereq.url %}
+                        <li><a href="{{ prereq.url }}" rel="noopener" target="_blank">{{ prereq.title|default(prereq.url) }}</a></li>
+                      {% else %}
+                        {# Missing URL - render title as plain text #}
+                        <li>{{ prereq.title|default('Untitled prerequisite') }}</li>
+                      {% endif %}
+                    {% else %}
+                      {# Unexpected format - skip #}
+                    {% endif %}
+                  {% endfor %}
+                </ul>
+              </section>
+            {% endif %}
+          {% endif %}
+
+          {#
+            Prev/Next Navigation
+            Resolution order:
+            1. If module belongs to a pathway (via pathways table's module_slugs_json), use pathway ordering
+            2. Otherwise, use fallback: all modules ordered by display_order, then hs_name
+
+            Hardening notes:
+            - Falls back to dynamic_page_hubdb_table_id when constants are missing
+            - Guards against JSON parse errors in pathway module_slugs_json
+            - Generates <link rel=prev/next> tags in head for SEO
+          #}
+          {% set prev_module = none %}
+          {% set next_module = none %}
+          {% set current_slug = dynamic_page_hubdb_row.hs_path %}
+
+          {# Try to find pathway context first - with fallback when constants missing #}
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% set pathways_table_id = constants.HUBDB_PATHWAYS_TABLE_ID %}
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID or dynamic_page_hubdb_table_id %}
+          {% set in_pathway = false %}
+
+          {% if pathways_table_id %}
+            {# Find pathways that contain this module #}
+            {% set all_pathways = hubdb_table_rows(pathways_table_id, "tags__not__icontains=archived") %}
+            {% for pathway in all_pathways %}
+              {% if pathway.module_slugs_json and not in_pathway %}
+                {% set module_slugs = pathway.module_slugs_json|fromjson %}
+
+                {% if module_slugs and current_slug in module_slugs %}
+                  {% set in_pathway = true %}
+                  {# Find current module index in pathway #}
+                  {% for slug in module_slugs %}
+                    {% if slug == current_slug %}
+                      {% set current_index = loop.index0 %}
+                      {# Get previous module #}
+                      {% if current_index > 0 %}
+                        {% set prev_slug = module_slugs[current_index - 1] %}
+                        {% set prev_rows = hubdb_table_rows(modules_table_id, "path__eq=" ~ prev_slug ~ "&tags__not__icontains=archived") %}
+                        {% if prev_rows and prev_rows|length > 0 %}
+                          {% set prev_module = prev_rows[0] %}
+                        {% endif %}
+                      {% endif %}
+                      {# Get next module #}
+                      {% if current_index < (module_slugs|length - 1) %}
+                        {% set next_slug = module_slugs[current_index + 1] %}
+                        {% set next_rows = hubdb_table_rows(modules_table_id, "path__eq=" ~ next_slug ~ "&tags__not__icontains=archived") %}
+                        {% if next_rows and next_rows|length > 0 %}
+                          {% set next_module = next_rows[0] %}
+                        {% endif %}
+                      {% endif %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          {# Fallback: Use all modules ordered by display_order #}
+          {% if not in_pathway and modules_table_id %}
+            {% set all_modules = hubdb_table_rows(modules_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+            {% for module in all_modules %}
+              {% if module.hs_path == current_slug %}
+                {% set current_index = loop.index0 %}
+                {# Get previous module #}
+                {% if current_index > 0 %}
+                  {% set prev_module = all_modules[current_index - 1] %}
+                {% endif %}
+                {# Get next module #}
+                {% if current_index < (all_modules|length - 1) %}
+                  {% set next_module = all_modules[current_index + 1] %}
+                {% endif %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          <!-- Prev/Next Navigation Bar -->
+          {% if prev_module or next_module %}
+          <nav class="module-nav" role="navigation" aria-label="Module navigation">
+            <div class="module-nav-container">
+              {% if prev_module %}
+              <a href="/learn-shadow/modules/{{ prev_module.hs_path }}" class="module-nav-link module-nav-prev">
+                <span class="module-nav-arrow" aria-hidden="true">←</span>
+                <div class="module-nav-content">
+                  <span class="module-nav-label">Previous</span>
+                  <span class="module-nav-title">{{ prev_module.hs_name }}</span>
+                </div>
+              </a>
+              {% else %}
+              <div class="module-nav-spacer"></div>
+              {% endif %}
+
+              {% if next_module %}
+              <a href="/learn-shadow/modules/{{ next_module.hs_path }}" class="module-nav-link module-nav-next">
+                <div class="module-nav-content">
+                  <span class="module-nav-label">Next</span>
+                  <span class="module-nav-title">{{ next_module.hs_name }}</span>
+                </div>
+                <span class="module-nav-arrow" aria-hidden="true">→</span>
+              </a>
+              {% else %}
+              <div class="module-nav-spacer"></div>
+              {% endif %}
+            </div>
+          </nav>
+          {% endif %}
+
+          <!-- Module Content -->
+          {% set is_archived = false %}
+          {% if dynamic_page_hubdb_row.tags %}
+            {% set tag_list = dynamic_page_hubdb_row.tags|lower|split(',') %}
+            {% for tag in tag_list %}
+              {% if tag|trim == 'archived' %}
+                {% set is_archived = true %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+          {% if is_archived %}
+            <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px;">
+              This module is archived and may be out of date.
+            </div>
+          {% endif %}
+          <div class="module-content">
+            {# Prefer full_content when present #}
+            {% if dynamic_page_hubdb_row.full_content %}
+              {{ dynamic_page_hubdb_row.full_content|safe }}
+            {% elif dynamic_page_hubdb_row.content_blocks_json %}
+              {# Render simple content blocks fallback (text/callout) if provided #}
+              {% set blocks = dynamic_page_hubdb_row.content_blocks_json|fromjson %}
+              {% for block in blocks %}
+                {% if block.type == 'text' %}
+                  {% if block.title %}<h2>{{ block.title }}</h2>{% endif %}
+                  {% if block.body_markdown %}{{ block.body_markdown|safe }}{% endif %}
+                {% elif block.type == 'callout' %}
+                  <div class="content-block content-block-callout">
+                    {% if block.title %}<h2>{{ block.title }}</h2>{% endif %}
+                    {% if block.body_markdown %}{{ block.body_markdown|safe }}{% endif %}
+                  </div>
+                {% endif %}
+              {% endfor %}
+            {% elif dynamic_page_hubdb_row.summary_markdown %}
+              {{ dynamic_page_hubdb_row.summary_markdown|safe }}
+            {% else %}
+              <p><em>Module content coming soon.</em></p>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </section>
+
+  {% else %}
+    {# List view - showing all modules #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        <h1 class="learn-page-title">Learning Modules</h1>
+        <p class="learn-page-subtitle">Browse all available learning modules to build your skills in AI networking</p>
+      </div>
+    </section>
+
+    <div class="learn-layout-with-nav">
+      {# Left navigation #}
+      {{ learning_left_nav('modules', show_filters=false) }}
+
+      {# Main content area #}
+      <div class="learn-main-content">
+        {% if dynamic_page_hubdb_table_id %}
+          {% set modules = hubdb_table_rows(dynamic_page_hubdb_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% if modules %}
+            <div class="modules-grid">
+              {% for module in modules %}
+                {% set is_archived = false %}
+                {% if module.tags %}
+                  {% set tag_list = module.tags|lower|split(',') %}
+                  {% for tag in tag_list %}
+                    {% if tag|trim == 'archived' %}
+                      {% set is_archived = true %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+                {% if not is_archived %}
+                <a href="/learn-shadow/modules/{{ module.hs_path }}" class="module-card">
+                  <div class="module-card-header">
+                    <span class="difficulty-badge">
+                      {{ module.difficulty.label }}
+                    </span>
+                    <span class="module-time">
+                      {{ module.estimated_minutes }} min
+                    </span>
+                  </div>
+
+                  <h3>{{ module.hs_name }}</h3>
+
+                  {% if module.meta_description %}
+                    <p>{{ module.meta_description|striptags|truncate(150) }}</p>
+                  {% endif %}
+
+                  {% if module.tags %}
+                    <div class="module-tags">
+                      {% set tag_list = module.tags.split(',') %}
+                      {% for tag in tag_list %}
+                        {% if tag|lower|trim != 'archived' %}
+                          <span class="module-tag">{{ tag|trim }}</span>
+                        {% endif %}
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+
+                  <span class="module-cta">View Module →</span>
+                </a>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% else %}
+            <p>No learning modules have been added yet.</p>
+          {% endif %}
+        {% else %}
+          <p><em>This is a preview. Content will populate once this template is used on a dynamic page connected to a HubDB table.</em></p>
+        {% endif %}
+      </div>
+    </div>
+    {# Cognito auth context for nav auth state on list pages #}
+    {#
+      Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+      HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+      Source: clean-x-hedgehog-templates/config/constants.json
+    #}
+    
+    {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+    {% set login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+    {% set logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+    <div
+      id="hhl-auth-context"
+      data-auth-me-url="{{ auth_me_url }}"
+      data-auth-login-url="{{ login_url }}"
+      data-auth-logout-url="{{ logout_url }}"
+      data-track-events-url="https://api.hedgehog.cloud/events/track"
+      data-enable-crm="true"
+      style="display:none"
+    ></div>
+    <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+  {% endif %}
+</main>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/my-learning.html
+++ b/clean-x-hedgehog-templates/learn-shadow/my-learning.html
@@ -7,6 +7,9 @@
 
 {% block head %}
   {{ super() }}
+
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
   {# SEO metadata for My Learning dashboard #}
   {#
     Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
@@ -31,13 +34,13 @@
 
   <title>My Learning - Learn Hedgehog AI Networking</title>
   <meta name="description" content="Track your learning progress with Hedgehog AI networking modules. View your started and completed modules in one place.">
-  <link rel="canonical" href="https://{{ request.domain }}/learn/my-learning">
+  <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/my-learning">
 
   {# Open Graph tags #}
   <meta property="og:type" content="website">
   <meta property="og:title" content="My Learning - Learn Hedgehog AI Networking">
   <meta property="og:description" content="Track your learning progress with Hedgehog AI networking modules. View your started and completed modules in one place.">
-  <meta property="og:url" content="https://{{ request.domain }}/learn/my-learning">
+  <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/my-learning">
   <meta property="og:image" content="{{ social_image }}">
 
   {# Twitter Card tags #}
@@ -569,7 +572,7 @@
           <div class="empty-state-icon">📚</div>
           <h2>Start Your Learning Journey</h2>
           <p>You haven't started any modules yet. Explore our pathways and courses to begin learning!</p>
-          <a href="/learn/pathways" class="empty-state-cta">Explore Pathways</a>
+          <a href="/learn-shadow/pathways" class="empty-state-cta">Explore Pathways</a>
         </div>
       </div>
       </div>

--- a/clean-x-hedgehog-templates/learn-shadow/my-learning.html
+++ b/clean-x-hedgehog-templates/learn-shadow/my-learning.html
@@ -1,0 +1,604 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+{% from "/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html" import learning_left_nav %}
+
+{% block head %}
+  {{ super() }}
+  {# SEO metadata for My Learning dashboard #}
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+  {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
+
+  <title>My Learning - Learn Hedgehog AI Networking</title>
+  <meta name="description" content="Track your learning progress with Hedgehog AI networking modules. View your started and completed modules in one place.">
+  <link rel="canonical" href="https://{{ request.domain }}/learn/my-learning">
+
+  {# Open Graph tags #}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="My Learning - Learn Hedgehog AI Networking">
+  <meta property="og:description" content="Track your learning progress with Hedgehog AI networking modules. View your started and completed modules in one place.">
+  <meta property="og:url" content="https://{{ request.domain }}/learn/my-learning">
+  <meta property="og:image" content="{{ social_image }}">
+
+  {# Twitter Card tags #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="My Learning - Learn Hedgehog AI Networking">
+  <meta name="twitter:description" content="Track your learning progress with Hedgehog AI networking modules. View your started and completed modules in one place.">
+  <meta name="twitter:image" content="{{ social_image }}">
+
+  {# Left navigation styles and scripts #}
+  <link rel="stylesheet" href="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css') }}">
+  <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js') }}" defer></script>
+{% endblock head %}
+
+{% block body %}
+{# Issue #345: Cognito handles auth client-side, no server-side redirect #}
+<style>
+  /* Header section styling */
+  .learn-header-section {
+    width: 100vw;
+    background: #1a4e8a url('https://hedgehog.cloud/hubfs/hh-clouds.webp') center center/cover no-repeat;
+    color: #fff;
+    padding: 96px 0 64px 0;
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+  .learn-header-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+  }
+  .learn-page-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -1px;
+  }
+  .learn-page-subtitle {
+    font-size: 1.2rem;
+    font-weight: 400;
+    margin: 0;
+    opacity: 0.9;
+  }
+
+  /* Main content section */
+  .learn-main-section {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0;
+    min-height: 60vh;
+  }
+  .learn-container {
+    max-width: 1600px;
+    width: 100%;
+    background: #fff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 2px 24px rgba(26,78,138,0.06);
+    min-height: 60vh;
+  }
+
+  /* Progress summary section */
+  .progress-summary {
+    background: linear-gradient(135deg, #EFF6FF 0%, #DBEAFE 100%);
+    border: 1px solid #BFDBFE;
+    border-radius: 12px;
+    padding: 32px;
+    margin-bottom: 40px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+  .progress-stats {
+    display: flex;
+    gap: 48px;
+  }
+  .progress-stat {
+    text-align: center;
+  }
+  .progress-stat-number {
+    font-size: 3rem;
+    font-weight: 700;
+    color: #1a4e8a;
+    line-height: 1;
+    margin-bottom: 8px;
+  }
+  .progress-stat-label {
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #0369a1;
+    font-weight: 600;
+  }
+  .auth-prompt {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-radius: 8px;
+    padding: 16px 20px;
+    font-size: 0.875rem;
+    color: #78350f;
+    display: none;
+  }
+  .auth-prompt a {
+    color: #92400e;
+    font-weight: 600;
+    text-decoration: underline;
+  }
+  .synced-indicator {
+    background: #D1FAE5;
+    border: 1px solid #6EE7B7;
+    border-radius: 8px;
+    padding: 16px 20px;
+    font-size: 0.875rem;
+    color: #065F46;
+    display: none;
+    align-items: center;
+    gap: 8px;
+  }
+  .synced-indicator-icon {
+    font-size: 1.125rem;
+  }
+
+  /* Section headers */
+  .section-header {
+    margin: 48px 0 24px 0;
+    padding-bottom: 16px;
+    border-bottom: 2px solid #E5E7EB;
+  }
+  .section-header h2 {
+    margin: 0;
+    font-size: 1.75rem;
+    color: #111827;
+    font-weight: 700;
+  }
+  .section-header .section-count {
+    color: #666;
+    font-size: 1rem;
+    font-weight: 400;
+    margin-left: 12px;
+  }
+
+  /* Enrollment cards */
+  .enrolled-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
+  }
+  .enrollment-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    background: #fff;
+    transition: box-shadow 0.2s, transform 0.2s;
+  }
+  .enrollment-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .enrollment-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 16px;
+    gap: 12px;
+  }
+  .enrollment-card-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    flex: 1;
+  }
+  .enrollment-badge {
+    background: #DBEAFE;
+    color: #1E40AF;
+    padding: 4px 12px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+  }
+  .enrollment-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 16px;
+    font-size: 0.875rem;
+    color: #666;
+  }
+  .enrollment-meta strong {
+    color: #374151;
+  }
+  .enrollment-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  .enrollment-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.2s;
+  }
+  .enrollment-cta:hover {
+    color: #0052A3;
+  }
+
+  /* Enrollment progress bar */
+  .enrollment-progress {
+    margin: 16px 0;
+  }
+  .enrollment-progress-label {
+    font-size: 0.875rem;
+    color: #374151;
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  .enrollment-progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #E5E7EB;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  .enrollment-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #1a4e8a 0%, #2563EB 100%);
+    transition: width 0.3s ease;
+    border-radius: 4px;
+  }
+
+  /* Enrollment module list (collapsible) */
+  .enrollment-modules-toggle {
+    margin: 16px 0;
+    border: 1px solid #E5E7EB;
+    border-radius: 6px;
+    background: #F9FAFB;
+  }
+  .enrollment-modules-summary {
+    padding: 12px 16px;
+    cursor: pointer;
+    font-weight: 600;
+    color: #1a4e8a;
+    user-select: none;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .enrollment-modules-summary::-webkit-details-marker {
+    display: none;
+  }
+  .enrollment-modules-summary::marker {
+    display: none;
+  }
+  .enrollment-modules-summary::before {
+    content: '▶';
+    font-size: 0.75rem;
+    transition: transform 0.2s;
+    display: inline-block;
+  }
+  .enrollment-modules-toggle[open] .enrollment-modules-summary::before {
+    transform: rotate(90deg);
+  }
+  .enrollment-modules-summary:hover {
+    background: #F3F4F6;
+  }
+  .enrollment-modules-list {
+    padding: 0 16px 12px 16px;
+    border-top: 1px solid #E5E7EB;
+  }
+  .enrollment-module-item {
+    padding: 10px 0;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 1px solid #F3F4F6;
+  }
+  .enrollment-module-item:last-child {
+    border-bottom: none;
+  }
+  .enrollment-module-status {
+    font-size: 1.125rem;
+    width: 24px;
+    text-align: center;
+    flex-shrink: 0;
+  }
+  .enrollment-module-item.completed .enrollment-module-status {
+    color: #059669;
+  }
+  .enrollment-module-item.in-progress .enrollment-module-status {
+    color: #2563EB;
+  }
+  .enrollment-module-item.not-started .enrollment-module-status {
+    color: #9CA3AF;
+  }
+  .enrollment-module-link {
+    color: #374151;
+    text-decoration: none;
+    flex: 1;
+    font-size: 0.9375rem;
+    transition: color 0.2s;
+  }
+  .enrollment-module-link:hover {
+    color: #1a4e8a;
+    text-decoration: underline;
+  }
+
+  /* Module cards */
+  .modules-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 24px;
+  }
+  .module-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+    background: #fff;
+  }
+  .module-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .module-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+  .module-progress-badge {
+    background: #EFF6FF;
+    color: #1a4e8a;
+    padding: 6px 12px;
+    border-radius: 12px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .module-progress-badge.completed {
+    background: #D1FAE5;
+    color: #065F46;
+  }
+  .module-time {
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .module-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+  }
+  .module-card p {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .module-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Empty state */
+  .empty-state {
+    text-align: center;
+    padding: 80px 40px;
+    color: #666;
+  }
+  .empty-state-icon {
+    font-size: 4rem;
+    margin-bottom: 24px;
+    opacity: 0.3;
+  }
+  .empty-state h2 {
+    font-size: 1.75rem;
+    color: #111827;
+    margin: 0 0 16px 0;
+  }
+  .empty-state p {
+    font-size: 1.125rem;
+    margin: 0 0 32px 0;
+    line-height: 1.6;
+  }
+  .empty-state-cta {
+    display: inline-block;
+    background: #1a4e8a;
+    color: #fff;
+    padding: 12px 32px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1rem;
+    transition: background 0.2s, transform 0.2s;
+  }
+  .empty-state-cta:hover {
+    background: #154171;
+    transform: translateY(-2px);
+  }
+
+  /* Loading state */
+  .loading-state {
+    text-align: center;
+    padding: 80px 40px;
+    color: #666;
+  }
+  .loading-spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid #E5E7EB;
+    border-top-color: #1a4e8a;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 24px;
+  }
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  @media (max-width: 900px) {
+    .learn-header-content, .learn-container {
+      padding: 0 16px;
+    }
+    .modules-grid, .enrolled-grid {
+      grid-template-columns: 1fr;
+    }
+    .progress-summary {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .progress-stats {
+      gap: 32px;
+    }
+  }
+</style>
+
+<main id="main-content">
+  <section class="learn-header-section">
+    <div class="learn-header-content">
+      <h1 class="learn-page-title">My Learning</h1>
+      <p class="learn-page-subtitle">Track your progress and pick up where you left off.</p>
+    </div>
+  </section>
+
+  <div class="learn-layout-with-nav">
+    {{ learning_left_nav('my-learning', show_filters=false) }}
+    <div class="learn-main-content">
+      <div class="learn-container">
+      <!-- Loading state (shown initially) -->
+      <div id="loading-state" class="loading-state">
+        <div class="loading-spinner"></div>
+        <p>Loading your progress...</p>
+      </div>
+
+      <!-- Main content (hidden until loaded) -->
+      <div id="main-content-container" style="display: none;">
+        <!-- Progress Summary -->
+        <div class="progress-summary">
+          <div class="progress-stats">
+            <div class="progress-stat">
+              <div class="progress-stat-number" id="stat-in-progress">0</div>
+              <div class="progress-stat-label">In Progress</div>
+            </div>
+            <div class="progress-stat">
+              <div class="progress-stat-number" id="stat-completed">0</div>
+              <div class="progress-stat-label">Completed</div>
+            </div>
+          </div>
+          {# Issue #345: Auth state and prompts driven by Cognito JS client-side #}
+          <div class="synced-indicator" style="display: none;">
+            <span class="synced-indicator-icon">✓</span>
+            <span>Progress synced across devices</span>
+          </div>
+          <div class="auth-prompt" id="auth-prompt" style="display: none;">
+            ℹ️ Progress is saved locally in your browser. <a href="{{ constants.AUTH_LOGIN_URL }}?redirect_url={{ request.path_and_query|urlencode }}">Sign in</a> to sync across devices.
+          </div>
+        </div>
+
+        <!-- Resume Panel (authenticated only) -->
+        <div id="last-viewed-panel" style="display:none; margin: 16px 0 8px 0; padding: 12px 16px; border:1px solid #E5E7EB; border-radius:8px; background:#F9FAFB;">
+          <span style="color:#374151; font-weight:600;">Resume: </span>
+          <a id="last-viewed-link" href="#" style="color:#0066CC; font-weight:600; text-decoration:none;"></a>
+          <span id="last-viewed-meta" style="color:#6B7280; margin-left:8px;"></span>
+        </div>
+
+        <!-- Enrolled Content Section (authenticated only) -->
+        <section id="enrolled-section" style="display: none;">
+          <div class="section-header">
+            <h2>My Enrollments <span class="section-count" id="enrolled-count">(0)</span></h2>
+          </div>
+          <div class="enrolled-grid" id="enrolled-grid"></div>
+        </section>
+
+        <!-- In Progress Section -->
+        <section id="in-progress-section" style="display: none;">
+          <div class="section-header">
+            <h2>In Progress <span class="section-count" id="in-progress-count">(0)</span></h2>
+          </div>
+          <div class="modules-grid" id="in-progress-modules"></div>
+        </section>
+
+        <!-- Completed Section -->
+        <section id="completed-section" style="display: none;">
+          <div class="section-header">
+            <h2>Completed <span class="section-count" id="completed-count">(0)</span></h2>
+          </div>
+          <div class="modules-grid" id="completed-modules"></div>
+        </section>
+
+        <!-- Empty State -->
+        <div id="empty-state" class="empty-state" style="display: none;">
+          <div class="empty-state-icon">📚</div>
+          <h2>Start Your Learning Journey</h2>
+          <p>You haven't started any modules yet. Explore our pathways and courses to begin learning!</p>
+          <a href="/learn/pathways" class="empty-state-cta">Explore Pathways</a>
+        </div>
+      </div>
+      </div>
+    </div>
+  </div>
+</main>
+
+{# Auth context for external JS and constants URL (Issue #272 - Native HubSpot membership only) #}
+{#
+  Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+  HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+  Source: clean-x-hedgehog-templates/config/constants.json
+#}
+
+{# Issue #345: Cognito auth context with inlined constants #}
+{% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+{% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+{% set auth_logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+<div id="hhl-auth-context"
+     data-auth-me-url="{{ auth_me_url }}"
+     data-auth-login-url="{{ auth_login_url }}"
+     data-auth-logout-url="{{ auth_logout_url }}"
+     data-enable-crm="true"
+     data-track-events-url="https://api.hedgehog.cloud/events/track"
+     data-hubdb-courses-table-id="135381433"
+     data-hubdb-modules-table-id="135621904"
+     style="display:none"></div>
+<script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/login-helper.js') }}"></script>
+{# Line 609 - Cognito auth replaces membership auth (Issue #345) - NO defer to load before my-learning.js #}
+<script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+<script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/my-learning.js') }}"></script>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
@@ -8,6 +8,9 @@
 {% block head %}
   {{ super() }}
 
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
   {#
     Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
     HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
@@ -35,7 +38,7 @@
     {# SEO metadata for pathway detail pages #}
     {% set page_title = dynamic_page_hubdb_row.hs_name ~ " - Pathways - Learn Hedgehog" %}
     {% set meta_desc = dynamic_page_hubdb_row.meta_description|striptags|truncate(160) if dynamic_page_hubdb_row.meta_description else (dynamic_page_hubdb_row.summary_markdown|striptags|truncate(160) if dynamic_page_hubdb_row.summary_markdown else "Learn " ~ dynamic_page_hubdb_row.hs_name) %}
-    {% set canonical_url = "https://" ~ request.domain ~ "/learn/pathways/" ~ dynamic_page_hubdb_row.hs_path %}
+    {% set canonical_url = "https://" ~ request.domain ~ "/learn-shadow/pathways/" ~ dynamic_page_hubdb_row.hs_path %}
     {% set social_image = dynamic_page_hubdb_row.social_image_url if dynamic_page_hubdb_row.social_image_url else constants.DEFAULT_SOCIAL_IMAGE_URL %}
 
     <title>{{ page_title }}</title>
@@ -65,7 +68,7 @@
       {% if dynamic_page_hubdb_row.meta_description or dynamic_page_hubdb_row.summary_markdown %}
       "description": {{ meta_desc|tojson }},
       {% endif %}
-      "url": "https://{{ request.domain }}/learn/pathways/{{ dynamic_page_hubdb_row.hs_path }}",
+      "url": "https://{{ request.domain }}/learn-shadow/pathways/{{ dynamic_page_hubdb_row.hs_path }}",
       {% if dynamic_page_hubdb_row.module_count %}
       "numberOfItems": {{ dynamic_page_hubdb_row.module_count }},
       {% endif %}
@@ -102,7 +105,7 @@
           "item": {
             "@type": "Course",
             "name": {{ (course.hs_name if course else slug|replace('-',' ')|title)|tojson }},
-            "url": "https://{{ request.domain }}/learn/courses/{{ (course.hs_path if course else slug) }}"
+            "url": "https://{{ request.domain }}/learn-shadow/courses/{{ (course.hs_path if course else slug) }}"
           }
         }{% if not loop.last %},{% endif %}
             {% endfor %}
@@ -132,7 +135,7 @@
           "item": {
             "@type": "LearningResource",
             "name": {{ module.hs_name|tojson }},
-            "url": "https://{{ request.domain }}/learn/modules/{{ module.hs_path }}"
+            "url": "https://{{ request.domain }}/learn-shadow/modules/{{ module.hs_path }}"
           }
         }{% if not loop.last %},{% endif %}
             {% endif %}
@@ -158,7 +161,7 @@
           "@type": "ListItem",
           "position": 2,
           "name": "Pathways",
-          "item": "https://{{ request.domain }}/learn/pathways"
+          "item": "https://{{ request.domain }}/learn-shadow/pathways"
         },
         {
           "@type": "ListItem",
@@ -178,13 +181,13 @@
 
     <title>Learning Pathways - Learn Hedgehog AI Networking</title>
     <meta name="description" content="Follow structured learning paths to master Hedgehog AI networking concepts step-by-step through curated courses and modules.">
-    <link rel="canonical" href="https://{{ request.domain }}/learn/pathways">
+    <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/pathways">
 
     {# Open Graph tags #}
     <meta property="og:type" content="website">
     <meta property="og:title" content="Learning Pathways - Learn Hedgehog AI Networking">
     <meta property="og:description" content="Follow structured learning paths to master Hedgehog AI networking concepts step-by-step through curated courses and modules.">
-    <meta property="og:url" content="https://{{ request.domain }}/learn/pathways">
+    <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/pathways">
     <meta property="og:image" content="{{ social_image }}">
 
     {# Twitter Card tags #}
@@ -221,7 +224,7 @@
           "item": {
             "@type": "ItemList",
             "name": {{ pathway.hs_name|tojson }},
-            "url": "https://{{ request.domain }}/learn/pathways/{{ pathway.hs_path }}"
+            "url": "https://{{ request.domain }}/learn-shadow/pathways/{{ pathway.hs_path }}"
             {% if pathway.summary_markdown %}
             ,"description": {{ pathway.summary_markdown|striptags|truncate(160)|tojson }}
             {% endif %}
@@ -617,7 +620,7 @@
         <div class="pathway-detail">
           <!-- Breadcrumbs -->
           <nav class="pathway-breadcrumbs">
-            <a href="/learn/pathways">← Back to Learning Pathways</a>
+            <a href="/learn-shadow/pathways">← Back to Learning Pathways</a>
           </nav>
 
           <!-- Pathway Header -->
@@ -840,7 +843,7 @@
                     {# Defensive fallback: create a minimal object if lookup failed #}
                     {% set course = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
                   {% endif %}
-                    <a href="/learn/courses/{{ (course.hs_path if course else slug) }}" class="module-card">
+                    <a href="/learn-shadow/courses/{{ (course.hs_path if course else slug) }}" class="module-card">
                       <div class="module-card-number">{{ loop.index }}</div>
                       <h3>{{ course.hs_name if course else (slug|replace('-',' ')|title) }}</h3>
 
@@ -868,7 +871,7 @@
             {# Fallback: Render modules list - OPTIMIZATION: Batch-fetch to avoid 10-call limit #}
             <section class="pathway-modules-section">
               <h2>Learning Modules</h2>
-              {% set modules_base_path = '/learn/modules' %}
+              {% set modules_base_path = '/learn-shadow/modules' %}
               {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
               {# Fetch all modules in ONE query using hs_path__in operator #}
               {% set slug_list = module_slugs|join(',') %}

--- a/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
@@ -1,0 +1,1031 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+{% from "/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html" import learning_left_nav %}
+
+{% block head %}
+  {{ super() }}
+
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Defined in shared scope so both detail and list views can access.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'LOGOUT_URL': '/_hcms/mem/logout',
+    'LOGIN_URL': '/_hcms/mem/login',
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+
+  {% if dynamic_page_hubdb_row %}
+    {# SEO metadata for pathway detail pages #}
+    {% set page_title = dynamic_page_hubdb_row.hs_name ~ " - Pathways - Learn Hedgehog" %}
+    {% set meta_desc = dynamic_page_hubdb_row.meta_description|striptags|truncate(160) if dynamic_page_hubdb_row.meta_description else (dynamic_page_hubdb_row.summary_markdown|striptags|truncate(160) if dynamic_page_hubdb_row.summary_markdown else "Learn " ~ dynamic_page_hubdb_row.hs_name) %}
+    {% set canonical_url = "https://" ~ request.domain ~ "/learn/pathways/" ~ dynamic_page_hubdb_row.hs_path %}
+    {% set social_image = dynamic_page_hubdb_row.social_image_url if dynamic_page_hubdb_row.social_image_url else constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    <title>{{ page_title }}</title>
+    <meta name="description" content="{{ meta_desc }}">
+    <link rel="canonical" href="{{ canonical_url }}">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="{{ page_title }}">
+    <meta property="og:description" content="{{ meta_desc }}">
+    <meta property="og:url" content="{{ canonical_url }}">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ page_title }}">
+    <meta name="twitter:description" content="{{ meta_desc }}">
+    <meta name="twitter:image" content="{{ social_image }}">
+
+    {# JSON-LD structured data for pathway detail #}
+    {# Note: Pathways are collections, so we use ItemList type #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": {{ dynamic_page_hubdb_row.hs_name|tojson }},
+      {% if dynamic_page_hubdb_row.meta_description or dynamic_page_hubdb_row.summary_markdown %}
+      "description": {{ meta_desc|tojson }},
+      {% endif %}
+      "url": "https://{{ request.domain }}/learn/pathways/{{ dynamic_page_hubdb_row.hs_path }}",
+      {% if dynamic_page_hubdb_row.module_count %}
+      "numberOfItems": {{ dynamic_page_hubdb_row.module_count }},
+      {% endif %}
+      "itemListElement": [
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% if dynamic_page_hubdb_row.course_slugs_json and constants.HUBDB_COURSES_TABLE_ID %}
+            {# Pathway contains courses - OPTIMIZATION: Batch-fetch to avoid 10-call limit #}
+            {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID %}
+            {% set course_slugs = dynamic_page_hubdb_row.course_slugs_json|fromjson %}
+            {% set slug_list = course_slugs|join(',') %}
+            {# HubL does not support __in on TEXT columns reliably; build list via per-slug hs_path__eq #}
+            {% set all_courses = [] %}
+            {% for slug in course_slugs %}
+              {% set rows = hubdb_table_rows(courses_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+              {% if rows %}
+                {% set all_courses = all_courses + rows %}
+              {% endif %}
+            {% endfor %}
+            {# Create lookup dictionary keyed by hs_path #}
+            {% set courses_by_slug = {} %}
+            {% for crs in all_courses %}
+              {% set _ = courses_by_slug.update({crs.hs_path: crs}) %}
+            {% endfor %}
+            {% for slug in course_slugs %}
+              {% set course = courses_by_slug[slug] %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "item": {
+            "@type": "Course",
+            "name": {{ (course.hs_name if course else slug|replace('-',' ')|title)|tojson }},
+            "url": "https://{{ request.domain }}/learn/courses/{{ (course.hs_path if course else slug) }}"
+          }
+        }{% if not loop.last %},{% endif %}
+            {% endfor %}
+        {% elif dynamic_page_hubdb_row.module_slugs_json and constants.HUBDB_MODULES_TABLE_ID %}
+          {# Pathway contains modules - OPTIMIZATION: Batch-fetch to avoid 10-call limit #}
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID %}
+          {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+          {% set slug_list = module_slugs|join(',') %}
+          {% set all_modules = [] %}
+          {% for slug in module_slugs %}
+            {% set rows = hubdb_table_rows(modules_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+            {% if rows %}
+              {% set all_modules = all_modules + rows %}
+            {% endif %}
+          {% endfor %}
+          {# Create lookup dictionary keyed by hs_path #}
+          {% set modules_by_slug = {} %}
+          {% for mod in all_modules %}
+            {% set _ = modules_by_slug.update({mod.hs_path: mod}) %}
+          {% endfor %}
+          {% for slug in module_slugs %}
+            {% set module = modules_by_slug[slug] %}
+            {% if module %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "item": {
+            "@type": "LearningResource",
+            "name": {{ module.hs_name|tojson }},
+            "url": "https://{{ request.domain }}/learn/modules/{{ module.hs_path }}"
+          }
+        }{% if not loop.last %},{% endif %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      ]
+    }
+    </script>
+
+    {# BreadcrumbList JSON-LD #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Learn",
+          "item": "https://{{ request.domain }}/learn"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Pathways",
+          "item": "https://{{ request.domain }}/learn/pathways"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": {{ dynamic_page_hubdb_row.hs_name|tojson }}
+        }
+      ]
+    }
+    </script>
+  {% else %}
+    {# SEO metadata for pathways list page #}
+    {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL %}
+
+    {# Left nav CSS and JS for list pages #}
+    {{ require_css(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css')) }}
+    {{ require_js(get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js'), { position: 'footer', defer: true }) }}
+
+    <title>Learning Pathways - Learn Hedgehog AI Networking</title>
+    <meta name="description" content="Follow structured learning paths to master Hedgehog AI networking concepts step-by-step through curated courses and modules.">
+    <link rel="canonical" href="https://{{ request.domain }}/learn/pathways">
+
+    {# Open Graph tags #}
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Learning Pathways - Learn Hedgehog AI Networking">
+    <meta property="og:description" content="Follow structured learning paths to master Hedgehog AI networking concepts step-by-step through curated courses and modules.">
+    <meta property="og:url" content="https://{{ request.domain }}/learn/pathways">
+    <meta property="og:image" content="{{ social_image }}">
+
+    {# Twitter Card tags #}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Learning Pathways - Learn Hedgehog AI Networking">
+    <meta name="twitter:description" content="Follow structured learning paths to master Hedgehog AI networking concepts step-by-step through curated courses and modules.">
+    <meta name="twitter:image" content="{{ social_image }}">
+
+    {# JSON-LD structured data for pathways list #}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "name": "Learning Pathways",
+      "description": "Hedgehog AI Networking learning pathways",
+      "itemListElement": [
+        {# Prefer dynamic table binding; fallback to constants and finally hardcoded ID #}
+        {% set pathways_table_id = dynamic_page_hubdb_table_id %}
+        {% if not pathways_table_id %}
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% set pathways_table_id = constants.HUBDB_PATHWAYS_TABLE_ID %}
+        {% endif %}
+        {% if pathways_table_id %}
+          {% set pathways = hubdb_table_rows(pathways_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% for pathway in pathways %}
+        {
+          "@type": "ListItem",
+          "position": {{ loop.index }},
+          "item": {
+            "@type": "ItemList",
+            "name": {{ pathway.hs_name|tojson }},
+            "url": "https://{{ request.domain }}/learn/pathways/{{ pathway.hs_path }}"
+            {% if pathway.summary_markdown %}
+            ,"description": {{ pathway.summary_markdown|striptags|truncate(160)|tojson }}
+            {% endif %}
+            {% if pathway.module_count %}
+            ,"numberOfItems": {{ pathway.module_count }}
+            {% endif %}
+          }
+        }{% if not loop.last %},{% endif %}
+          {% endfor %}
+        {% endif %}
+      ]
+    }
+    </script>
+  {% endif %}
+{% endblock head %}
+
+{% block body %}
+<style>
+  /* Header section styling */
+  .learn-header-section {
+    width: 100vw;
+    background: #1a4e8a url('https://hedgehog.cloud/hubfs/hh-clouds.webp') center center/cover no-repeat;
+    color: #fff;
+    padding: 96px 0 64px 0;
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+  .learn-header-content {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 0 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    text-align: center;
+  }
+  .learn-page-title {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    letter-spacing: -1px;
+  }
+  .learn-page-subtitle {
+    font-size: 1.2rem;
+    font-weight: 400;
+    margin: 0;
+    opacity: 0.9;
+  }
+  .learn-header-nav {
+    display: flex;
+    gap: 24px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .learn-header-nav a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: background 0.2s;
+  }
+  .learn-header-nav a:hover {
+    background: rgba(255, 255, 255, 0.15);
+  }
+  .auth-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .user-greeting {
+    color: #fff;
+    font-size: 0.875rem;
+    opacity: 0.9;
+  }
+  .auth-link {
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+    padding: 6px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 6px;
+    transition: all 0.2s;
+  }
+  .auth-link:hover {
+    background: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.5);
+  }
+
+  /* Main content section */
+  .learn-main-section {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0;
+    min-height: 60vh;
+  }
+  .learn-container {
+    max-width: 1600px;
+    width: 100%;
+    background: #fff;
+    padding: 40px;
+    border-radius: 12px;
+    box-shadow: 0 2px 24px rgba(26,78,138,0.06);
+    min-height: 60vh;
+  }
+
+  /* Pathway grid (list view) */
+  .pathways-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+    margin-top: 32px;
+  }
+  .pathway-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+  }
+  .pathway-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .pathway-card h2 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+  }
+  .pathway-card-summary {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .pathway-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    color: #666;
+    font-size: 0.875rem;
+    margin-bottom: 16px;
+  }
+  .pathway-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .pathway-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Pathway detail view */
+  .pathway-detail {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  .pathway-breadcrumbs {
+    padding: 16px 0;
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .pathway-breadcrumbs a {
+    color: #0066CC;
+    text-decoration: none;
+  }
+  .pathway-detail-header {
+    margin: 32px 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid #E5E7EB;
+  }
+  .pathway-detail-header h1 {
+    margin: 0 0 16px 0;
+    color: #1a4e8a;
+  }
+  .pathway-summary {
+    line-height: 1.8;
+    font-size: 1.0625rem;
+    margin: 32px 0;
+    padding: 24px;
+    background: #F9FAFB;
+    border-left: 4px solid #1a4e8a;
+    border-radius: 4px;
+  }
+
+  /* Module/Course list section */
+  .pathway-modules-section {
+    margin-top: 48px;
+  }
+  .pathway-modules-section h2 {
+    margin: 0 0 24px 0;
+    font-size: 1.75rem;
+    color: #111827;
+  }
+  .modules-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 24px;
+  }
+  .module-card {
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    padding: 24px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+    position: relative;
+  }
+  .module-card:hover {
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-2px);
+  }
+  .module-card-number {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: #1a4e8a;
+    color: #fff;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.875rem;
+  }
+  .module-card h3 {
+    margin: 0 0 12px 0;
+    font-size: 1.25rem;
+    color: #1a4e8a;
+    padding-right: 40px;
+  }
+  .module-card p {
+    color: #666;
+    margin: 0 0 16px 0;
+    line-height: 1.6;
+  }
+  .module-time {
+    color: #666;
+    font-size: 0.875rem;
+  }
+  .module-cta {
+    color: #0066CC;
+    text-decoration: none;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* Progress tracker */
+  .pathway-progress {
+    background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+    border: 1px solid #bae6fd;
+    border-radius: 8px;
+    padding: 20px 24px;
+    margin: 24px 0;
+  }
+  .progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+  .progress-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #0c4a6e;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .progress-stats {
+    display: flex;
+    gap: 16px;
+    font-size: 0.875rem;
+    color: #0369a1;
+  }
+  .progress-stat {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .progress-stat strong {
+    font-weight: 700;
+    color: #0c4a6e;
+  }
+  .progress-bar-container {
+    background: #ffffff;
+    border-radius: 8px;
+    height: 8px;
+    overflow: hidden;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
+  }
+  .progress-bar {
+    background: linear-gradient(90deg, #0ea5e9 0%, #0284c7 100%);
+    height: 100%;
+    border-radius: 8px;
+    transition: width 0.3s ease;
+  }
+  .progress-auth-prompt {
+    margin-top: 12px;
+    padding: 12px 16px;
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    color: #78350f;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .progress-auth-prompt a {
+    color: #92400e;
+    font-weight: 600;
+    text-decoration: underline;
+  }
+
+  /* Enrollment CTA Block */
+  .enrollment-cta-block {
+    background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+    border: 2px solid #0284c7;
+    border-radius: 12px;
+    padding: 24px;
+    margin: 24px 0;
+    text-align: center;
+  }
+  .enrollment-cta-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #0c4a6e;
+    margin: 0 0 12px 0;
+  }
+  .enrollment-cta-description {
+    font-size: 0.9375rem;
+    color: #0369a1;
+    margin: 0 0 20px 0;
+    line-height: 1.6;
+  }
+  .enrollment-button {
+    display: inline-block;
+    background: #1a4e8a;
+    color: #fff;
+    padding: 14px 32px;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 1rem;
+    border: none;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+    text-decoration: none;
+  }
+  .enrollment-button:hover:not(:disabled) {
+    background: #154171;
+    transform: translateY(-2px);
+  }
+  .enrollment-button:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 900px) {
+    .learn-header-content, .learn-container {
+      padding: 0 16px;
+    }
+    .pathways-grid, .modules-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+
+<main id="main-content">
+  {% if dynamic_page_hubdb_row %}
+    {# Detail mode - showing a single pathway #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        {# Omit a visible H1 in the hero on detail pages to avoid duplicates #}
+      </div>
+    </section>
+
+    <section class="learn-main-section">
+      <div class="learn-container">
+        <div class="pathway-detail">
+          <!-- Breadcrumbs -->
+          <nav class="pathway-breadcrumbs">
+            <a href="/learn/pathways">← Back to Learning Pathways</a>
+          </nav>
+
+          <!-- Pathway Header -->
+          <header class="pathway-detail-header">
+            <h1>{{ dynamic_page_hubdb_row.hs_name }}</h1>
+            <div class="pathway-meta">
+              {% if dynamic_page_hubdb_row.course_slugs_json %}
+                {% set course_count = dynamic_page_hubdb_row.course_slugs_json|fromjson|length %}
+                <span class="pathway-meta-item">
+                  <strong>{{ course_count }}</strong> course{% if course_count != 1 %}s{% endif %}
+                </span>
+              {% elif dynamic_page_hubdb_row.module_count %}
+                <span class="pathway-meta-item">
+                  <strong>{{ dynamic_page_hubdb_row.module_count }}</strong> module{% if dynamic_page_hubdb_row.module_count != 1 %}s{% endif %}
+                </span>
+              {% endif %}
+              {% if dynamic_page_hubdb_row.total_estimated_minutes %}
+                <span class="pathway-meta-item">
+                  <strong>{{ dynamic_page_hubdb_row.total_estimated_minutes }}</strong> minutes total
+                </span>
+              {% endif %}
+            </div>
+          </header>
+
+          <!-- Enrollment CTA Block -->
+          {# Issue #345: Server renders login link - Cognito JS upgrades to button if authenticated #}
+          {% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+          <div class="enrollment-cta-block" id="hhl-enrollment-cta">
+            <div class="enrollment-cta-title">Ready to Begin This Learning Pathway?</div>
+            <div class="enrollment-cta-description">
+              Enroll to track your progress and receive personalized recommendations as you work through this pathway.
+            </div>
+            {# Server always renders login link; enrollment.js upgrades to button if Cognito authenticated #}
+            <a class="enrollment-button"
+               id="hhl-enroll-login"
+               href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}">
+              Sign in to enroll
+            </a>
+            <p class="enrollment-cta-helper" id="hhl-enroll-helper" aria-live="polite">
+              Already registered? <a href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}">Sign in</a> to continue.
+            </p>
+          </div>
+
+          <!-- Progress Tracker -->
+          <div class="pathway-progress" id="pathway-progress">
+            <div class="progress-header">
+              <div class="progress-title">Your Progress</div>
+              <div class="progress-stats">
+                <div class="progress-stat">
+                  <span>Started: <strong id="progress-started">0</strong></span>
+                </div>
+                <div class="progress-stat">
+                  <span>Completed: <strong id="progress-completed">0</strong></span>
+                </div>
+              </div>
+            </div>
+            <div class="progress-bar-container">
+              <div class="progress-bar" id="progress-bar" style="width: 0%"></div>
+            </div>
+            {#
+              Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+              HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+              Source: clean-x-hedgehog-templates/config/constants.json
+            #}
+            {% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+            <div class="progress-auth-prompt" style="display: none;" id="auth-prompt">
+              ℹ️ Progress is saved locally. <a href="{{ auth_login_url }}?redirect_url={{ request.path_and_query|urlencode }}">Sign in</a> to sync across devices.
+            </div>
+          </div>
+
+          {# Auth context for JS (Issue #345 - Cognito auth with inlined constants) #}
+          {# module_count is now precomputed in the sync script for both module-based and course-based pathways #}
+          {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+          {% set auth_logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+          <div id="hhl-auth-context"
+               data-auth-me-url="{{ auth_me_url }}"
+               data-auth-login-url="{{ auth_login_url }}"
+               data-auth-logout-url="{{ auth_logout_url }}"
+               data-enable-crm="true"
+               data-track-events-url="https://api.hedgehog.cloud/events/track"
+               data-pathway-slug="{{ dynamic_page_hubdb_row.hs_path }}"
+               data-total-modules="{{ dynamic_page_hubdb_row.module_count|default(0) }}"
+               style="display:none"></div>
+          {# Line 696 - auth-context.js REMOVED (Issue #345: Cognito-only auth) #}
+          <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+          <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/pathways.js') }}"></script>
+          <script>
+            (function() {
+              if (typeof window.waitForIdentityReady === 'function' && typeof window.getAuth === 'function') {
+                return;
+              }
+
+              function parseBoolean(value) {
+                if (typeof value === 'boolean') return value;
+                if (!value) return false;
+                var normalized = value.toString().trim().toLowerCase();
+                return normalized === 'true' || normalized === '1' || normalized === 'yes';
+              }
+
+              window.waitForIdentityReady = window.waitForIdentityReady || function() {
+                try {
+                  if (window.hhIdentity && window.hhIdentity.ready && typeof window.hhIdentity.ready.then === 'function') {
+                    return window.hhIdentity.ready;
+                  }
+                } catch (error) {}
+                return Promise.resolve(null);
+              };
+
+              window.getAuth = window.getAuth || function() {
+                var el = document.getElementById('hhl-auth-context');
+                var identity = (window.hhIdentity && typeof window.hhIdentity.get === 'function')
+                  ? window.hhIdentity.get()
+                  : null;
+                var authenticated = identity ? !!identity.authenticated : parseBoolean(el && el.getAttribute('data-authenticated'));
+                var email = identity && identity.email ? identity.email : (el && el.getAttribute('data-email')) || null;
+                var contactId = identity && identity.contactId ? identity.contactId : (el && el.getAttribute('data-contact-id')) || null;
+                return {
+                  authenticated: authenticated,
+                  email: email,
+                  contactId: contactId,
+                  enableCrm: parseBoolean(el && el.getAttribute('data-enable-crm')),
+                  trackEventsUrl: el && el.getAttribute('data-track-events-url')
+                };
+              };
+            })();
+          </script>
+          <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/js/enrollment.js') }}"></script>
+          <script>
+            // Initialize enrollment UI when enrollment.js is loaded
+            document.addEventListener('DOMContentLoaded', function() {
+              if (window.hhInitEnrollment) {
+                window.hhInitEnrollment('pathway', '{{ dynamic_page_hubdb_row.hs_path }}');
+              }
+            });
+          </script>
+
+          <!-- Pathway Summary -->
+          {% if dynamic_page_hubdb_row.summary_markdown %}
+            <div class="pathway-summary">
+              {{ dynamic_page_hubdb_row.summary_markdown|safe }}
+            </div>
+          {% endif %}
+
+          <!-- Archived warning -->
+          {% set is_archived = false %}
+          {% if dynamic_page_hubdb_row.tags %}
+            {% set tag_list = dynamic_page_hubdb_row.tags|lower|split(',') %}
+            {% for tag in tag_list %}
+              {% if tag|trim == 'archived' %}
+                {% set is_archived = true %}
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+          {% if is_archived %}
+            <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px;">
+              This pathway is archived and may be out of date.
+            </div>
+          {% endif %}
+
+          {# Debug banner for pathway detail - only show when ?debug=1 is present #}
+          {% if request.query_dict.debug == '1' %}
+            <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px; font-family:monospace; font-size:0.875rem;">
+              <strong>🔍 Debug Info (Pathway Detail):</strong><br>
+              Pathway: {{ dynamic_page_hubdb_row.hs_name }}<br>
+              {#
+                Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+                HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+                Source: clean-x-hedgehog-templates/config/constants.json
+              #}
+              
+              {% set courses_table_id_debug = constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else 135381433 %}
+              {% set modules_table_id_debug = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else 135621904 %}
+              courses_table_id: {{ courses_table_id_debug }}<br>
+              modules_table_id: {{ modules_table_id_debug }}<br>
+              constants.HUBDB_COURSES_TABLE_ID: {{ constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else "n/a" }}<br>
+              constants.HUBDB_MODULES_TABLE_ID: {{ constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else "n/a" }}<br>
+              has course_slugs_json: {{ "yes" if dynamic_page_hubdb_row.course_slugs_json else "no" }}<br>
+              has module_slugs_json: {{ "yes" if dynamic_page_hubdb_row.module_slugs_json else "no" }}
+            </div>
+          {% endif %}
+
+          <!-- Pathway Content: Prefer course_slugs_json if present, otherwise fallback to module_slugs_json -->
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% set courses_table_id = constants.HUBDB_COURSES_TABLE_ID if constants and constants.HUBDB_COURSES_TABLE_ID else 135381433 %}
+          {% set modules_table_id = constants.HUBDB_MODULES_TABLE_ID if constants and constants.HUBDB_MODULES_TABLE_ID else 135621904 %}
+
+          {% if dynamic_page_hubdb_row.course_slugs_json and courses_table_id %}
+            {# Prefer courses when available - OPTIMIZATION: Batch-fetch to avoid 10-call limit #}
+            <section class="pathway-modules-section">
+              <h2>Courses</h2>
+              {% set course_slugs = dynamic_page_hubdb_row.course_slugs_json|fromjson %}
+              {# Fetch all courses in ONE query using hs_path__in operator #}
+              {% set slug_list = course_slugs|join(',') %}
+              {% set all_courses = [] %}
+              {% for slug in course_slugs %}
+                {% set rows = hubdb_table_rows(courses_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+                {% if not rows or rows|length == 0 %}
+                  {# Fallback for hubs that expose 'path' instead of 'hs_path' in filters #}
+                  {% set rows = hubdb_table_rows(courses_table_id, "path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+                {% endif %}
+                {% if rows %}
+                  {% set all_courses = all_courses + rows %}
+                {% endif %}
+              {% endfor %}
+              {# Create lookup dictionary keyed by hs_path #}
+              {% set courses_by_slug = {} %}
+              {% for crs in all_courses %}
+                {% set _ = courses_by_slug.update({crs.hs_path: crs}) %}
+              {% endfor %}
+              <div class="modules-grid">
+                {% for slug in course_slugs %}
+                  {# Lookup course from batch-fetched dictionary #}
+                  {% set course = courses_by_slug[slug] %}
+                  {% if not course %}
+                    {# Defensive fallback: create a minimal object if lookup failed #}
+                    {% set course = { 'hs_path': slug, 'hs_name': slug|replace('-',' ')|title } %}
+                  {% endif %}
+                    <a href="/learn/courses/{{ (course.hs_path if course else slug) }}" class="module-card">
+                      <div class="module-card-number">{{ loop.index }}</div>
+                      <h3>{{ course.hs_name if course else (slug|replace('-',' ')|title) }}</h3>
+
+                      {% if course and course.summary_markdown %}
+                        <p>{{ course.summary_markdown|striptags|truncate(150) }}</p>
+                      {% endif %}
+
+                      <div style="display: flex; gap: 16px; color: #666; font-size: 0.875rem; margin-bottom: 16px;">
+                        {% if course.module_slugs_json %}
+                          {% set module_count = course.module_slugs_json|fromjson|length %}
+                          <span><strong>{{ module_count }}</strong> module{% if module_count != 1 %}s{% endif %}</span>
+                        {% endif %}
+                        {% if course.estimated_minutes %}
+                          <span><strong>{{ course.estimated_minutes }}</strong> minutes</span>
+                        {% endif %}
+                      </div>
+
+                      <span class="module-cta">View Course →</span>
+                    </a>
+                {% endfor %}
+              </div>
+            </section>
+
+          {% elif dynamic_page_hubdb_row.module_slugs_json and modules_table_id %}
+            {# Fallback: Render modules list - OPTIMIZATION: Batch-fetch to avoid 10-call limit #}
+            <section class="pathway-modules-section">
+              <h2>Learning Modules</h2>
+              {% set modules_base_path = '/learn/modules' %}
+              {% set module_slugs = dynamic_page_hubdb_row.module_slugs_json|fromjson %}
+              {# Fetch all modules in ONE query using hs_path__in operator #}
+              {% set slug_list = module_slugs|join(',') %}
+              {% set all_modules = [] %}
+          {% for slug in module_slugs %}
+            {% set rows = hubdb_table_rows(modules_table_id, "hs_path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+            {% if not rows or rows|length == 0 %}
+              {# Fallback for hubs that expose 'path' instead of 'hs_path' in filters #}
+              {% set rows = hubdb_table_rows(modules_table_id, "path__eq=" ~ slug ~ "&tags__not__icontains=archived") %}
+            {% endif %}
+            {% if rows %}
+              {% set all_modules = all_modules + rows %}
+            {% endif %}
+          {% endfor %}
+              {# Create lookup dictionary keyed by hs_path #}
+              {% set modules_by_slug = {} %}
+              {% for mod in all_modules %}
+                {% set _ = modules_by_slug.update({mod.hs_path: mod}) %}
+              {% endfor %}
+              <div class="modules-grid">
+                {% for slug in module_slugs %}
+                  {# Lookup module from batch-fetched dictionary #}
+                  {% set module = modules_by_slug[slug] %}
+                  {% if module %}
+                    <a href="{{ modules_base_path }}/{{ module.hs_path }}" class="module-card">
+                      <div class="module-card-number">{{ loop.index }}</div>
+                      <h3>{{ module.hs_name }}</h3>
+
+                      {% if module.meta_description %}
+                        <p>{{ module.meta_description|striptags|truncate(150) }}</p>
+                      {% endif %}
+
+                      <div class="module-time">
+                        {{ module.estimated_minutes }} minutes
+                      </div>
+
+                      <div style="margin-top: 16px;">
+                        <span class="module-cta">Start Module →</span>
+                      </div>
+                    </a>
+                  {% endif %}
+                {% endfor %}
+              </div>
+            </section>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+
+  {% else %}
+    {# List mode - showing all pathways #}
+    <section class="learn-header-section">
+      <div class="learn-header-content">
+        <h1 class="learn-page-title">Learning Pathways</h1>
+        <p class="learn-page-subtitle">Follow structured learning paths to master Hedgehog AI networking concepts step-by-step.</p>
+      </div>
+    </section>
+
+    <div class="learn-layout-with-nav">
+      {# Left navigation with filters #}
+      {{ learning_left_nav('pathways', show_filters=true) }}
+
+      {# Main content area #}
+      <div class="learn-main-content">
+        {# Prefer dynamic_page_hubdb_table_id, fallback to constants.json for backward compatibility #}
+        {% set pathways_table_id = dynamic_page_hubdb_table_id %}
+        {% if not pathways_table_id %}
+          {#
+            Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+            HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+            Source: clean-x-hedgehog-templates/config/constants.json
+          #}
+          
+          {% set pathways_table_id = constants.HUBDB_PATHWAYS_TABLE_ID %}
+        {% endif %}
+        {# Debug banner - only show when ?debug=1 is present #}
+        {% if request.query_dict.debug == '1' %}
+          <div style="background:#FEF3C7; border:1px solid #F59E0B; color:#92400E; padding:12px 16px; border-radius:8px; margin-bottom:16px; font-family:monospace; font-size:0.875rem;">
+            <strong>🔍 Debug Info (Pathways List):</strong><br>
+            pathways_table_id: {{ pathways_table_id if pathways_table_id else "n/a" }}<br>
+            dynamic_page_hubdb_table_id: {{ dynamic_page_hubdb_table_id if dynamic_page_hubdb_table_id else "n/a" }}<br>
+            constants.HUBDB_PATHWAYS_TABLE_ID: {{ constants.HUBDB_PATHWAYS_TABLE_ID if constants and constants.HUBDB_PATHWAYS_TABLE_ID else "n/a" }}
+          </div>
+        {% endif %}
+        {% if pathways_table_id %}
+          {% set pathways = hubdb_table_rows(pathways_table_id, "orderBy=display_order&tags__not__icontains=archived") %}
+          {% if pathways %}
+            <div class="pathways-grid">
+              {% for pathway in pathways %}
+                {% set is_archived = false %}
+                {% if pathway.tags %}
+                  {% set tag_list = pathway.tags|lower|split(',') %}
+                  {% for tag in tag_list %}
+                    {% if tag|trim == 'archived' %}
+                      {% set is_archived = true %}
+                    {% endif %}
+                  {% endfor %}
+                {% endif %}
+                {% if not is_archived %}
+                <a href="{{ request.path }}/{{ pathway.hs_path }}" class="pathway-card">
+                  <h2>{{ pathway.hs_name }}</h2>
+
+                  {% if pathway.summary_markdown %}
+                    <p class="pathway-card-summary">{{ pathway.summary_markdown|striptags|truncate(150) }}</p>
+                  {% endif %}
+
+                  <div class="pathway-meta">
+                    {% if pathway.course_slugs_json %}
+                      {% set course_count = pathway.course_slugs_json|fromjson|length %}
+                      <span class="pathway-meta-item">
+                        <strong>{{ course_count }}</strong> course{% if course_count != 1 %}s{% endif %}
+                      </span>
+                    {% elif pathway.module_count %}
+                      <span class="pathway-meta-item">
+                        <strong>{{ pathway.module_count }}</strong> module{% if pathway.module_count != 1 %}s{% endif %}
+                      </span>
+                    {% endif %}
+                    {% if pathway.total_estimated_minutes %}
+                      <span class="pathway-meta-item">
+                        <strong>{{ pathway.total_estimated_minutes }}</strong> minutes
+                      </span>
+                    {% endif %}
+                  </div>
+
+                  <span class="pathway-cta">View Pathway →</span>
+                </a>
+                {% endif %}
+              {% endfor %}
+            </div>
+          {% else %}
+            <p>No learning pathways have been added yet.</p>
+          {% endif %}
+        {% else %}
+          <p><em>Bind this page to the Pathways table in the HubSpot page settings.</em></p>
+        {% endif %}
+      </div>
+    </div>
+    {# Cognito auth context for nav auth state on list pages #}
+    {#
+      Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+      HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+      Source: clean-x-hedgehog-templates/config/constants.json
+    #}
+    
+    {% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+    {% set login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+    {% set logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+    <div
+      id="hhl-auth-context"
+      data-auth-me-url="{{ auth_me_url }}"
+      data-auth-login-url="{{ login_url }}"
+      data-auth-logout-url="{{ logout_url }}"
+      data-track-events-url="https://api.hedgehog.cloud/events/track"
+      data-enable-crm="true"
+      style="display:none"
+    ></div>
+    <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
+  {% endif %}
+</main>
+{% endblock body %}

--- a/clean-x-hedgehog-templates/learn-shadow/register.html
+++ b/clean-x-hedgehog-templates/learn-shadow/register.html
@@ -7,6 +7,9 @@
 {% block head %}
   {{ super() }}
 
+  {# Shadow environment: prevent search indexing #}
+  <meta name="robots" content="noindex, nofollow">
+
   {# Registration form specific styles #}
   <link rel="stylesheet" href="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/registration.css') }}">
 
@@ -39,13 +42,13 @@
 
   <title>Register for Hedgehog Learn - Create Your Account</title>
   <meta name="description" content="Join Hedgehog Learn to access all our AI networking courses, track your progress, and earn certifications.">
-  <link rel="canonical" href="https://{{ request.domain }}/learn/register">
+  <link rel="canonical" href="https://{{ request.domain }}/learn-shadow/register">
 
   {# Open Graph tags #}
   <meta property="og:type" content="website">
   <meta property="og:title" content="Register for Hedgehog Learn">
   <meta property="og:description" content="Join Hedgehog Learn to access all our AI networking courses and track your progress.">
-  <meta property="og:url" content="https://{{ request.domain }}/learn/register">
+  <meta property="og:url" content="https://{{ request.domain }}/learn-shadow/register">
   <meta property="og:image" content="{{ social_image }}">
 
   {# Twitter Card tags #}

--- a/clean-x-hedgehog-templates/learn-shadow/register.html
+++ b/clean-x-hedgehog-templates/learn-shadow/register.html
@@ -1,0 +1,146 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+
+{% block head %}
+  {{ super() }}
+
+  {# Registration form specific styles #}
+  <link rel="stylesheet" href="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/shadow/css/registration.css') }}">
+
+  {# HubSpot Forms JavaScript #}
+  <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
+
+  {# SEO metadata #}
+  {#
+    Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+    HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+    Source: clean-x-hedgehog-templates/config/constants.json
+  #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'HUBDB_CATALOG_TABLE_ID': '136199186',
+    'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
+    'ENABLE_CRM_PROGRESS': true,
+    'LOGOUT_URL': '/_hcms/mem/logout',
+    'LOGIN_URL': '/_hcms/mem/login',
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
+    'TRACK_EVENTS_ENABLED': true,
+    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
+  } %}
+  {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
+
+  <title>Register for Hedgehog Learn - Create Your Account</title>
+  <meta name="description" content="Join Hedgehog Learn to access all our AI networking courses, track your progress, and earn certifications.">
+  <link rel="canonical" href="https://{{ request.domain }}/learn/register">
+
+  {# Open Graph tags #}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Register for Hedgehog Learn">
+  <meta property="og:description" content="Join Hedgehog Learn to access all our AI networking courses and track your progress.">
+  <meta property="og:url" content="https://{{ request.domain }}/learn/register">
+  <meta property="og:image" content="{{ social_image }}">
+
+  {# Twitter Card tags #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Register for Hedgehog Learn">
+  <meta name="twitter:description" content="Join Hedgehog Learn to access all our AI networking courses.">
+  <meta name="twitter:image" content="{{ social_image }}">
+{% endblock head %}
+
+{% block body %}
+<main id="main-content">
+  <section class="registration-hero">
+    <div class="registration-hero-content">
+      <h1 class="registration-title">Join Hedgehog Learn</h1>
+      <p class="registration-subtitle">Create your account to access courses, track progress, and earn certifications</p>
+    </div>
+  </section>
+
+  <section class="registration-section">
+    <div class="registration-container">
+      <div class="registration-layout">
+        {# Benefits sidebar #}
+        <aside class="registration-benefits">
+          <h2>What You'll Get</h2>
+          <ul class="benefits-list">
+            <li>
+              <span class="benefit-icon" aria-hidden="true">📚</span>
+              <div class="benefit-content">
+                <h3>Full Course Access</h3>
+                <p>Unlimited access to all modules, courses, and pathways</p>
+              </div>
+            </li>
+            <li>
+              <span class="benefit-icon" aria-hidden="true">📊</span>
+              <div class="benefit-content">
+                <h3>Progress Tracking</h3>
+                <p>Track your learning journey and see what you've completed</p>
+              </div>
+            </li>
+            <li>
+              <span class="benefit-icon" aria-hidden="true">🏆</span>
+              <div class="benefit-content">
+                <h3>Earn Certifications</h3>
+                <p>Get recognized for your achievements with certificates</p>
+              </div>
+            </li>
+            <li>
+              <span class="benefit-icon" aria-hidden="true">🎯</span>
+              <div class="benefit-content">
+                <h3>Personalized Recommendations</h3>
+                <p>Discover content tailored to your interests and skill level</p>
+              </div>
+            </li>
+          </ul>
+        </aside>
+
+        {# Registration form #}
+        <div class="registration-form-container">
+          <h2>Create Your Account</h2>
+
+          {# HubSpot Form Embed #}
+          <div id="registration-form">
+            {# Form will be injected here by HubSpot #}
+          </div>
+
+          <script>
+            hbspt.forms.create({
+              region: "na1",
+              portalId: "21430285",
+              formId: "b2fd98ff-2055-41b2-85a0-0f497e798087",
+              target: "#registration-form",
+              onFormSubmit: function($form) {
+                console.log('Registration form submitted successfully');
+              },
+              onFormReady: function($form) {
+                console.log('Registration form loaded and ready');
+              }
+            });
+          </script>
+
+          <div class="registration-footer">
+            <p>Already have an account?
+              {#
+                Issue #327 Fix: Inline constants instead of using request_json (which doesn't exist in HubL)
+                HubL cannot fetch/parse JSON files server-side, so we inline the values directly.
+                Source: clean-x-hedgehog-templates/config/constants.json
+              #}
+              
+              {% set login_url = constants.AUTH_LOGIN_URL|default('https://api.hedgehog.cloud/auth/login') if constants else 'https://api.hedgehog.cloud/auth/login' %}
+              <a href="{{ login_url }}?redirect_url=/learn">Sign in here</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</main>
+{% endblock body %}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "provision:crm-properties": "node scripts/create-crm-properties.js",
     "publish:constants": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-constants.js",
     "provision:pages": "npm run build && node dist/scripts/hubspot/provision-pages.js",
+    "provision:shadow-pages": "npm run build && node dist/scripts/hubspot/provision-shadow-pages.js",
     "publish:pages": "npm run build && node dist/scripts/hubspot/publish-pages.js",
     "publish:template": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-template.js",
     "validate:template": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/validate-template.js",

--- a/scripts/hubspot/provision-shadow-pages.ts
+++ b/scripts/hubspot/provision-shadow-pages.ts
@@ -1,0 +1,311 @@
+#!/usr/bin/env ts-node
+/**
+ * Provision shadow CMS pages for the HH-Learn shadow environment (Issue #371)
+ *
+ * Shadow pages are published but unlisted pages that mirror the /learn structure
+ * at /learn-shadow, allowing safe feature development without touching live pages.
+ *
+ * Shadow page slugs: learn-shadow, learn-shadow/modules, learn-shadow/courses,
+ *   learn-shadow/pathways, learn-shadow/my-learning, learn-shadow/register,
+ *   learn-shadow/action-runner
+ *
+ * Shadow templates: CLEAN x HEDGEHOG/templates/learn-shadow/
+ *
+ * This script:
+ * 1. Creates or updates shadow site pages via CMS Pages API
+ * 2. Binds pages to the same HubDB tables as production (Phase 0A: data not isolated)
+ * 3. Creates pages in DRAFT state by default (use --publish to publish immediately)
+ * 4. Idempotent: if page exists by slug, PATCH the draft instead of creating duplicates
+ *
+ * Usage: node dist/scripts/hubspot/provision-shadow-pages.js [--dry-run] [--publish] [--allow-create]
+ */
+
+import 'dotenv/config';
+import { getHubSpotToken } from './get-hubspot-token.js';
+import { Client } from '@hubspot/api-client';
+
+const hubspot = new Client({
+  accessToken: getHubSpotToken()
+});
+
+const SHADOW_TEMPLATE_PREFIX = 'CLEAN x HEDGEHOG/templates/learn-shadow/';
+const SHADOW_SLUG_PREFIX = 'learn-shadow';
+
+interface PageConfig {
+  name: string;
+  slug: string;
+  templatePath: string;
+  /** Name of env var that holds the HubDB table ID. Use 'STATIC' for pages with no HubDB binding. */
+  tableEnvVar: string;
+}
+
+interface PageResult {
+  name: string;
+  slug: string;
+  id: string;
+  state: string;
+  url?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries: number = 3,
+  initialDelayMs: number = 2000
+): Promise<T> {
+  let lastError: any;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      lastError = err;
+      const isRateLimit = err.code === 429 || err.code === 403 ||
+        (err.message && err.message.includes('rate limit'));
+      if (!isRateLimit && err.code !== 404) throw err;
+      if (attempt === maxRetries) throw err;
+      const delay = initialDelayMs * Math.pow(2, attempt);
+      console.log(`  ⏳ Rate limit, waiting ${delay / 1000}s (retry ${attempt + 1}/${maxRetries})...`);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+async function findPageBySlug(slug: string): Promise<any | null> {
+  const token = getHubSpotToken();
+  const base = 'https://api.hubapi.com';
+
+  // Try search endpoint first
+  try {
+    const res = await fetch(`${base}/cms/v3/pages/site-pages/search`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ filters: [{ propertyName: 'slug', operator: 'EQ', value: slug }], limit: 10 })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const found = (data.results ?? []).find((r: any) => r.slug === slug);
+      if (found) return found;
+    }
+  } catch { /* fall through */ }
+
+  // Fallback: list + filter
+  try {
+    let after: string | undefined = undefined;
+    for (let i = 0; i < 5; i++) {
+      const url = new URL(`${base}/cms/v3/pages/site-pages`);
+      url.searchParams.set('limit', '100');
+      if (after) url.searchParams.set('after', after);
+      const res = await fetch(url.toString(), {
+        headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' }
+      });
+      if (!res.ok) break;
+      const data = await res.json();
+      const found = (data.results ?? []).find((r: any) => r.slug === slug);
+      if (found) return found;
+      after = data?.paging?.next?.after;
+      if (!after) break;
+    }
+  } catch { /* ignore */ }
+
+  return null;
+}
+
+async function validateTemplateExists(templatePath: string): Promise<boolean> {
+  const token = getHubSpotToken();
+  try {
+    const res = await fetch(
+      `https://api.hubapi.com/cms/v3/source-code/draft/metadata/${encodeURIComponent(templatePath)}`,
+      { headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' } }
+    );
+    return res.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+async function createOrUpdatePage(
+  config: PageConfig,
+  tableId: string,
+  dryRun: boolean,
+  publish: boolean,
+  allowCreate: boolean
+): Promise<PageResult | null> {
+  // Guardrail: only allow shadow slugs and shadow template paths
+  if (!config.slug.startsWith(SHADOW_SLUG_PREFIX)) {
+    console.log(`❌ Guardrail: slug "${config.slug}" does not start with "${SHADOW_SLUG_PREFIX}". Blocked.`);
+    return null;
+  }
+  if (!config.templatePath.startsWith(SHADOW_TEMPLATE_PREFIX)) {
+    console.log(`❌ Guardrail: template "${config.templatePath}" is not a shadow template. Blocked.`);
+    return null;
+  }
+
+  console.log(`\n📄 Shadow page: ${config.name}`);
+  console.log(`   Slug: ${config.slug}`);
+  console.log(`   Template: ${config.templatePath}`);
+
+  if (!dryRun) {
+    const exists = await validateTemplateExists(config.templatePath);
+    if (!exists) {
+      console.log(`   ❌ Template not found in Design Manager. Upload templates first.`);
+      console.log(`      Run: npm run upload:templates`);
+      return null;
+    }
+  }
+
+  const existingPage = await findPageBySlug(config.slug);
+
+  const payload: any = {
+    name: config.name,
+    slug: config.slug,
+    templatePath: config.templatePath,
+    state: 'DRAFT',
+    ...(publish && { publishImmediately: true, publicAccessRulesEnabled: false })
+  };
+
+  const isStatic = config.tableEnvVar === 'STATIC';
+  if (!isStatic) {
+    payload.dynamicPageDataSourceType = 1; // HUBDB
+    payload.dynamicPageDataSourceId = parseInt(tableId, 10);
+  }
+
+  if (dryRun) {
+    const action = existingPage ? `UPDATE (id: ${existingPage.id})` : 'CREATE';
+    console.log(`   Action: ${action}`);
+    console.log('   Payload:', JSON.stringify(payload, null, 2));
+    return { name: config.name, slug: config.slug, id: existingPage?.id || '<new>', state: publish ? 'PUBLISHED' : 'DRAFT' };
+  }
+
+  try {
+    let page: any;
+    if (existingPage) {
+      console.log(`   Updating existing page (id: ${existingPage.id})`);
+      page = await retryWithBackoff(() =>
+        hubspot.cms.pages.sitePagesApi.update(String(existingPage.id), payload as any)
+      );
+      console.log(`   ✓ Updated`);
+    } else if (allowCreate) {
+      console.log(`   Creating new page`);
+      page = await retryWithBackoff(() =>
+        hubspot.cms.pages.sitePagesApi.create(payload as any)
+      );
+      console.log(`   ✓ Created (id: ${page.id})`);
+    } else {
+      console.log(`   ⚠️  No existing page found. Use --allow-create to create it.`);
+      return { name: config.name, slug: config.slug, id: '<skipped>', state: 'SKIPPED' };
+    }
+
+    if (publish && page.state !== 'PUBLISHED') {
+      try {
+        const api: any = hubspot.cms.pages.sitePagesApi;
+        await retryWithBackoff(() => api.schedule(String(page.id), String(page.id)));
+        console.log(`   ✓ Scheduled for publish`);
+      } catch (err: any) {
+        console.log(`   ⚠️  Auto-publish failed: ${err.message}. Publish manually in CMS.`);
+      }
+    }
+
+    return { name: config.name, slug: config.slug, id: String(page.id), state: publish ? 'PUBLISHED' : 'DRAFT', url: page.url };
+  } catch (err: any) {
+    console.error(`   ✗ Failed: ${err.message}`);
+    if (err.body) console.error('   Details:', JSON.stringify(err.body, null, 2));
+    return null;
+  }
+}
+
+async function provisionShadowPages(dryRun: boolean, publish: boolean, allowCreate: boolean) {
+  console.log('🌑 Starting shadow CMS page provisioning (Issue #371)...\n');
+  if (dryRun) console.log('📝 DRY RUN — no changes will be made\n');
+  if (publish && !dryRun) console.log('🚀 PUBLISH MODE — pages published immediately\n');
+  if (allowCreate && !dryRun) console.log('➕ CREATE MODE — new pages will be created\n');
+
+  // Shadow pages mirror production but at learn-shadow/* slugs and use learn-shadow/* templates.
+  // Phase 0A: HubDB table bindings point to the same production tables (data isolation is future work).
+  const pageConfigs: PageConfig[] = [
+    {
+      name: 'Learn Shadow — Get Started',
+      slug: 'learn-shadow',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}get-started.html`,
+      tableEnvVar: 'HUBDB_CATALOG_TABLE_ID'
+    },
+    {
+      name: 'Learn Shadow — Modules',
+      slug: 'learn-shadow/modules',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}module-page.html`,
+      tableEnvVar: 'HUBDB_MODULES_TABLE_ID'
+    },
+    {
+      name: 'Learn Shadow — Courses',
+      slug: 'learn-shadow/courses',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}courses-page.html`,
+      tableEnvVar: 'HUBDB_COURSES_TABLE_ID'
+    },
+    {
+      name: 'Learn Shadow — Pathways',
+      slug: 'learn-shadow/pathways',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}pathways-page.html`,
+      tableEnvVar: 'HUBDB_PATHWAYS_TABLE_ID'
+    },
+    {
+      name: 'Learn Shadow — My Learning',
+      slug: 'learn-shadow/my-learning',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}my-learning.html`,
+      tableEnvVar: 'HUBDB_MODULES_TABLE_ID'
+    },
+    {
+      name: 'Learn Shadow — Register',
+      slug: 'learn-shadow/register',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}register.html`,
+      tableEnvVar: 'STATIC'
+    },
+    {
+      name: 'Learn Shadow — Action Runner',
+      slug: 'learn-shadow/action-runner',
+      templatePath: `${SHADOW_TEMPLATE_PREFIX}action-runner.html`,
+      tableEnvVar: 'STATIC'
+    }
+  ];
+
+  const results: PageResult[] = [];
+
+  for (const config of pageConfigs) {
+    const isStatic = config.tableEnvVar === 'STATIC';
+    const tableId = isStatic ? 'STATIC' : (process.env[config.tableEnvVar] || '');
+    if (!tableId && !dryRun) {
+      console.error(`✗ ${config.tableEnvVar} not set in env. Skipping ${config.name}.`);
+      continue;
+    }
+    const result = await createOrUpdatePage(config, tableId, dryRun, publish, allowCreate);
+    if (result) results.push(result);
+    if (!dryRun) await sleep(1000);
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log('📊 Shadow Page Provisioning Summary');
+  console.log('='.repeat(60));
+  for (const r of results) {
+    console.log(`\n  ${r.name}`);
+    console.log(`    Slug:  ${r.slug}`);
+    console.log(`    ID:    ${r.id}`);
+    console.log(`    State: ${r.state}`);
+    if (r.url) console.log(`    URL:   ${r.url}`);
+  }
+  console.log('\n✅ Shadow page provisioning complete!\n');
+  if (!dryRun && !publish && results.length > 0) {
+    console.log('💡 Pages are in DRAFT. Run with --publish to publish them.\n');
+  }
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const publish = args.includes('--publish');
+const allowCreate = args.includes('--allow-create');
+
+provisionShadowPages(dryRun, publish, allowCreate).catch(err => {
+  console.error('❌ Shadow page provisioning failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/hubspot/provision-shadow-pages.ts
+++ b/scripts/hubspot/provision-shadow-pages.ts
@@ -164,6 +164,11 @@ async function createOrUpdatePage(
     slug: config.slug,
     templatePath: config.templatePath,
     state: 'DRAFT',
+    // Shadow pages must never appear in search results.
+    // Primary protection: <meta name="robots" content="noindex, nofollow"> in each template.
+    // Belt-and-suspenders: set HubSpot page-level no-index flags as well.
+    metaRobotsNoIndex: true,
+    metaRobotsNoFollow: true,
     ...(publish && { publishImmediately: true, publicAccessRulesEnabled: false })
   };
 

--- a/scripts/hubspot/upload-templates.ts
+++ b/scripts/hubspot/upload-templates.ts
@@ -18,6 +18,7 @@ const LOCAL_BASE = 'clean-x-hedgehog-templates';
 const REMOTE_BASE = 'CLEAN x HEDGEHOG/templates';
 const ALLOWED_REMOTE_PREFIXES = [
   'CLEAN x HEDGEHOG/templates/learn/',
+  'CLEAN x HEDGEHOG/templates/learn-shadow/',
   'CLEAN x HEDGEHOG/templates/assets/',
 ];
 const ALLOWED_SINGLE_FILE = 'CLEAN x HEDGEHOG/templates/config/constants.json';

--- a/verification-output/issue-371/asset-inventory.md
+++ b/verification-output/issue-371/asset-inventory.md
@@ -1,0 +1,49 @@
+# Issue #371 — CMS Asset Inventory and Clone/Share Decisions
+
+## Decision Summary
+
+| Asset | HubSpot Path | Local Path | Decision | Rationale |
+|-------|-------------|------------|----------|-----------|
+| Base layout | `CLEAN x HEDGEHOG/templates/layouts/base.html` | `clean-x-hedgehog-templates/layouts/base.html` | **SHARE** | Theme infrastructure; changes affect all pages regardless of shadow/prod. Shadow templates extend it unchanged. Only clone if base changes are needed (document when that happens). |
+| Production templates (9) | `CLEAN x HEDGEHOG/templates/learn/*.html` | `clean-x-hedgehog-templates/learn/*.html` | **SHARED (source)** | These are the production originals — unchanged by this issue. |
+| Shadow templates (9) | `CLEAN x HEDGEHOG/templates/learn-shadow/*.html` | `clean-x-hedgehog-templates/learn-shadow/*.html` | **CLONE** | Any template edit during shadow work would affect live production pages if shared. |
+| Macro: left-nav | `CLEAN x HEDGEHOG/templates/learn/macros/left-nav.html` | `clean-x-hedgehog-templates/learn/macros/left-nav.html` | **CLONE** → shadow | Imported by all list-view templates; must match shadow template namespace. |
+| cognito-auth-integration.js (learn/) | `CLEAN x HEDGEHOG/templates/learn/assets/js/cognito-auth-integration.js` | same under `learn/` | **CLONE** → shadow | In-template JS asset; changes would affect production pages. |
+| CSS assets (4) | `CLEAN x HEDGEHOG/templates/assets/css/*.css` | `clean-x-hedgehog-templates/assets/css/` | **CLONE** → shadow | Mutable assets shared by template require_css calls; any change would affect production templates. |
+| JS assets (16) | `CLEAN x HEDGEHOG/templates/assets/js/*.js` | `clean-x-hedgehog-templates/assets/js/` | **CLONE** → shadow | Mutable assets; changes would cross-impact production pages. |
+| learn-landing.css | `CLEAN x HEDGEHOG/templates/assets/css/learn-landing.css` | (was missing from repo) | **CLONE** → shadow + recovered to repo | Existed in HubSpot portal but not in git. Fetched from published environment and added to both `assets/css/` and `assets/shadow/css/`. |
+| constants.json | `CLEAN x HEDGEHOG/templates/config/constants.json` | `clean-x-hedgehog-templates/config/constants.json` | **SHARE (Phase 0A)** | Shadow env uses same production HubDB tables in Phase 0A. Data isolation is future work (Phase 0B+). The inline-constants pattern (Issue #327) means templates don't actually load this at runtime. |
+
+## Shadow Asset Namespace
+
+All shadow assets live under distinct paths that make environment identity obvious:
+
+- **Templates**: `CLEAN x HEDGEHOG/templates/learn-shadow/` (previously `learn/`)
+- **Shadow CSS**: `CLEAN x HEDGEHOG/templates/assets/shadow/css/` (previously `assets/css/`)
+- **Shadow JS**: `CLEAN x HEDGEHOG/templates/assets/shadow/js/` (previously `assets/js/`)
+- **Shadow Cognito JS**: `CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/` (previously `learn/assets/js/`)
+
+## Reference Updates in Shadow Templates
+
+All shadow templates had the following path substitutions applied:
+
+| Original | Shadow |
+|---------|--------|
+| `/CLEAN x HEDGEHOG/templates/learn/macros/left-nav.html` | `/CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html` |
+| `/CLEAN x HEDGEHOG/templates/assets/css/` | `/CLEAN x HEDGEHOG/templates/assets/shadow/css/` |
+| `/CLEAN x HEDGEHOG/templates/assets/js/` | `/CLEAN x HEDGEHOG/templates/assets/shadow/js/` |
+| `/CLEAN x HEDGEHOG/templates/learn/assets/js/` | `/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/` |
+| `'ACTION_RUNNER_URL': '/learn/action-runner'` | `'ACTION_RUNNER_URL': '/learn-shadow/action-runner'` |
+
+## Known Pre-existing Issues (not introduced by this PR)
+
+1. **debug-hubdb.html**: References `hs_path__eq=authoring-basics` which no longer exists in HubDB (module was archived). Template fails HubSpot validation. Exists in both prod and shadow. Not provisioned as a CMS page.
+
+2. **learn-landing.css missing from git**: The production `get-started.html` template references `assets/css/learn-landing.css` which existed in HubSpot but was absent from the repo. This issue was discovered during shadow env work and **recovered**: the file was fetched from the published environment and committed to git.
+
+## Phase 0A Limitations (follow-up work needed)
+
+1. **HubDB data**: Shadow pages bind to the same production HubDB tables. Data isolation (separate shadow HubDB tables with test content) is Phase 0B work.
+2. **Canonical URLs**: Shadow templates still have hardcoded `/learn/` paths in `canonical_url` constructions. This is acceptable for dev/test use but should be addressed if shadow env is used for SEO-sensitive testing.
+3. **`base.html` not cloned**: If base layout changes are needed for shadow work, a shadow base layout will need to be created at that time. The relative `../../` paths in base.html constrain where it can live.
+4. **Catalog page**: Shadow catalog page template is published but the `/learn-shadow/catalog` page slug is not provisioned as a CMS page (only the action-runner and the 6 main pages are provisioned). The `catalog.html` template is available in the shadow namespace for future use.

--- a/verification-output/issue-371/review-fix-log.md
+++ b/verification-output/issue-371/review-fix-log.md
@@ -1,0 +1,77 @@
+# Issue #371 — Review Fix Log (commit ab70289)
+
+Date: 2026-04-09
+
+Three issues identified in review of PR #377 were fixed in this commit.
+
+---
+
+## Fix 1: module-page.html was gitignored
+
+**Root cause:** `.gitignore` line 18 contained `module-page.html` (bare filename, matched all paths).
+
+**Fix:** Changed to `/module-page.html` (anchored to repo root only). The root-level `module-page.html` scratchpad file continues to be ignored; `clean-x-hedgehog-templates/learn-shadow/module-page.html` is now tracked.
+
+**Verification:**
+```
+git check-ignore -v clean-x-hedgehog-templates/learn-shadow/module-page.html
+→ NOT IGNORED
+
+git check-ignore -v module-page.html
+→ .gitignore:18:/module-page.html  (root file still ignored)
+```
+
+---
+
+## Fix 2: Internal links still routing to production /learn
+
+**Root cause:** First pass of sed only updated asset references and the `ACTION_RUNNER_URL` constant. All href-based navigation links, canonical URLs, og:url, rel=prev/next, and JS fallback URLs still pointed to `/learn/`.
+
+**Fix:** Applied `s|/learn/|/learn-shadow/|g` across all shadow template HTML files and the cognito-auth-integration.js. Files updated:
+
+- `macros/left-nav.html` — nav links (modules/courses/pathways/my-learning/register)
+- `get-started.html` — hero CTAs, pathway/catalog/course card links
+- `courses-page.html` — canonical_url var, og:url, back-to-courses link, module card hrefs, `?from=course:` query links
+- `pathways-page.html` — canonical_url var, og:url, back-to-pathways, course links, `modules_base_path` template var
+- `module-page.html` — canonical_url var, og:url, rel=prev/next, prereq links, nav links, module card hrefs
+- `my-learning.html` — empty-state pathway CTA
+- `catalog.html` — type-based href routing for modules/courses/pathways
+- `assets/js/cognito-auth-integration.js` — hardcoded fallback `'/learn/action-runner'`
+
+**Verification (live HTML check):**
+
+| Page | HTTP | noindex | /learn/ hrefs | /learn-shadow/ hrefs |
+|------|------|---------|---------------|----------------------|
+| /learn-shadow | 200 | 1 | 0 | 14 |
+| /learn-shadow/modules | 200 | 1 | 0 | 28 |
+| /learn-shadow/courses | 200 | 1 | 0 | 9 |
+
+Production pages have 0 noindex tags (unchanged).
+
+---
+
+## Fix 3: Anti-indexing not implemented
+
+**Fix:**
+
+**Template-level (primary):** Added `<meta name="robots" content="noindex, nofollow">` immediately after `{{ super() }}` in `{% block head %}` in all 8 shadow page templates. For `debug-hubdb.html` (no HubL block structure), added directly inside `<head>`.
+
+**CMS page-level (belt-and-suspenders):** Updated all 7 existing shadow CMS pages via `PATCH /cms/v3/pages/site-pages/{id}` with `{"metaRobotsNoIndex": true, "metaRobotsNoFollow": true}`.
+
+**Script:** Added `metaRobotsNoIndex: true` and `metaRobotsNoFollow: true` to the `provision-shadow-pages.ts` page payload so future page provisioning automatically sets both protection layers.
+
+**Verification:**
+```bash
+curl -s https://hedgehog.cloud/learn-shadow | grep -i "robots"
+→ <meta name="robots" content="noindex, nofollow">
+
+# Production pages:
+curl -s https://hedgehog.cloud/learn | grep -ic "noindex"
+→ 0  (production is NOT affected)
+```
+
+---
+
+## Pre-existing issue (not a blocker for #371)
+
+`get-started.html` (shadow) inherits the `request_json` usage from production template — this filter does not exist in HubL (Issue #327 fix documented this). The production template has the same issue. Cleanup should be tracked in a separate issue.

--- a/verification-output/issue-371/review-fix-log.md
+++ b/verification-output/issue-371/review-fix-log.md
@@ -1,6 +1,37 @@
-# Issue #371 — Review Fix Log (commit ab70289)
+# Issue #371 — Review Fix Log
 
+Commits: ab70289 (initial review fixes), 47573ec (bare /learn link fix)
 Date: 2026-04-09
+
+Four issues across two review rounds addressed in PR #377.
+
+---
+
+## Fix 4: Bare `/learn` home links (commit 47573ec)
+
+Three links using `href="/learn"` (no trailing slash) were missed by the earlier
+`s|/learn/|/learn-shadow/|g` substitution (which only matched paths with a
+trailing slash):
+
+| File | Line | Element |
+|---|---|---|
+| `macros/left-nav.html` | 17 | Home nav link |
+| `module-page.html` | 687 | "Back to Learning Portal" |
+| `action-runner.html` | 171 | "Return to Learn" button |
+
+All changed to `href="/learn-shadow"`. **No intentional exceptions to production
+`/learn` remain.** All shadow internal navigation stays within `/learn-shadow`.
+
+**Verification:**
+```
+curl -s https://hedgehog.cloud/learn-shadow | grep -c 'href="/learn"'  → 0
+curl -s https://hedgehog.cloud/learn-shadow/modules | grep -c 'href="/learn"'  → 0
+curl -s https://hedgehog.cloud/learn-shadow/action-runner | grep -c 'href="/learn"'  → 0
+```
+
+---
+
+## Fixes 1–3 (commit ab70289)
 
 Three issues identified in review of PR #377 were fixed in this commit.
 

--- a/verification-output/issue-371/upload-publish-log.md
+++ b/verification-output/issue-371/upload-publish-log.md
@@ -1,0 +1,119 @@
+# Issue #371 — Template Upload & Publish Log
+
+Date: 2026-04-08
+
+## Template Upload (DRAFT)
+
+Command: `node dist/scripts/hubspot/upload-templates.js`
+
+Result: **63 files uploaded successfully, 0 failures** (1 file outside allowlist skipped: `layouts/base.html` — correct, intentionally not uploaded via this script).
+
+Shadow files uploaded to DRAFT:
+- `CLEAN x HEDGEHOG/templates/learn-shadow/action-runner.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/catalog.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/courses-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/debug-hubdb.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/get-started.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/module-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/my-learning.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/pathways-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/register.html` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/learn-landing.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/module-media.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/registration.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/action-runner.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/auth-context.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/catalog-filters.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-breadcrumbs.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-context.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-navigation.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/courses.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/debug.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/enrollment.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/login-helper.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/my-learning.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/pageview.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/pathways.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/progress.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/toast.js` ✓
+
+## Template Publish (DRAFT → PUBLISHED)
+
+Command: `node dist-cjs/scripts/hubspot/publish-template.js --path ... --local ...`
+
+Validation: HubSpot Source Code API validation passed for all templates below.
+
+Published successfully (29 files):
+- `CLEAN x HEDGEHOG/templates/learn-shadow/module-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/courses-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/pathways-page.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/my-learning.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/register.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/action-runner.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/catalog.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/macros/left-nav.html` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/catalog.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/learn-landing.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/left-nav.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/module-media.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/css/registration.css` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/action-runner.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/auth-context.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/catalog-filters.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-breadcrumbs.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-context.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/course-navigation.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/courses.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/enrollment.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/left-nav.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/login-helper.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/my-learning.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/pageview.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/pathways.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/progress.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/toast.js` ✓
+- `CLEAN x HEDGEHOG/templates/assets/shadow/js/debug.js` ✓
+- `CLEAN x HEDGEHOG/templates/learn-shadow/get-started.html` ✓ (after learn-landing.css was recovered)
+
+Skipped/failed (pre-existing issues):
+- `CLEAN x HEDGEHOG/templates/learn-shadow/debug-hubdb.html` — validation error: references `authoring-basics` HubDB row which no longer exists. Pre-existing issue in production template. Not used as a provisioned page.
+
+## Shadow CMS Pages Provisioned
+
+Command: `node dist/scripts/hubspot/provision-shadow-pages.js --allow-create --publish`
+Publish: `PATCH state=PUBLISHED` via CMS Pages API
+
+| Page Name | Slug | HubSpot ID | State |
+|-----------|------|-----------|-------|
+| Learn Shadow — Get Started | `learn-shadow` | 210727657869 | PUBLISHED |
+| Learn Shadow — Modules | `learn-shadow/modules` | 210723427736 | PUBLISHED |
+| Learn Shadow — Courses | `learn-shadow/courses` | 210727657871 | PUBLISHED |
+| Learn Shadow — Pathways | `learn-shadow/pathways` | 210723427738 | PUBLISHED |
+| Learn Shadow — My Learning | `learn-shadow/my-learning` | 210723427741 | PUBLISHED |
+| Learn Shadow — Register | `learn-shadow/register` | 210727657873 | PUBLISHED |
+| Learn Shadow — Action Runner | `learn-shadow/action-runner` | 210727657875 | PUBLISHED |
+
+## HTTP Verification
+
+### Shadow pages (all return HTTP 200):
+- https://hedgehog.cloud/learn-shadow → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/modules → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/courses → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/pathways → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/my-learning → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/register → HTTP 200 ✓
+- https://hedgehog.cloud/learn-shadow/action-runner → HTTP 200 ✓
+
+### Production pages (all return HTTP 200, templates UNCHANGED):
+- https://hedgehog.cloud/learn → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/get-started.html`)
+- https://hedgehog.cloud/learn/modules → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/module-page.html`)
+- https://hedgehog.cloud/learn/courses → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/courses-page.html`)
+- https://hedgehog.cloud/learn/pathways → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/pathways-page.html`)
+- https://hedgehog.cloud/learn/my-learning → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/my-learning.html`)
+- https://hedgehog.cloud/learn/register → HTTP 200 ✓ (template: `CLEAN x HEDGEHOG/templates/learn/register.html`)


### PR DESCRIPTION
## Summary

Implements Phase 0A (#371) of the shadow HH-Learn environment: clones and isolates all mutable CMS/frontend assets needed to run shadow pages at `/learn-shadow/*` inside the current HubSpot portal, without touching production `/learn` pages.

- Clones all 9 page templates (`learn/` → `learn-shadow/`) with updated internal references
- Clones all CSS assets (`assets/css/` → `assets/shadow/css/`) and all JS assets (`assets/js/` → `assets/shadow/js/`)
- Shares `layouts/base.html` (theme infrastructure) and `config/constants.json` (Phase 0A: same HubDB tables)
- Adds `provision-shadow-pages.ts` script to create/manage shadow CMS pages
- Updates `upload-templates.ts` allowlist to include `learn-shadow/` paths
- Adds `provision:shadow-pages` npm script
- Recovers `learn-landing.css` which existed in HubSpot but was absent from the repo

## Test plan

- [x] All 7 shadow pages created and published (HTTP 200): `/learn-shadow`, `/learn-shadow/modules`, `/learn-shadow/courses`, `/learn-shadow/pathways`, `/learn-shadow/my-learning`, `/learn-shadow/register`, `/learn-shadow/action-runner`
- [x] All 6 production pages verified unchanged (HTTP 200, original template paths): `/learn`, `/learn/modules`, `/learn/courses`, `/learn/pathways`, `/learn/my-learning`, `/learn/register`
- [x] HubSpot validation passes for all published shadow templates (29 files)
- [x] Shadow templates reference `learn-shadow/` macro and `assets/shadow/` CSS/JS (not production paths)
- [x] `upload:templates` dry-run confirms shadow files in allowlist and blocked files excluded correctly

## Verification artifacts

`verification-output/issue-371/`
- `asset-inventory.md` — full clone/share decision table with rationale
- `upload-publish-log.md` — upload counts, publish results, HTTP verification log

## Notes / follow-up

- `debug-hubdb.html` shadow template left in DRAFT (pre-existing validation error: references archived `authoring-basics` HubDB row). Same issue exists in production template.
- Phase 0B: HubDB data isolation (shadow tables) is out of scope for this issue per #371.
- `layouts/base.html` is shared. If base layout changes are needed for shadow work, clone at that time and update all shadow template `{% extends %}` paths.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)