### PR TITLE
feat(shadow): Phase 0B — environment-aware config and backend routing isolation (#372)

### DIFF
--- a/clean-x-hedgehog-templates/assets/shadow/js/course-breadcrumbs.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/course-breadcrumbs.js
@@ -60,7 +60,7 @@
     var breadcrumbsNav = document.getElementById('hhl-breadcrumbs');
     if (!breadcrumbsNav) return;
 
-    var courseUrl = '/learn/courses/' + encodeURIComponent(courseSlug);
+    var courseUrl = '/learn-shadow/courses/' + encodeURIComponent(courseSlug);
     var linkHTML = '<a href="' + courseUrl + '">← Back to ' + escapeHtml(courseName) + '</a>';
 
     // Replace the first child (default breadcrumb)

--- a/clean-x-hedgehog-templates/assets/shadow/js/enrollment.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/enrollment.js
@@ -82,7 +82,7 @@
     // Return constants synchronously from data attributes
     callback({
       TRACK_EVENTS_URL: auth.trackEventsUrl || null,
-      ACTION_RUNNER_URL: '/learn/action-runner'
+      ACTION_RUNNER_URL: '/learn-shadow/action-runner'
     });
   }
 
@@ -103,11 +103,11 @@
 
   function getActionRunnerBase(constants) {
     if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
-    return '/learn/action-runner';
+    return '/learn-shadow/action-runner';
   }
 
   function buildRunnerUrl(base, redirectUrl, params) {
-    var runner = base || '/learn/action-runner';
+    var runner = base || '/learn-shadow/action-runner';
     var search = new URLSearchParams();
     Object.keys(params || {}).forEach(function(key) {
       var value = params[key];

--- a/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
@@ -105,7 +105,7 @@
   }
   function renderModuleCard(module, isCompleted){
     var a = document.createElement('a');
-    a.href = '/learn-shadow/' + (module.path || module.hs_path || '');
+    a.href = '/learn-shadow/modules/' + (module.path || module.hs_path || '');
     a.className = 'module-card';
     var minutes = (module.values && module.values.estimated_minutes) || module.estimated_minutes || 0;
     var name = (module.values && module.values.hs_name) || module.hs_name || 'Untitled Module';
@@ -125,7 +125,7 @@
       var panel = q('last-viewed-panel');
       var link = q('last-viewed-link');
       var meta = q('last-viewed-meta');
-      var href = last.type === 'course' ? ('/learn-shadow/courses/' + last.slug) : ('/learn-shadow/' + last.slug);
+      var href = last.type === 'course' ? ('/learn-shadow/courses/' + last.slug) : ('/learn-shadow/modules/' + last.slug);
       link.href = href;
       link.textContent = (last.type==='course'?'Course: ':'Module: ') + last.slug;
       if (last.at) meta.textContent = '· viewed ' + last.at;
@@ -213,7 +213,7 @@
         var modStatusClass = mod.completed ? 'completed' : (mod.started ? 'in-progress' : 'not-started');
         html += '<div class="enrollment-module-item '+modStatusClass+'">\
           <span class="enrollment-module-status">'+modStatus+'</span>\
-          <a href="/learn-shadow/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
+          <a href="/learn-shadow/modules/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
         </div>';
       });
 
@@ -223,7 +223,7 @@
       if (nextIncompleteModule) {
         var nextPath = nextIncompleteModule.path || nextIncompleteModule.hs_path || nextIncompleteModule.slug;
         html += '<div class="enrollment-actions">\
-          <a href="/learn-shadow/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
+          <a href="/learn-shadow/modules/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
         </div>';
       } else {
         html += '<div class="enrollment-actions">\

--- a/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/my-learning.js
@@ -105,7 +105,7 @@
   }
   function renderModuleCard(module, isCompleted){
     var a = document.createElement('a');
-    a.href = '/learn/' + (module.path || module.hs_path || '');
+    a.href = '/learn-shadow/' + (module.path || module.hs_path || '');
     a.className = 'module-card';
     var minutes = (module.values && module.values.estimated_minutes) || module.estimated_minutes || 0;
     var name = (module.values && module.values.hs_name) || module.hs_name || 'Untitled Module';
@@ -125,7 +125,7 @@
       var panel = q('last-viewed-panel');
       var link = q('last-viewed-link');
       var meta = q('last-viewed-meta');
-      var href = last.type === 'course' ? ('/learn/courses/' + last.slug) : ('/learn/' + last.slug);
+      var href = last.type === 'course' ? ('/learn-shadow/courses/' + last.slug) : ('/learn-shadow/' + last.slug);
       link.href = href;
       link.textContent = (last.type==='course'?'Course: ':'Module: ') + last.slug;
       if (last.at) meta.textContent = '· viewed ' + last.at;
@@ -159,7 +159,7 @@
     var slug = item.slug || '';
     var enrolledAt = item.enrolled_at || '';
     var source = item.enrollment_source || 'unknown';
-    var href = type === 'pathway' ? ('/learn/pathways/' + slug) : ('/learn/courses/' + slug);
+    var href = type === 'pathway' ? ('/learn-shadow/pathways/' + slug) : ('/learn-shadow/courses/' + slug);
     var title = slug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
     var sourceLabel = source.replace(/_/g, ' ');
 
@@ -213,7 +213,7 @@
         var modStatusClass = mod.completed ? 'completed' : (mod.started ? 'in-progress' : 'not-started');
         html += '<div class="enrollment-module-item '+modStatusClass+'">\
           <span class="enrollment-module-status">'+modStatus+'</span>\
-          <a href="/learn/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
+          <a href="/learn-shadow/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
         </div>';
       });
 
