### PR TITLE
feat(shadow): Phase 0C — provision published unlisted shadow pages (#373)

### DIFF
--- a/docs/shadow-environment.md
+++ b/docs/shadow-environment.md
@@ -140,6 +140,21 @@ npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-template.js \
 npm run provision:shadow-pages [-- --dry-run] [-- --allow-create] [-- --publish]
 ```
 
+### Anti-Indexing Controls
+
+Shadow pages are protected from search engine indexing at two layers:
+
+1. **Template-level (primary):** All shadow templates include `<meta name="robots" content="noindex, nofollow">`. This is the primary protection and is always active.
+
+2. **robots.txt (operator step):** The HubSpot v3 CMS API does not expose robots.txt editing. An operator must add the following rule manually in HubSpot:
+   - Navigate to: **Website → Pages → Settings → Crawlers & Indexing**
+   - Add to "Custom robots.txt additions":
+     ```
+     Disallow: /learn-shadow
+     Disallow: /learn-shadow/
+     ```
+   Shadow pages are not in the sitemap and are safe for use without the robots.txt change, but add it before any extended shadow testing period.
+
 ### Enabling event tracking for a controlled shadow test
 
 If a future test requires tracking events in an isolated environment, the correct path is a separate Lambda stage (not re-enabling writes against production). See the Phase 0C+ notes above.

--- a/docs/shadow-environment.md
+++ b/docs/shadow-environment.md
@@ -2,7 +2,7 @@
 
 This document describes the in-portal shadow environment for HH-Learn feature development. The shadow environment lives at `/learn-shadow/*` inside the production HubSpot portal and is isolated from the live `/learn` experience.
 
-**Status:** Phase 0A + 0B complete (Issues #371, #372). See epic #370 for the full roadmap.
+**Status:** Phase 0A + 0B + 0C complete (Issues #371, #372, #373). See epic #370 for the full roadmap.
 
 ---
 
@@ -20,7 +20,7 @@ Shadow:       hedgehog.cloud/learn-shadow/*
               ↓ backend:   api.hedgehog.cloud (auth only — writes disabled)
 ```
 
-Shadow pages are published but have `noindex, nofollow` in templates and `metaRobotsNoIndex: true` at the CMS page level. They are not linked from the production site.
+Shadow pages are published but have `noindex, nofollow` in templates. The HubSpot v3 CMS Pages API does not expose `metaRobotsNoIndex`/`metaRobotsNoFollow` fields — template-level `<meta name="robots" content="noindex, nofollow">` is the actual and only API-available anti-indexing mechanism. Shadow pages are not linked from the production site.
 
 ---
 

--- a/scripts/hubspot/provision-shadow-pages.ts
+++ b/scripts/hubspot/provision-shadow-pages.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 /**
- * Provision shadow CMS pages for the HH-Learn shadow environment (Issue #371)
+ * Provision shadow CMS pages for the HH-Learn shadow environment (Issues #371, #373)
  *
  * Shadow pages are published but unlisted pages that mirror the /learn structure
  * at /learn-shadow, allowing safe feature development without touching live pages.
@@ -164,11 +164,9 @@ async function createOrUpdatePage(
     slug: config.slug,
     templatePath: config.templatePath,
     state: 'DRAFT',
-    // Shadow pages must never appear in search results.
-    // Primary protection: <meta name="robots" content="noindex, nofollow"> in each template.
-    // Belt-and-suspenders: set HubSpot page-level no-index flags as well.
-    metaRobotsNoIndex: true,
-    metaRobotsNoFollow: true,
+    // Anti-indexing: primary protection is <meta name="robots" content="noindex, nofollow">
+    // rendered by each shadow template. The v3 CMS pages API does not expose metaRobots
+    // fields, so template-level noindex is the only mechanism available here.
     ...(publish && { publishImmediately: true, publicAccessRulesEnabled: false })
   };
 
@@ -204,17 +202,39 @@ async function createOrUpdatePage(
       return { name: config.name, slug: config.slug, id: '<skipped>', state: 'SKIPPED' };
     }
 
-    if (publish && page.state !== 'PUBLISHED') {
+    if (publish) {
+      // Use PATCH state=PUBLISHED via REST — the SDK's schedule() method is unreliable.
       try {
-        const api: any = hubspot.cms.pages.sitePagesApi;
-        await retryWithBackoff(() => api.schedule(String(page.id), String(page.id)));
-        console.log(`   ✓ Scheduled for publish`);
+        const token = getHubSpotToken();
+        const res = await retryWithBackoff(async () => {
+          const r = await fetch(
+            `https://api.hubapi.com/cms/v3/pages/site-pages/${page.id}`,
+            {
+              method: 'PATCH',
+              headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+              },
+              body: JSON.stringify({ state: 'PUBLISHED' })
+            }
+          );
+          if (!r.ok) {
+            const txt = await r.text();
+            const err: any = new Error(`HTTP ${r.status}: ${txt.substring(0, 200)}`);
+            err.code = r.status;
+            throw err;
+          }
+          return await r.json();
+        });
+        console.log(`   ✓ Published (state: ${res.state ?? 'PUBLISHED'})`);
+        page = res;
       } catch (err: any) {
-        console.log(`   ⚠️  Auto-publish failed: ${err.message}. Publish manually in CMS.`);
+        console.log(`   ⚠️  Publish failed: ${err.message}. Publish manually in HubSpot CMS.`);
       }
     }
 
-    return { name: config.name, slug: config.slug, id: String(page.id), state: publish ? 'PUBLISHED' : 'DRAFT', url: page.url };
+    return { name: config.name, slug: config.slug, id: String(page.id), state: page.state ?? (publish ? 'PUBLISHED' : 'DRAFT'), url: page.url };
   } catch (err: any) {
     console.error(`   ✗ Failed: ${err.message}`);
     if (err.body) console.error('   Details:', JSON.stringify(err.body, null, 2));
@@ -223,7 +243,7 @@ async function createOrUpdatePage(
 }
 
 async function provisionShadowPages(dryRun: boolean, publish: boolean, allowCreate: boolean) {
-  console.log('🌑 Starting shadow CMS page provisioning (Issue #371)...\n');
+  console.log('🌑 Starting shadow CMS page provisioning (Issues #371, #373)...\n');
   if (dryRun) console.log('📝 DRY RUN — no changes will be made\n');
   if (publish && !dryRun) console.log('🚀 PUBLISH MODE — pages published immediately\n');
   if (allowCreate && !dryRun) console.log('➕ CREATE MODE — new pages will be created\n');

--- a/verification-output/issue-373/shadow-page-inventory.md
+++ b/verification-output/issue-373/shadow-page-inventory.md
@@ -1,0 +1,89 @@
+# Phase 0C: Shadow Page Inventory — Issue #373
+
+## Shadow URL Prefix
+
+`/learn-shadow` — chosen in Phase 0A (#371), confirmed and documented in `docs/shadow-environment.md`.
+
+The issue suggested `/learn-next` or `/learn-dev`; `/learn-shadow` was selected and accepted in the Phase 0A review. This issue confirms that choice.
+
+---
+
+## Provisioned Shadow Pages
+
+All 7 shadow pages confirmed **PUBLISHED** via HubSpot CMS Pages API (2026-04-09).
+
+| Page Name | Slug | HubSpot ID | State | Template |
+|---|---|---|---|---|
+| Learn Shadow — Get Started | `learn-shadow` | 210727657869 | PUBLISHED | `learn-shadow/get-started.html` |
+| Learn Shadow — Modules | `learn-shadow/modules` | 210723427736 | PUBLISHED | `learn-shadow/module-page.html` |
+| Learn Shadow — Courses | `learn-shadow/courses` | 210727657871 | PUBLISHED | `learn-shadow/courses-page.html` |
+| Learn Shadow — Pathways | `learn-shadow/pathways` | 210723427738 | PUBLISHED | `learn-shadow/pathways-page.html` |
+| Learn Shadow — My Learning | `learn-shadow/my-learning` | 210723427741 | PUBLISHED | `learn-shadow/my-learning.html` |
+| Learn Shadow — Register | `learn-shadow/register` | 210727657873 | PUBLISHED | `learn-shadow/register.html` |
+| Learn Shadow — Action Runner | `learn-shadow/action-runner` | 210727657875 | PUBLISHED | `learn-shadow/action-runner.html` |
+
+All pages use the `learn-shadow/` template path prefix, isolating them from production templates.
+
+---
+
+## Page → Template → Asset Binding
+
+Each shadow page binds to:
+- **Template**: `CLEAN x HEDGEHOG/templates/learn-shadow/<template>.html` (isolated copy, not the production template)
+- **CSS**: `CLEAN x HEDGEHOG/templates/assets/shadow/css/` (isolated copies)
+- **JS**: `CLEAN x HEDGEHOG/templates/assets/shadow/js/` (isolated copies with shadow-safe paths)
+
+HubDB table bindings use the same production tables (read-only access; data isolation is Phase 0C+ future work per `docs/shadow-environment.md`).
+
+---
+
+## Anti-Indexing Controls
+
+### Template-level (primary)
+
+All 9 shadow templates include:
+```html
+<meta name="robots" content="noindex, nofollow">
+```
+This is the primary and reliable noindex mechanism. The HubSpot v3 CMS Pages API does not expose `metaRobotsNoIndex`/`metaRobotsNoFollow` fields — attempts to set them via the API payload are silently ignored. Template-level meta tags are rendered on every page response.
+
+### Sitemap
+
+Shadow pages confirmed absent from `https://hedgehog.cloud/sitemap.xml`.
+
+### HubSpot Page Naming
+
+All shadow pages use the prefix `Learn Shadow — ` in their HubSpot page name, making non-production status visible to operators in the CMS dashboard.
+
+### robots.txt — Operator Step Required
+
+Current `hedgehog.cloud/robots.txt` does not have a `Disallow: /learn-shadow` rule. HubSpot does not expose robots.txt editing via API. An operator must add the rule manually:
+
+**Steps:**
+1. HubSpot portal → **Website** → **Pages** → **Settings** → **Crawlers & Indexing**
+2. Under "Custom robots.txt additions", add:
+   ```
+   Disallow: /learn-shadow
+   Disallow: /learn-shadow/
+   ```
+3. Save and confirm the updated robots.txt at `https://hedgehog.cloud/robots.txt`.
+
+Note: The `noindex` meta tag is defense layer 1 and is already in place. The robots.txt disallow is defense layer 2. The shadow environment is safe for use without the robots.txt change, but the change should be made before any extended shadow testing period.
+
+---
+
+## Production Page Isolation
+
+Production `/learn` pages confirmed PUBLISHED and using production templates (not shadow templates):
+
+| Slug | State | Template |
+|---|---|---|
+| `learn` | PUBLISHED | `learn/get-started.html` |
+| `learn/modules` | PUBLISHED | `learn/module-page.html` |
+| `learn/courses` | PUBLISHED | `learn/courses-page.html` |
+
+---
+
+## Bug Fixed: Provision Script Publish Mechanism
+
+Previous runs of `npm run provision:shadow-pages -- --publish` appeared to succeed but left all pages in DRAFT state. Root cause: `hubspot.cms.pages.sitePagesApi.schedule()` does not work for page publishing in this context. Fixed by replacing with a direct `PATCH /cms/v3/pages/site-pages/{id}` with `{"state": "PUBLISHED"}`. Pages confirmed PUBLISHED via API after fix.


### PR DESCRIPTION
## Summary

- Fix the shadow page publish mechanism: `api.schedule()` was silently failing, leaving all 7 shadow pages in DRAFT. Replaced with `PATCH /cms/v3/pages/site-pages/{id}` with `{"state": "PUBLISHED"}`. All pages now confirmed PUBLISHED via API.
- Correct the anti-indexing documentation: the HubSpot v3 CMS API does not expose `metaRobotsNoIndex`/`metaRobotsNoFollow` fields — they were silently dropped. Template-level `<meta name="robots" content="noindex, nofollow">` (present in all 9 shadow templates) is the actual mechanism.
- Add robots.txt operator instructions to `docs/shadow-environment.md` (manual HubSpot UI step, not API-accessible).
- Add full page inventory verification artifact under `verification-output/issue-373/`.

Closes #373. Based on #378 (Phase 0B).

## Shadow URL Strategy

Prefix: `/learn-shadow` — chosen in Phase 0A (#371), confirmed here. The issue suggested `/learn-next` or `/learn-dev`; `/learn-shadow` was selected and accepted through the #371 review cycle.

## Pages Provisioned

All 7 shadow pages are PUBLISHED with correct template bindings:

| Slug | HubSpot ID | Template |
|---|---|---|
| `learn-shadow` | 210727657869 | `learn-shadow/get-started.html` |
| `learn-shadow/modules` | 210723427736 | `learn-shadow/module-page.html` |
| `learn-shadow/courses` | 210727657871 | `learn-shadow/courses-page.html` |
| `learn-shadow/pathways` | 210723427738 | `learn-shadow/pathways-page.html` |
| `learn-shadow/my-learning` | 210723427741 | `learn-shadow/my-learning.html` |
| `learn-shadow/register` | 210727657873 | `learn-shadow/register.html` |
| `learn-shadow/action-runner` | 210727657875 | `learn-shadow/action-runner.html` |

## Anti-Indexing

- Template `<meta name="robots" content="noindex, nofollow">`: present in all 9 shadow templates ✓
- Sitemap: shadow pages absent from `hedgehog.cloud/sitemap.xml` ✓
- robots.txt: `Disallow: /learn-shadow` not yet added — requires manual operator step in HubSpot portal (API limitation). Instructions added to `docs/shadow-environment.md`.

## Test plan

- [ ] Confirm all 7 shadow pages resolve (HTTP 200 with auth)
- [ ] Confirm `<meta name="robots" content="noindex, nofollow">` in rendered HTML of at least one shadow page
- [ ] Confirm production `/learn`, `/learn/modules`, `/learn/courses` still PUBLISHED and use production templates
- [ ] Operator: add `Disallow: /learn-shadow` to robots.txt via HubSpot portal settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)