### PR TITLE
feat(shadow): Phase 0D — CRM isolation conventions and form isolation (#374)

### DIFF
--- a/clean-x-hedgehog-templates/learn-shadow/register.html
+++ b/clean-x-hedgehog-templates/learn-shadow/register.html
@@ -115,10 +115,23 @@
           </div>
 
           <script>
+            {#
+              SHADOW FORM — OPERATOR ACTION REQUIRED (Issue #374)
+              This form ID must be replaced with the shadow-specific form.
+              Steps:
+              1. In HubSpot: Marketing → Forms → clone production form
+                 "HH-Learn Registration" → name it "HH-Learn Registration — Shadow"
+              2. Add hidden field to shadow form: hhl_environment = shadow
+              3. Copy the new form GUID and replace SHADOW_FORM_ID_PLACEHOLDER below.
+              See docs/shadow-operational-assets.md for full instructions.
+
+              Production form ID (DO NOT USE here): b2fd98ff-2055-41b2-85a0-0f497e798087
+              Shadow form ID (set after cloning):    SHADOW_FORM_ID_PLACEHOLDER
+            #}
             hbspt.forms.create({
               region: "na1",
               portalId: "21430285",
-              formId: "b2fd98ff-2055-41b2-85a0-0f497e798087",
+              formId: "SHADOW_FORM_ID_PLACEHOLDER",
               target: "#registration-form",
               onFormSubmit: function($form) {
                 console.log('Registration form submitted successfully');

--- a/docs/shadow-environment.md
+++ b/docs/shadow-environment.md
@@ -2,7 +2,9 @@
 
 This document describes the in-portal shadow environment for HH-Learn feature development. The shadow environment lives at `/learn-shadow/*` inside the production HubSpot portal and is isolated from the live `/learn` experience.
 
-**Status:** Phase 0A + 0B + 0C complete (Issues #371, #372, #373). See epic #370 for the full roadmap.
+**Status:** Phase 0A + 0B + 0C + 0D complete (Issues #371, #372, #373, #374). See epic #370 for the full roadmap.
+
+For operational asset conventions (forms, workflows, CRM isolation), see `docs/shadow-operational-assets.md`.
 
 ---
 

--- a/docs/shadow-operational-assets.md
+++ b/docs/shadow-operational-assets.md
@@ -1,0 +1,173 @@
+---
+title: Shadow Environment — Operational Asset Conventions
+issue: "#374"
+status: Phase 0D complete
+---
+
+# Shadow HH-Learn — Operational Asset Conventions
+
+This document covers the non-template HubSpot operational assets (forms, workflows, lists, reports) and CRM isolation conventions required to safely operate the shadow environment alongside the production `/learn` experience in the same HubSpot portal.
+
+See `docs/shadow-environment.md` for template/asset/backend isolation.
+
+---
+
+## Constraint: Same-Portal CRM
+
+The production and shadow environments share the same HubSpot portal (portal ID `21430285`). CRM contacts, form submissions, workflows, and lists cannot be physically separated. All isolation is therefore **operational** — naming conventions, environment markers, and filtering.
+
+---
+
+## Operational Asset Inventory
+
+### Forms
+
+| Asset | Production | Shadow | Clone Status |
+|---|---|---|---|
+| Registration form | `b2fd98ff-2055-41b2-85a0-0f497e798087` | `SHADOW_FORM_ID_PLACEHOLDER` | **Operator step required** (see below) |
+
+**All other forms:** None identified. The only form in use across HH-Learn templates is the registration form on the `/learn/register` and `/learn-shadow/register` pages.
+
+### Workflows
+
+| Asset | Production | Shadow | Status |
+|---|---|---|---|
+| Post-registration sequence (if any) | Existing | Operator step: clone and filter to shadow contacts | **Document and isolate** |
+
+No production workflows were found defined in this repo. Workflows are managed in HubSpot UI. Before activating any workflow that triggers on form submission or contact property changes, ensure it filters by `hhl_environment = production` or is cloned and re-targeted to `hhl_environment = shadow`.
+
+### Lists / Segments
+
+| Asset | Production | Shadow | Status |
+|---|---|---|---|
+| Any active-contact lists | Filter: `hhl_environment = production` | Filter: `hhl_environment = shadow` | **Apply after property is provisioned** |
+
+### Reports / Dashboards
+
+No shadow-specific reports are needed until active shadow testing begins. When created, apply `hhl_environment = shadow` as a filter to exclude shadow contacts from production metrics.
+
+---
+
+## CRM Environment Marker Convention
+
+### Property: `hhl_environment`
+
+**Purpose:** Distinguishes contacts and activity originating from the shadow environment vs. production. Enables filtering in workflows, lists, and reports.
+
+**Definition:**
+
+| Field | Value |
+|---|---|
+| Property name | `hhl_environment` |
+| Label | HHL Environment |
+| Type | `enumeration` (select) |
+| Group | `learning_milestones` |
+| Options | `production`, `shadow`, `test` |
+
+**Provisioning:**
+
+The property is defined in `scripts/hubspot/provision-shadow-crm-properties.ts` and can be provisioned via:
+```bash
+npm run provision:shadow-crm-properties
+```
+
+**API scope required:** `crm.schemas.contacts.write` — this scope must be granted to the private app (`HUBSPOT_PRIVATE_APP_TOKEN`) before the script can run. If the scope is not available, create the property manually in HubSpot:
+- HubSpot portal → **Settings** → **Properties** → **Contact Properties**
+- Create property with the definition above
+- Add options: Production, Shadow, Test
+
+**How it gets set on contacts:**
+
+1. **Shadow form hidden field (primary):** After cloning the shadow form (see below), add a hidden field `hhl_environment` with the default value `shadow`. Every contact created via the shadow form will automatically have this property set.
+
+2. **Workflow fallback:** Optionally create a workflow: `Enrolled in "HH-Learn Registration — Shadow"` → set `hhl_environment = shadow`. This catches cases where the form hidden field doesn't fire.
+
+3. **Test contacts:** Manually set `hhl_environment = test` for contacts used in automated testing.
+
+### Test Contact Email Convention
+
+Use the following email pattern for shadow/test contacts:
+```
+shadow-test+YYYYMMDD@hedgehog.cloud
+shadow-test+<purpose>@hedgehog.cloud
+```
+
+Examples:
+- `shadow-test+20260409@hedgehog.cloud`
+- `shadow-test+auth-flow@hedgehog.cloud`
+
+All test contacts should have `hhl_environment = shadow` or `hhl_environment = test`.
+
+**Filtering in HubSpot:**
+
+To exclude shadow/test contacts from production views, create a saved filter:
+- `hhl_environment` is `production` (or `is unknown`, for contacts before this property was added)
+
+---
+
+## Form Clone — Operator Steps
+
+The shadow registration form must be cloned manually (HubSpot Forms API requires `forms-access` scope, which is not granted to the current private app token).
+
+**Steps:**
+
+1. In HubSpot portal: **Marketing → Forms**
+2. Find the production form: `b2fd98ff-2055-41b2-85a0-0f497e798087`
+   - Name: "HH-Learn Registration" (or similar)
+3. Click **Actions → Clone**
+4. Name the clone: `HH-Learn Registration — Shadow`
+5. Open the cloned form and add a **Hidden field**:
+   - Property: `hhl_environment`
+   - Default value: `shadow`
+6. Save and copy the new form GUID (visible in the form's URL or embed code)
+7. In `clean-x-hedgehog-templates/learn-shadow/register.html`, replace `SHADOW_FORM_ID_PLACEHOLDER` with the new GUID
+8. Upload and publish the updated template:
+   ```bash
+   npm run build && node dist/scripts/hubspot/upload-templates.js
+   npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-template.js \
+     --path "CLEAN x HEDGEHOG/templates/learn-shadow/register.html" \
+     --local "clean-x-hedgehog-templates/learn-shadow/register.html"
+   ```
+9. Commit the updated `register.html` to git.
+
+---
+
+## Workflow Clone — Operator Steps (When Applicable)
+
+If production has a post-registration workflow (e.g., welcome email sequence) triggered by form submission to the production form:
+
+1. Clone the workflow in HubSpot: **Automation → Workflows**
+2. Name the clone: `[Shadow] <original name>`
+3. Change the enrollment trigger from production form → shadow form
+4. Add a contact filter: `hhl_environment = shadow`
+5. Pause the workflow until shadow testing is active
+
+**Important:** Never add the shadow form as a trigger to an existing production workflow. Always use a separate cloned workflow.
+
+---
+
+## Production Safety Guarantees
+
+The following are in place regardless of whether the form clone operator step has been completed:
+
+| Risk | Mitigation |
+|---|---|
+| Shadow events tracked to DynamoDB/CRM | `TRACK_EVENTS_ENABLED: false`, `TRACK_EVENTS_URL: ''` in all shadow templates (Phase 0B) |
+| Shadow pages indexed by search engines | `<meta name="robots" content="noindex, nofollow">` in all shadow templates (Phase 0A) |
+| Shadow pages in sitemap | Confirmed absent from sitemap.xml |
+| Shadow form submissions mixed with production | Shadow form not yet cloned — `SHADOW_FORM_ID_PLACEHOLDER` will cause form embed to fail gracefully (no submission possible) until operator completes clone step |
+
+The `SHADOW_FORM_ID_PLACEHOLDER` in `register.html` intentionally prevents shadow form submissions until the clone is complete. This is safer than the previous state where shadow used the production form ID.
+
+---
+
+## Summary: Automated vs Manual
+
+| Step | Status | Command |
+|---|---|---|
+| `hhl_environment` CRM property definition | Scripted (scope blocked) | `npm run provision:shadow-crm-properties` (after granting scope) |
+| Shadow registration form clone | **Manual operator step** | HubSpot UI (see above) |
+| Shadow `register.html` form ID update | Manual (after clone) | Edit + upload template |
+| Workflow clone | **Manual operator step** | HubSpot UI (when workflows exist) |
+| List/segment filter | Manual operator step | HubSpot UI (after property is provisioned) |
+| `hhl_environment = shadow` hidden field | Manual (part of form clone) | HubSpot UI |

--- a/docs/shadow-operational-assets.md
+++ b/docs/shadow-operational-assets.md
@@ -63,6 +63,7 @@ No shadow-specific reports are needed until active shadow testing begins. When c
 | Type | `enumeration` (select) |
 | Group | `learning_milestones` |
 | Options | `production`, `shadow`, `test` |
+| Form-usable (`formField`) | `true` — must be enabled so the property appears in the HubSpot form field selector and can be added as a hidden field on the cloned shadow registration form |
 
 **Provisioning:**
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "publish:constants": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-constants.js",
     "provision:pages": "npm run build && node dist/scripts/hubspot/provision-pages.js",
     "provision:shadow-pages": "npm run build && node dist/scripts/hubspot/provision-shadow-pages.js",
+    "provision:shadow-crm-properties": "npm run build && node dist/scripts/hubspot/provision-shadow-crm-properties.js",
     "publish:pages": "npm run build && node dist/scripts/hubspot/publish-pages.js",
     "publish:template": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/publish-template.js",
     "validate:template": "npm run build:scripts-cjs && node dist-cjs/scripts/hubspot/validate-template.js",

--- a/scripts/hubspot/provision-shadow-crm-properties.ts
+++ b/scripts/hubspot/provision-shadow-crm-properties.ts
@@ -34,7 +34,11 @@ const SHADOW_PROPERTIES = [
       { label: 'Shadow', value: 'shadow', displayOrder: 1, hidden: false },
       { label: 'Test', value: 'test', displayOrder: 2, hidden: false },
     ],
-    formField: false,
+    // formField: true — required so the property can be added as a hidden field
+    // on the cloned HubSpot registration form ("Show in forms and chat tools").
+    // HubSpot docs: contact properties must have this enabled to appear in
+    // form field selectors.
+    formField: true,
   },
 ];
 
@@ -50,34 +54,52 @@ async function upsertProperty(prop: any, dryRun: boolean): Promise<void> {
     return;
   }
 
-  // Check if property already exists
+  const propertyPayload = {
+    name: prop.name,
+    label: prop.label,
+    type: prop.type,
+    fieldType: prop.fieldType,
+    groupName: prop.groupName,
+    description: prop.description,
+    options: prop.options,
+    formField: prop.formField,
+  };
+
+  // Check if property already exists — if so, PATCH it to reconcile any wrong settings.
+  // Not returning early here ensures formField and options are always in the correct state
+  // even if the property was previously created with the wrong values.
+  let exists = false;
   try {
     const existing = await hubspot.crm.properties.coreApi.getByName('contacts', prop.name);
-    console.log(`   ✓ Already exists (type: ${existing.type})`);
-    return;
+    exists = true;
+    const formFieldMismatch = existing.formField !== prop.formField;
+    console.log(`   Found existing (type: ${existing.type}, formField: ${existing.formField})`);
+    if (formFieldMismatch) {
+      console.log(`   ⚠️  formField mismatch (want: ${prop.formField}, got: ${existing.formField}) — will PATCH`);
+    }
   } catch (err: any) {
     if (err.code !== 404 && err.statusCode !== 404) {
-      // Non-404 error — property may exist but something else is wrong
       console.warn(`   ⚠️  Existence check returned unexpected error: ${err.message}`);
     }
-    // 404 = doesn't exist yet, proceed to create
+    // 404 = doesn't exist yet
   }
 
   try {
-    const created = await hubspot.crm.properties.coreApi.create('contacts', {
-      name: prop.name,
-      label: prop.label,
-      type: prop.type,
-      fieldType: prop.fieldType,
-      groupName: prop.groupName,
-      description: prop.description,
-      options: prop.options,
-      formField: prop.formField,
-    } as any);
-    console.log(`   ✓ Created (type: ${created.type})`);
+    if (exists) {
+      // PATCH to reconcile — updates label, description, formField, and options
+      const updated = await hubspot.crm.properties.coreApi.update(
+        'contacts',
+        prop.name,
+        { label: prop.label, description: prop.description, options: prop.options, formField: prop.formField } as any
+      );
+      console.log(`   ✓ Updated (formField: ${updated.formField})`);
+    } else {
+      const created = await hubspot.crm.properties.coreApi.create('contacts', propertyPayload as any);
+      console.log(`   ✓ Created (type: ${created.type}, formField: ${created.formField})`);
+    }
   } catch (err: any) {
     if (err.statusCode === 409 || (err.body && err.body.message && err.body.message.includes('already exists'))) {
-      console.log(`   ✓ Already exists (conflict response)`);
+      console.log(`   ✓ Already exists (conflict — no changes applied; verify formField manually)`);
     } else {
       console.error(`   ✗ Failed: ${err.message}`);
       if (err.body) console.error('   Details:', JSON.stringify(err.body, null, 2));

--- a/scripts/hubspot/provision-shadow-crm-properties.ts
+++ b/scripts/hubspot/provision-shadow-crm-properties.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env ts-node
+/**
+ * Provision shadow environment CRM contact properties (Issue #374)
+ *
+ * Creates or verifies the CRM properties needed to distinguish shadow
+ * contacts/activity from production contacts in the same HubSpot portal.
+ *
+ * Properties created:
+ *   hhl_environment  — "production" | "shadow" | "test"
+ *                      Set by form hidden field or workflow on registration.
+ *                      Enables filtering shadow contacts out of production reports.
+ *
+ * Usage: npm run provision:shadow-crm-properties [-- --dry-run]
+ */
+
+import 'dotenv/config';
+import { Client } from '@hubspot/api-client';
+import { getHubSpotToken } from './get-hubspot-token.js';
+
+const hubspot = new Client({ accessToken: getHubSpotToken() });
+
+const PROPERTY_GROUP = 'learning_milestones';
+
+const SHADOW_PROPERTIES = [
+  {
+    name: 'hhl_environment',
+    label: 'HHL Environment',
+    type: 'enumeration',
+    fieldType: 'select',
+    groupName: PROPERTY_GROUP,
+    description: 'Identifies whether the contact originated from the production or shadow HH-Learn environment. Set via form hidden field or workflow. Use to filter shadow contacts from production reports.',
+    options: [
+      { label: 'Production', value: 'production', displayOrder: 0, hidden: false },
+      { label: 'Shadow', value: 'shadow', displayOrder: 1, hidden: false },
+      { label: 'Test', value: 'test', displayOrder: 2, hidden: false },
+    ],
+    formField: false,
+  },
+];
+
+async function upsertProperty(prop: any, dryRun: boolean): Promise<void> {
+  console.log(`\n📋 Property: ${prop.label} (${prop.name})`);
+
+  if (dryRun) {
+    console.log(`   [DRY RUN] Would create/update property in group "${prop.groupName}"`);
+    console.log(`   Type: ${prop.type} / ${prop.fieldType}`);
+    if (prop.options) {
+      console.log(`   Options: ${prop.options.map((o: any) => o.value).join(', ')}`);
+    }
+    return;
+  }
+
+  // Check if property already exists
+  try {
+    const existing = await hubspot.crm.properties.coreApi.getByName('contacts', prop.name);
+    console.log(`   ✓ Already exists (type: ${existing.type})`);
+    return;
+  } catch (err: any) {
+    if (err.code !== 404 && err.statusCode !== 404) {
+      // Non-404 error — property may exist but something else is wrong
+      console.warn(`   ⚠️  Existence check returned unexpected error: ${err.message}`);
+    }
+    // 404 = doesn't exist yet, proceed to create
+  }
+
+  try {
+    const created = await hubspot.crm.properties.coreApi.create('contacts', {
+      name: prop.name,
+      label: prop.label,
+      type: prop.type,
+      fieldType: prop.fieldType,
+      groupName: prop.groupName,
+      description: prop.description,
+      options: prop.options,
+      formField: prop.formField,
+    } as any);
+    console.log(`   ✓ Created (type: ${created.type})`);
+  } catch (err: any) {
+    if (err.statusCode === 409 || (err.body && err.body.message && err.body.message.includes('already exists'))) {
+      console.log(`   ✓ Already exists (conflict response)`);
+    } else {
+      console.error(`   ✗ Failed: ${err.message}`);
+      if (err.body) console.error('   Details:', JSON.stringify(err.body, null, 2));
+      throw err;
+    }
+  }
+}
+
+async function provisionShadowCrmProperties(dryRun: boolean): Promise<void> {
+  console.log('🔧 Provisioning shadow CRM properties (Issue #374)...\n');
+  if (dryRun) console.log('📝 DRY RUN — no changes will be made\n');
+
+  for (const prop of SHADOW_PROPERTIES) {
+    await upsertProperty(prop, dryRun);
+  }
+
+  console.log('\n✅ Shadow CRM property provisioning complete!\n');
+
+  if (!dryRun) {
+    console.log('Next steps:');
+    console.log('  1. In HubSpot portal, clone the production registration form:');
+    console.log('     Marketing → Forms → find "HH-Learn Registration" → Clone');
+    console.log('     Name the clone: "HH-Learn Registration — Shadow"');
+    console.log('  2. Add a hidden field to the shadow form: hhl_environment = shadow');
+    console.log('  3. Update clean-x-hedgehog-templates/learn-shadow/register.html');
+    console.log('     with the new shadow form ID (run: npm run provision:shadow-crm-properties -- --dry-run)');
+    console.log('     Then edit the formId in the register.html embed block.');
+    console.log('  See docs/shadow-operational-assets.md for full instructions.\n');
+  }
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+
+provisionShadowCrmProperties(dryRun).catch((err) => {
+  console.error('❌ Failed:', err.message);
+  process.exit(1);
+});

--- a/verification-output/issue-374/operational-asset-inventory.md
+++ b/verification-output/issue-374/operational-asset-inventory.md
@@ -26,7 +26,9 @@ Production and shadow share HubSpot portal `21430285`. CRM isolation is operatio
 - Type: `enumeration` (select)
 - Group: `learning_milestones`
 - Options: `production`, `shadow`, `test`
+- `formField: true` — required for the property to appear in HubSpot form field selectors ("Show in forms and chat tools"). This enables adding it as a hidden field on the cloned shadow registration form.
 - Provisioning: `npm run provision:shadow-crm-properties` (requires `crm.schemas.contacts.write` scope on private app — currently not granted; operator must grant scope or create property manually)
+- The script is a true upsert: if the property already exists, it PATCHes it to reconcile `formField` and `options` rather than returning early. This ensures a previously created property with `formField: false` is corrected automatically.
 - Once provisioned: add as hidden field on shadow form (value: `shadow`), add as filter on any production workflows/lists
 
 ### API Scope Constraint

--- a/verification-output/issue-374/operational-asset-inventory.md
+++ b/verification-output/issue-374/operational-asset-inventory.md
@@ -1,0 +1,77 @@
+# Phase 0D: Operational Asset Inventory — Issue #374
+
+## Constraint
+
+Production and shadow share HubSpot portal `21430285`. CRM isolation is operational (naming conventions + `hhl_environment` property), not physical.
+
+---
+
+## Forms
+
+### Production form
+- Form ID: `b2fd98ff-2055-41b2-85a0-0f497e798087`
+- Embed: `clean-x-hedgehog-templates/learn/register.html` line ~121
+- Status: Unchanged ✓
+
+### Shadow form
+- Previous state: shadow `register.html` embedded the **same production form ID** — shadow registrations were indistinguishable from production registrations.
+- Current state: shadow `register.html` now has `SHADOW_FORM_ID_PLACEHOLDER` instead of the production form ID. This intentionally breaks the embed until the operator completes the manual clone step. No shadow form submissions can occur in the meantime.
+- Clone required: **Operator step** — HubSpot Forms API requires `forms-access` scope (not granted to available tokens). Full instructions in `docs/shadow-operational-assets.md`.
+
+---
+
+## CRM Environment Marker
+
+### Property: `hhl_environment`
+- Type: `enumeration` (select)
+- Group: `learning_milestones`
+- Options: `production`, `shadow`, `test`
+- Provisioning: `npm run provision:shadow-crm-properties` (requires `crm.schemas.contacts.write` scope on private app — currently not granted; operator must grant scope or create property manually)
+- Once provisioned: add as hidden field on shadow form (value: `shadow`), add as filter on any production workflows/lists
+
+### API Scope Constraint
+The private app token (`HUBSPOT_PRIVATE_APP_TOKEN`) does not have `crm.schemas.contacts.write` scope. Neither does `HUBSPOT_PROJECT_ACCESS_TOKEN`. The property cannot be created programmatically with current tokens. This is documented as a required operator action.
+
+---
+
+## Workflows
+
+No production workflows were found defined in this repository. Workflows are managed entirely in the HubSpot portal UI. Conventions for shadow workflow naming and isolation are documented in `docs/shadow-operational-assets.md`.
+
+---
+
+## Lists / Segments / Reports
+
+No active lists or reports were found defined in this repository. Operator instructions for applying `hhl_environment` filter after property is provisioned are in `docs/shadow-operational-assets.md`.
+
+---
+
+## Test Contact Convention
+
+Email pattern: `shadow-test+<purpose>@hedgehog.cloud`
+CRM property: `hhl_environment = shadow` or `hhl_environment = test`
+
+---
+
+## What Was Automated vs Manual
+
+| Item | Automated | Manual |
+|---|---|---|
+| Shadow register.html form ID → placeholder | ✓ (this PR) | |
+| `hhl_environment` property definition + script | ✓ (script written, scope blocked) | Grant scope or create manually |
+| Registration form clone | | ✓ Operator (HubSpot UI) |
+| `hhl_environment = shadow` hidden field on form | | ✓ Operator (after clone) |
+| Shadow register.html form ID update | | ✓ Operator (after clone) |
+| Workflow clone | | ✓ Operator (when applicable) |
+| List/segment filter | | ✓ Operator (after property provisioned) |
+
+---
+
+## Production Safety: Current State
+
+| Risk | Status |
+|---|---|
+| Shadow events tracked to DynamoDB/CRM | Blocked — `TRACK_EVENTS_ENABLED: false` (Phase 0B) |
+| Shadow pages indexed | Blocked — `noindex,nofollow` in all shadow templates (Phase 0A) |
+| Shadow form submissions mixed with production | **Blocked** — `SHADOW_FORM_ID_PLACEHOLDER` prevents form render until operator clone is complete |
+| Production templates changed | Not changed ✓ |


### PR DESCRIPTION
## Summary

- Replace production form ID in shadow `register.html` with `SHADOW_FORM_ID_PLACEHOLDER` — prevents shadow form submissions from creating indistinguishable production CRM contacts until operator completes the manual form clone. Previous state silently used the production form ID.
- Add `scripts/hubspot/provision-shadow-crm-properties.ts`: provisions `hhl_environment` (`production`/`shadow`/`test`) contact property for CRM-level environment tagging. API scope limitation documented.
- Add `docs/shadow-operational-assets.md`: complete operational asset inventory, form clone procedure, CRM convention, test-contact email pattern, workflow/list naming conventions.
- Add `npm run provision:shadow-crm-properties` script.

Closes #374. Based on #379 (Phase 0C).

## Operational Asset Inventory

| Asset | Production | Shadow | Clone Status |
|---|---|---|---|
| Registration form | `b2fd98ff-...` | `SHADOW_FORM_ID_PLACEHOLDER` | Operator step required |
| Workflows | Portal UI | Clone + filter to `hhl_environment = shadow` | Operator step (when applicable) |
| Lists/segments | Portal UI | Apply `hhl_environment` filter | After property provisioned |
| Reports | Portal UI | Apply `hhl_environment = shadow` filter | When shadow testing active |

## CRM Isolation Convention

New contact property `hhl_environment` (enumeration: `production`, `shadow`, `test`) tags contacts at the CRM level. Set via:
1. Hidden field on shadow form (primary — after clone)
2. Workflow trigger fallback (optional)
3. Manual for test contacts

Test contact email pattern: `shadow-test+<purpose>@hedgehog.cloud`

## What's Automated vs Manual

| Step | Status |
|---|---|
| Shadow form ID → placeholder | ✓ This PR |
| `hhl_environment` property script | ✓ Written (blocked by API scope — operator grants `crm.schemas.contacts.write` or creates manually) |
| Form clone | Manual — HubSpot Forms API requires `forms-access` scope (not granted) |
| Shadow form hidden field (`hhl_environment = shadow`) | Manual (part of form clone) |
| Shadow `register.html` form ID update | Manual (after clone) |

## Production Safety

- Production `register.html` form ID unchanged ✓
- Shadow `SHADOW_FORM_ID_PLACEHOLDER` prevents any form submissions until operator clone is complete — safer than previous state ✓
- All Phase 0B write blocks remain in place (TRACK_EVENTS_ENABLED=false, etc.) ✓

## Test plan

- [ ] Confirm shadow `register.html` contains `SHADOW_FORM_ID_PLACEHOLDER` (not production form ID)
- [ ] Confirm production `register.html` still has original form ID
- [ ] Operator: grant `crm.schemas.contacts.write` to private app and run `npm run provision:shadow-crm-properties`, or create `hhl_environment` property manually
- [ ] Operator: complete form clone steps in `docs/shadow-operational-assets.md`, update shadow `register.html`, commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)