@@ -223,7 +223,7 @@
       if (nextIncompleteModule) {
         var nextPath = nextIncompleteModule.path || nextIncompleteModule.hs_path || nextIncompleteModule.slug;
         html += '<div class="enrollment-actions">\
-          <a href="/learn/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
+          <a href="/learn-shadow/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
         </div>';
       } else {
         html += '<div class="enrollment-actions">\

--- a/clean-x-hedgehog-templates/assets/shadow/js/progress.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/progress.js
@@ -36,12 +36,12 @@
         return json || {};
       })
       .catch(function () {
-        // Hard fallback to known API gateway used by this project
+        // Hard fallback — shadow env: writes disabled, shadow action-runner
         return {
-          TRACK_EVENTS_ENABLED: true,
-          TRACK_EVENTS_URL: 'https://api.hedgehog.cloud/events/track',
-          ENABLE_CRM_PROGRESS: true,
-          ACTION_RUNNER_URL: '/learn/action-runner'
+          TRACK_EVENTS_ENABLED: false,
+          TRACK_EVENTS_URL: '',
+          ENABLE_CRM_PROGRESS: false,
+          ACTION_RUNNER_URL: '/learn-shadow/action-runner'
         };
       });
   }
@@ -67,11 +67,11 @@
 
   function getActionRunnerBase(constants) {
     if (constants && constants.ACTION_RUNNER_URL) return constants.ACTION_RUNNER_URL;
-    return '/learn/action-runner';
+    return '/learn-shadow/action-runner';
   }
 
   function buildRunnerUrl(base, redirectUrl, params) {
-    var runner = base || '/learn/action-runner';
+    var runner = base || '/learn-shadow/action-runner';
     var search = new URLSearchParams();
     Object.keys(params || {}).forEach(function(key) {
       var value = params[key];

--- a/clean-x-hedgehog-templates/config/shadow-constants.json
+++ b/clean-x-hedgehog-templates/config/shadow-constants.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Shadow environment constants for /learn-shadow pages. Do NOT sync to HubSpot. Documents the authoritative shadow config inlined in learn-shadow templates.",
+  "_environment": "shadow",
+  "_issue": "#372",
+
+  "HUBDB_MODULES_TABLE_ID": "135621904",
+  "HUBDB_PATHWAYS_TABLE_ID": "135381504",
+  "HUBDB_COURSES_TABLE_ID": "135381433",
+  "HUBDB_CATALOG_TABLE_ID": "136199186",
+  "DEFAULT_SOCIAL_IMAGE_URL": "https://hedgehog.cloud/hubfs/social-share-default.png",
+
+  "ENABLE_CRM_PROGRESS": false,
+  "TRACK_EVENTS_ENABLED": false,
+  "TRACK_EVENTS_URL": "",
+
+  "LOGOUT_URL": "/_hcms/mem/logout",
+  "LOGIN_URL": "/_hcms/mem/login",
+  "AUTH_LOGIN_URL": "https://api.hedgehog.cloud/auth/login",
+  "AUTH_ME_URL": "https://api.hedgehog.cloud/auth/me",
+  "AUTH_LOGOUT_URL": "https://api.hedgehog.cloud/auth/logout",
+
+  "ACTION_RUNNER_URL": "/learn-shadow/action-runner",
+
+  "_decisions": {
+    "TRACK_EVENTS_ENABLED=false": "Disables POST /events/track from shadow pages. Prevents shadow browsing/testing activity from writing progress/enrollment state to production DynamoDB.",
+    "TRACK_EVENTS_URL=''": "Empty URL ensures data-track-events-url attribute renders empty. JS guards against empty trackUrl and skips the fetch.",
+    "ENABLE_CRM_PROGRESS=false": "Disables CRM progress reads in shadow env. My Learning and course progress fall back to localStorage only. Prevents shadow env from reading/displaying production user state.",
+    "AUTH_*=production": "Auth endpoints are safe to share. They authenticate against the same Cognito user pool; the auth/me call is read-only identity verification, not a write operation.",
+    "HUBDB_TABLE_IDS=production": "Shadow pages read from the same production HubDB tables. Content isolation (separate shadow HubDB tables) is Phase 0C+ work.",
+    "ACTION_RUNNER_URL=/learn-shadow/action-runner": "Shadow action-runner at isolated path. With TRACK_EVENTS_URL empty, the action-runner cannot post events to the backend even if called."
+  }
+}

--- a/clean-x-hedgehog-templates/learn-shadow/action-runner.html
+++ b/clean-x-hedgehog-templates/learn-shadow/action-runner.html
@@ -127,14 +127,14 @@
       'HUBDB_COURSES_TABLE_ID': '135381433',
       'HUBDB_CATALOG_TABLE_ID': '136199186',
       'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-      'ENABLE_CRM_PROGRESS': true,
+      'ENABLE_CRM_PROGRESS': false,
       'LOGOUT_URL': '/_hcms/mem/logout',
       'LOGIN_URL': '/_hcms/mem/login',
       'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
       'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
       'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-      'TRACK_EVENTS_ENABLED': true,
-      'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+      'TRACK_EVENTS_ENABLED': false,
+      'TRACK_EVENTS_URL': '',
       'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
     } %}
     {% set login_url = constants.AUTH_LOGIN_URL %}
@@ -178,8 +178,8 @@
          data-auth-me-url="{{ constants.AUTH_ME_URL|default('https://api.hedgehog.cloud/auth/me') if constants else 'https://api.hedgehog.cloud/auth/me' }}"
          data-auth-login-url="{{ constants.AUTH_LOGIN_URL|default('https://api.hedgehog.cloud/auth/login') if constants else 'https://api.hedgehog.cloud/auth/login' }}"
          data-auth-logout-url="{{ constants.AUTH_LOGOUT_URL|default('https://api.hedgehog.cloud/auth/logout') if constants else 'https://api.hedgehog.cloud/auth/logout' }}"
-         data-track-events-url="https://api.hedgehog.cloud/events/track"
-         data-enable-crm="true"
+         data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+         data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
          style="display:none">
     </div>
 

--- a/clean-x-hedgehog-templates/learn-shadow/catalog.html
+++ b/clean-x-hedgehog-templates/learn-shadow/catalog.html
@@ -29,14 +29,14 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'LOGOUT_URL': '/_hcms/mem/logout',
     'LOGIN_URL': '/_hcms/mem/login',
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
   {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
@@ -181,8 +181,8 @@
        data-auth-me-url="{{ auth_me_url }}"
        data-auth-login-url="{{ login_url }}"
        data-auth-logout-url="{{ logout_url }}"
-       data-track-events-url="https://api.hedgehog.cloud/events/track"
-       data-enable-crm="true"
+       data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+       data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
        style="display:none">
   </div>
   <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>

--- a/clean-x-hedgehog-templates/learn-shadow/courses-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/courses-page.html
@@ -23,14 +23,14 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'LOGOUT_URL': '/_hcms/mem/logout',
     'LOGIN_URL': '/_hcms/mem/login',
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
 
@@ -627,8 +627,8 @@
                data-auth-me-url="{{ auth_me_url }}"
                data-auth-login-url="{{ auth_login_url }}"
                data-auth-logout-url="{{ auth_logout_url }}"
-               data-enable-crm="true"
-               data-track-events-url="https://api.hedgehog.cloud/events/track"
+               data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
+               data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
                data-course-slug="{{ dynamic_page_hubdb_row.hs_path }}"
                data-total-modules="{% if dynamic_page_hubdb_row.module_slugs_json %}{{ dynamic_page_hubdb_row.module_slugs_json|fromjson|length }}{% else %}0{% endif %}"
                style="display:none"></div>
@@ -1015,8 +1015,8 @@
       data-auth-me-url="{{ auth_me_url }}"
       data-auth-login-url="{{ login_url }}"
       data-auth-logout-url="{{ logout_url }}"
-      data-track-events-url="https://api.hedgehog.cloud/events/track"
-      data-enable-crm="true"
+      data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+      data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
       style="display:none"
     ></div>
     <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>

--- a/clean-x-hedgehog-templates/learn-shadow/module-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/module-page.html
@@ -28,14 +28,14 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'LOGOUT_URL': '/_hcms/mem/logout',
     'LOGIN_URL': '/_hcms/mem/login',
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
 
@@ -721,8 +721,8 @@
                  data-auth-me-url="{{ auth_me_url }}"
                  data-auth-login-url="{{ auth_login_url }}"
                  data-auth-logout-url="{{ auth_logout_url }}"
-                 data-enable-crm="true"
-                 data-track-events-url="https://api.hedgehog.cloud/events/track"
+                 data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
+                 data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
                  style="display:none"></div>
             <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>
 
@@ -1077,8 +1077,8 @@
       data-auth-me-url="{{ auth_me_url }}"
       data-auth-login-url="{{ login_url }}"
       data-auth-logout-url="{{ logout_url }}"
-      data-track-events-url="https://api.hedgehog.cloud/events/track"
-      data-enable-crm="true"
+      data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+      data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
       style="display:none"
     ></div>
     <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>

--- a/clean-x-hedgehog-templates/learn-shadow/my-learning.html
+++ b/clean-x-hedgehog-templates/learn-shadow/my-learning.html
@@ -22,12 +22,12 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
   {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}
@@ -595,8 +595,8 @@
      data-auth-me-url="{{ auth_me_url }}"
      data-auth-login-url="{{ auth_login_url }}"
      data-auth-logout-url="{{ auth_logout_url }}"
-     data-enable-crm="true"
-     data-track-events-url="https://api.hedgehog.cloud/events/track"
+     data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
+     data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
      data-hubdb-courses-table-id="135381433"
      data-hubdb-modules-table-id="135621904"
      style="display:none"></div>

--- a/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
+++ b/clean-x-hedgehog-templates/learn-shadow/pathways-page.html
@@ -23,14 +23,14 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'LOGOUT_URL': '/_hcms/mem/logout',
     'LOGIN_URL': '/_hcms/mem/login',
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
 
@@ -699,8 +699,8 @@
                data-auth-me-url="{{ auth_me_url }}"
                data-auth-login-url="{{ auth_login_url }}"
                data-auth-logout-url="{{ auth_logout_url }}"
-               data-enable-crm="true"
-               data-track-events-url="https://api.hedgehog.cloud/events/track"
+               data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
+               data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
                data-pathway-slug="{{ dynamic_page_hubdb_row.hs_path }}"
                data-total-modules="{{ dynamic_page_hubdb_row.module_count|default(0) }}"
                style="display:none"></div>
@@ -1024,8 +1024,8 @@
       data-auth-me-url="{{ auth_me_url }}"
       data-auth-login-url="{{ login_url }}"
       data-auth-logout-url="{{ logout_url }}"
-      data-track-events-url="https://api.hedgehog.cloud/events/track"
-      data-enable-crm="true"
+      data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+      data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}" 
       style="display:none"
     ></div>
     <script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn-shadow/assets/js/cognito-auth-integration.js') }}"></script>

--- a/clean-x-hedgehog-templates/learn-shadow/register.html
+++ b/clean-x-hedgehog-templates/learn-shadow/register.html
@@ -28,14 +28,14 @@
     'HUBDB_COURSES_TABLE_ID': '135381433',
     'HUBDB_CATALOG_TABLE_ID': '136199186',
     'DEFAULT_SOCIAL_IMAGE_URL': 'https://hedgehog.cloud/hubfs/social-share-default.png',
-    'ENABLE_CRM_PROGRESS': true,
+    'ENABLE_CRM_PROGRESS': false,
     'LOGOUT_URL': '/_hcms/mem/logout',
     'LOGIN_URL': '/_hcms/mem/login',
     'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
     'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
     'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout',
-    'TRACK_EVENTS_ENABLED': true,
-    'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
+    'TRACK_EVENTS_ENABLED': false,
+    'TRACK_EVENTS_URL': '',
     'ACTION_RUNNER_URL': '/learn-shadow/action-runner'
   } %}
   {% set social_image = constants.DEFAULT_SOCIAL_IMAGE_URL if constants else "https://hedgehog.cloud/hubfs/social-share-default.png" %}

--- a/docs/shadow-environment.md
+++ b/docs/shadow-environment.md
@@ -1,0 +1,156 @@
+# Shadow HH-Learn Environment
+
+This document describes the in-portal shadow environment for HH-Learn feature development. The shadow environment lives at `/learn-shadow/*` inside the production HubSpot portal and is isolated from the live `/learn` experience.
+
+**Status:** Phase 0A + 0B complete (Issues #371, #372). See epic #370 for the full roadmap.
+
+---
+
+## Architecture Overview
+
+```
+Production:   hedgehog.cloud/learn/*
+              ↓ templates: CLEAN x HEDGEHOG/templates/learn/
+              ↓ assets:    CLEAN x HEDGEHOG/templates/assets/{css,js}/
+              ↓ backend:   api.hedgehog.cloud (Lambda, DynamoDB, CRM)
+
+Shadow:       hedgehog.cloud/learn-shadow/*
+              ↓ templates: CLEAN x HEDGEHOG/templates/learn-shadow/
+              ↓ assets:    CLEAN x HEDGEHOG/templates/assets/shadow/{css,js}/
+              ↓ backend:   api.hedgehog.cloud (auth only — writes disabled)
+```
+
+Shadow pages are published but have `noindex, nofollow` in templates and `metaRobotsNoIndex: true` at the CMS page level. They are not linked from the production site.
+
+---
+
+## Backend Interaction Classification (Phase 0B)
+
+All stateful frontend → backend interactions were audited and classified:
+
+### Safe to Share
+
+| Endpoint | Method | Reason |
+|---|---|---|
+| `/auth/login` | GET | Redirect to Cognito — identity is shared across environments |
+| `/auth/signup` | GET | Same Cognito user pool — safe |
+| `/auth/callback` | GET | OAuth token exchange — read-only for the page |
+| `/auth/me` | GET | Returns user identity — read-only |
+| `/auth/logout` | POST/GET | Clears auth cookies — safe |
+| `/auth/check-email` | GET | Pre-auth lookup — read-only |
+| `/progress/read` | GET | Reads CRM contact properties — read-only |
+| `/progress/aggregate` | GET | Aggregated progress query — read-only |
+| `/enrollments/list` | GET | Lists enrollments — read-only |
+| HubDB API | GET | Content reads — read-only |
+
+### Disabled in Shadow (Phase 0B)
+
+| Endpoint | Method | Why Disabled | Config Key |
+|---|---|---|---|
+| `/events/track` | POST | Writes progress/enrollment state to DynamoDB and CRM. Shadow browsing must not pollute production user data. | `TRACK_EVENTS_ENABLED: false`, `TRACK_EVENTS_URL: ''` |
+
+### CRM Progress Display
+
+| Feature | Shadow Behavior | Config Key |
+|---|---|---|
+| CRM-backed progress bars/counts | **Disabled** — falls back to localStorage | `ENABLE_CRM_PROGRESS: false` |
+| My Learning dashboard | Shows localStorage-only data | `ENABLE_CRM_PROGRESS: false` |
+
+This ensures shadow env testers see a clean slate (local-only progress) rather than their real production progress, preventing confusion between environments.
+
+### Must Isolate (Future Phases)
+
+| Endpoint | Status | Notes |
+|---|---|---|
+| `/quiz/grade` | Not yet in templates — blocked in shadow by `TRACK_EVENTS_URL: ''` | When implemented, will need a shadow-specific Lambda stage or event tagging |
+| `/events/track` | Currently disabled | Phase 0C+: consider shadow-tagged events or a separate `stage: shadow` Lambda deployment |
+| HubDB tables | Currently shared | Phase 0C+: provision shadow HubDB tables for content isolation |
+
+---
+
+## How Environment-Aware Config Works
+
+Shadow templates use an inline `constants` block in every HubL template. Unlike production templates (which also inline constants), shadow templates set environment-specific values:
+
+```hubl
+{% set constants = {
+  'ENABLE_CRM_PROGRESS': false,
+  'TRACK_EVENTS_ENABLED': false,
+  'TRACK_EVENTS_URL': '',
+  'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+  'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+  ...
+} %}
+```
+
+The data attributes on the `#hhl-auth-context` element are rendered from these constants:
+
+```html
+data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}"
+data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+```
+
+This means the rendered HTML for shadow pages will have:
+```html
+data-enable-crm="false"
+data-track-events-url=""
+```
+
+The JavaScript reads these data attributes at runtime:
+- `data-enable-crm="false"` → `enrollment.js`, `courses.js`, `pathways.js`, `my-learning.js` skip CRM calls
+- `data-track-events-url=""` → `action-runner.js` guards against empty `trackUrl` and skips `fetch()`
+- `TRACK_EVENTS_ENABLED: false` → `pageview.js` does not send `sendBeacon()` events
+
+Auth data attributes continue to point to the production auth backend (safe — they are read-only identity operations).
+
+The authoritative shadow constant values are documented in `clean-x-hedgehog-templates/config/shadow-constants.json`. This file is for operator reference only; it is not loaded by HubL at runtime (constants are inlined directly in each template).
+
+---
+
+## Production Isolation Guarantee
+
+Production `/learn` templates and assets are **not modified** by the shadow environment setup. Production pages continue to use:
+- Templates at `CLEAN x HEDGEHOG/templates/learn/` (unchanged)
+- Assets at `CLEAN x HEDGEHOG/templates/assets/{css,js}/` (unchanged)
+- Inline constants with `ENABLE_CRM_PROGRESS: true`, `TRACK_EVENTS_ENABLED: true`, full backend URLs
+
+Shadow pages use:
+- Templates at `CLEAN x HEDGEHOG/templates/learn-shadow/` (isolated copies)
+- Assets at `CLEAN x HEDGEHOG/templates/assets/shadow/{css,js}/` (isolated copies)
+- Inline constants with writes disabled
+
+---
+
+## Operating the Shadow Environment
+
+### Updating shadow template config
+
+Edit the `{% set constants = {...} %}` block in the relevant shadow template under `clean-x-hedgehog-templates/learn-shadow/`. After editing:
+
+```bash
+npm run build && node dist/scripts/hubspot/upload-templates.js
+npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-template.js \
+  --path "CLEAN x HEDGEHOG/templates/learn-shadow/<filename>.html" \
+  --local "clean-x-hedgehog-templates/learn-shadow/<filename>.html"
+```
+
+### Reprovisioning shadow pages
+
+```bash
+npm run provision:shadow-pages [-- --dry-run] [-- --allow-create] [-- --publish]
+```
+
+### Enabling event tracking for a controlled shadow test
+
+If a future test requires tracking events in an isolated environment, the correct path is a separate Lambda stage (not re-enabling writes against production). See the Phase 0C+ notes above.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `clean-x-hedgehog-templates/learn-shadow/**` | Shadow page templates |
+| `clean-x-hedgehog-templates/assets/shadow/**` | Shadow CSS/JS assets |
+| `clean-x-hedgehog-templates/config/shadow-constants.json` | Authoritative shadow constant values (reference doc, not loaded at runtime) |
+| `scripts/hubspot/provision-shadow-pages.ts` | Shadow CMS page provisioning script |

--- a/verification-output/issue-372/backend-interaction-audit.md
+++ b/verification-output/issue-372/backend-interaction-audit.md
@@ -1,0 +1,55 @@
+# Phase 0B: Backend Interaction Audit — Issue #372
+
+## Scope
+
+All stateful frontend → backend interactions across the 8 shadow templates in `clean-x-hedgehog-templates/learn-shadow/`.
+
+---
+
+## Audit Results: Safe to Share
+
+| Endpoint | Method | Templates | Reason |
+|---|---|---|---|
+| `/auth/login` | GET redirect | all | Cognito redirect — identity shared across environments |
+| `/auth/signup` | GET redirect | register | Same Cognito user pool — safe |
+| `/auth/callback` | GET | all | OAuth token exchange — read-only for the page |
+| `/auth/me` | GET | all | Returns user identity — read-only |
+| `/auth/logout` | POST/GET | all | Clears auth cookies — safe |
+| `/auth/check-email` | GET | register | Pre-auth lookup — read-only |
+| `/progress/read` | GET | module-page, my-learning | Reads CRM contact properties — read-only |
+| `/progress/aggregate` | GET | courses-page, pathways-page | Aggregated progress query — read-only |
+| `/enrollments/list` | GET | courses-page, my-learning | Lists enrollments — read-only |
+| HubDB API | GET | all | Content reads — read-only |
+
+These endpoints are **shared with production**. Auth endpoints authenticate against the same Cognito user pool; `auth/me` is a read-only identity verification call.
+
+---
+
+## Audit Results: Disabled in Shadow
+
+| Endpoint | Method | Why Disabled | Config Key Set |
+|---|---|---|---|
+| `/events/track` | POST | Writes progress/enrollment state to DynamoDB and CRM. Shadow browsing must not pollute production user data. | `TRACK_EVENTS_ENABLED: false`, `TRACK_EVENTS_URL: ''` |
+
+---
+
+## CRM Progress Display (Disabled)
+
+| Feature | Shadow Behavior |
+|---|---|
+| CRM-backed progress bars | Disabled — falls back to localStorage |
+| My Learning dashboard | Shows localStorage-only data |
+| Course/pathway progress counts | Disabled — localStorage only |
+
+Config key: `ENABLE_CRM_PROGRESS: false`
+
+Shadow env testers see a clean slate (local-only progress) rather than their real production progress, preventing confusion between environments.
+
+---
+
+## Must Isolate (Future Phases)
+
+| Endpoint | Notes |
+|---|---|
+| `/quiz/grade` | Not yet in templates — blocked in shadow by `TRACK_EVENTS_URL: ''`. When implemented, will need a shadow-specific Lambda stage or event tagging |
+| HubDB tables | Currently shared (read-only). Phase 0C+: provision shadow HubDB tables for content isolation |

--- a/verification-output/issue-372/js-isolation-verification.md
+++ b/verification-output/issue-372/js-isolation-verification.md
@@ -1,0 +1,107 @@
+# Phase 0B Correction: Shadow JS Runtime Isolation — Issue #372
+
+## Problem Found (PR #378 Review)
+
+The shadow JS files cloned from production in Phase 0A still contained production paths as hardcoded fallbacks. These are not overridden by data attributes — they fire when `constants.ACTION_RUNNER_URL` is absent or falsy, or in `.catch()` error paths.
+
+### Files Affected
+
+| File | Issue |
+|---|---|
+| `assets/shadow/js/enrollment.js` | `getConstants()` default, `getActionRunnerBase()` fallback, `buildRunnerUrl()` base fallback — all `/learn/action-runner` |
+| `assets/shadow/js/progress.js` | Same 3 fallback sites PLUS `.catch()` hard fallback that set `TRACK_EVENTS_ENABLED: true` and `TRACK_EVENTS_URL: 'https://api.hedgehog.cloud/events/track'` |
+| `assets/shadow/js/my-learning.js` | 5 runtime link constructions: module card href, last-viewed resume href, enrollment card href, module list links, "Continue to Next Module" CTA |
+
+---
+
+## Changes Made
+
+### enrollment.js — 3 sites fixed
+
+```diff
+- ACTION_RUNNER_URL: '/learn/action-runner'   // getConstants() default
++ ACTION_RUNNER_URL: '/learn-shadow/action-runner'
+
+- return '/learn/action-runner';              // getActionRunnerBase() fallback
++ return '/learn-shadow/action-runner';
+
+- var runner = base || '/learn/action-runner'; // buildRunnerUrl() base fallback
++ var runner = base || '/learn-shadow/action-runner';
+```
+
+### progress.js — 4 sites fixed (including critical .catch() hard fallback)
+
+```diff
+// .catch() hard fallback — was ENABLING writes on error:
+- TRACK_EVENTS_ENABLED: true,
+- TRACK_EVENTS_URL: 'https://api.hedgehog.cloud/events/track',
+- ENABLE_CRM_PROGRESS: true,
+- ACTION_RUNNER_URL: '/learn/action-runner'
+// Now safe in all error paths:
++ TRACK_EVENTS_ENABLED: false,
++ TRACK_EVENTS_URL: '',
++ ENABLE_CRM_PROGRESS: false,
++ ACTION_RUNNER_URL: '/learn-shadow/action-runner'
+
+- return '/learn/action-runner';              // getActionRunnerBase() fallback
++ return '/learn-shadow/action-runner';
+
+- var runner = base || '/learn/action-runner'; // buildRunnerUrl() base fallback
++ var runner = base || '/learn-shadow/action-runner';
+```
+
+### my-learning.js — 5 runtime links fixed
+
+```diff
+- a.href = '/learn/' + (module.path || ...)          // module card href
++ a.href = '/learn-shadow/' + (module.path || ...)
+
+- var href = last.type === 'course' ? ('/learn/courses/' + ...) : ('/learn/' + ...) // resume link
++ var href = last.type === 'course' ? ('/learn-shadow/courses/' + ...) : ('/learn-shadow/' + ...)
+
+- var href = type === 'pathway' ? ('/learn/pathways/' + ...) : ('/learn/courses/' + ...) // enrollment card
++ var href = type === 'pathway' ? ('/learn-shadow/pathways/' + ...) : ('/learn-shadow/courses/' + ...)
+
+- <a href="/learn/'+modPath+'" ...>                   // module list links
++ <a href="/learn-shadow/'+modPath+'" ...>
+
+- <a href="/learn/'+nextPath+'" class="enrollment-cta"> // Continue CTA
++ <a href="/learn-shadow/'+nextPath+'" class="enrollment-cta">
+```
+
+---
+
+## Write-Isolation Guarantee After Fix
+
+Shadow enrollment/progress flows cannot reach the production write path because:
+
+1. **`data-track-events-url` is empty** → `action-runner.js` guards against empty `trackUrl` and skips `fetch()`
+2. **`data-enable-crm="false"`** → enrollment.js, progress.js, my-learning.js skip CRM calls
+3. **All `ACTION_RUNNER_URL` constants and JS fallbacks** now point to `/learn-shadow/action-runner`, not `/learn/action-runner`
+4. **`progress.js` `.catch()` hard fallback** — previously would have re-enabled writes if an error occurred reading constants; now sets `TRACK_EVENTS_ENABLED: false` and `TRACK_EVENTS_URL: ''` even on error
+5. **The shadow action-runner template** (`learn-shadow/action-runner.html`) has `TRACK_EVENTS_URL: ''` in its constants block, so even if the shadow action-runner is reached, it cannot post events to the backend
+
+No path through the shadow JS can construct a URL to `/learn/action-runner` at runtime.
+
+---
+
+## Other Shadow JS Files Checked
+
+| File | Status |
+|---|---|
+| `action-runner.js` | No action-runner URL construction — it's the runner itself |
+| `courses.js` | `/learn/action-runner` appears only in JSDoc comments, not runtime code |
+| `pathways.js` | Same — JSDoc comments only |
+| `login-helper.js` | `/learn/my-learning` appears only in a `@example` JSDoc block |
+| `pageview.js` | No action-runner references |
+| `auth.js`, `cognito-*.js` | Auth only — no action-runner references |
+
+---
+
+## Deploy Confirmation
+
+- All 65 files uploaded to HubSpot DRAFT: ✓ (0 failures)
+- `assets/shadow/js/enrollment.js` published live: ✓
+- `assets/shadow/js/progress.js` published live: ✓
+- `assets/shadow/js/my-learning.js` published live: ✓
+- All 7 shadow CMS pages republished: ✓

--- a/verification-output/issue-372/live-verification.md
+++ b/verification-output/issue-372/live-verification.md
@@ -1,0 +1,66 @@
+# Phase 0B: Live Verification — Issue #372
+
+## Verification Method
+
+Fetched live shadow pages and parsed `data-enable-crm` and `data-track-events-url` attributes from the `#hhl-auth-context` div after templates were uploaded and all 7 shadow CMS pages were republished.
+
+Date: 2026-04-07
+
+---
+
+## Shadow Page Results
+
+| Page | URL | data-enable-crm | data-track-events-url | Status |
+|---|---|---|---|---|
+| learn-shadow (get-started) | hedgehog.cloud/learn-shadow | no auth-context div (correct) | no auth-context div (correct) | ✓ |
+| learn-shadow/modules | hedgehog.cloud/learn-shadow/modules | `false` | `""` (empty) | ✓ |
+| learn-shadow/courses | hedgehog.cloud/learn-shadow/courses | `false` | `""` (empty) | ✓ |
+| learn-shadow/pathways | hedgehog.cloud/learn-shadow/pathways | `false` | `""` (empty) | ✓ |
+| learn-shadow/my-learning | hedgehog.cloud/learn-shadow/my-learning | `false` | `""` (empty) | ✓ |
+| learn-shadow/action-runner | hedgehog.cloud/learn-shadow/action-runner | `false` | `""` (empty) | ✓ |
+
+Note: `learn-shadow/register` has no `#hhl-auth-context` div (registration page — correct).
+Note: `learn-shadow` (get-started page) has no `#hhl-auth-context` div (pre-auth landing — correct).
+
+---
+
+## Production Isolation Check
+
+Confirmed production `/learn` pages are **unchanged**:
+
+| Page | data-enable-crm | data-track-events-url | Status |
+|---|---|---|---|
+| learn/modules | `true` | `https://api.hedgehog.cloud/events/track` | ✓ unchanged |
+| learn/courses | `true` | `https://api.hedgehog.cloud/events/track` | ✓ unchanged |
+
+Production templates and assets were not modified by Phase 0B work.
+
+---
+
+## Template Diff Summary
+
+### Constants block changes (all 8 shadow templates)
+
+```diff
+- 'ENABLE_CRM_PROGRESS': true,
++ 'ENABLE_CRM_PROGRESS': false,
+- 'TRACK_EVENTS_ENABLED': true,
+- 'TRACK_EVENTS_URL': 'https://api.hedgehog.cloud/events/track',
++ 'TRACK_EVENTS_ENABLED': false,
++ 'TRACK_EVENTS_URL': '',
+```
+
+Templates updated: action-runner.html, catalog.html, courses-page.html, module-page.html, my-learning.html, pathways-page.html, register.html, get-started.html (get-started has no auth-context div, constants change is still correct for consistency)
+
+### Data attribute changes (6 shadow templates)
+
+```diff
+- data-track-events-url="https://api.hedgehog.cloud/events/track"
++ data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
+- data-enable-crm="true"
++ data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}"
+```
+
+Templates updated: action-runner.html, catalog.html, courses-page.html, module-page.html, my-learning.html, pathways-page.html
+
+**Critical finding:** The original shadow templates (cloned from production in Phase 0A) had these data attributes hardcoded, bypassing the constants block entirely. The constants block alone would not have been sufficient — both the constants AND the data attribute rendering had to be updated.


### PR DESCRIPTION
## Summary

- Disabled all write operations in shadow templates: `TRACK_EVENTS_ENABLED: false`, `TRACK_EVENTS_URL: ''`, `ENABLE_CRM_PROGRESS: false`
- Fixed hardcoded data attributes in 6 shadow templates so they render from the constants block (without this, the constants changes would have had no effect on runtime JS behavior)
- Added `clean-x-hedgehog-templates/config/shadow-constants.json` as authoritative reference for all shadow constant values and decision rationale
- Added `docs/shadow-environment.md` with full architecture overview, backend interaction classification table, and operating procedures

Closes #372. Based on #377 (Phase 0A).

## Backend Interaction Classification

**Safe to share (production endpoints):** `/auth/login`, `/auth/signup`, `/auth/callback`, `/auth/me`, `/auth/logout`, `/auth/check-email`, `/progress/read`, `/progress/aggregate`, `/enrollments/list`, HubDB reads — all read-only or safe identity operations.

**Disabled in shadow:** `POST /events/track` — blocked via `TRACK_EVENTS_ENABLED: false` and `TRACK_EVENTS_URL: ''`. Shadow browsing cannot write progress or enrollment state to production DynamoDB/CRM.

**CRM progress display:** Disabled via `ENABLE_CRM_PROGRESS: false`. Shadow testers see localStorage-only progress, not their real production data.

## Key Finding

The original shadow templates (Phase 0A) had `data-enable-crm="true"` and `data-track-events-url="https://api.hedgehog.cloud/events/track"` hardcoded in HTML — the constants block alone would have been bypassed. Both the constants values and the data attribute rendering needed to be updated.

## Test plan

- [ ] Verify `data-enable-crm="false"` on all shadow pages with an auth-context div
- [ ] Verify `data-track-events-url=""` (empty) on all shadow pages with an auth-context div
- [ ] Verify production `learn/modules` and `learn/courses` still show `data-enable-crm="true"` and full track-events-url
- [ ] Confirm no events posted to `/events/track` when browsing `/learn-shadow/*` (network tab)
- [ ] Confirm auth flows still work (login/logout) — auth endpoints are shared

See `verification-output/issue-372/live-verification.md` for live verification results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)