### PR TITLE
feat(my-learning): #383 UX redesign — production rollout

### DIFF
--- a/clean-x-hedgehog-templates/assets/js/my-learning.js
+++ b/clean-x-hedgehog-templates/assets/js/my-learning.js
@@ -1,12 +1,17 @@
 /**
- * Hedgehog Learn – My Learning dashboard (CSP-safe)
- * - Authenticated users: hydrate from CRM via GET /progress/read
- * - Logged-out users: fall back to localStorage
- * - Fetches module metadata from HubDB and renders In Progress and Completed sections
+ * Hedgehog Learn – My Learning dashboard (CSP-safe) — #383 UX redesign
+ *
+ * Production version. For shadow version see assets/shadow/js/my-learning.js.
+ *
+ * - Authenticated users (Cognito): hydrate from CRM via /progress/read + /enrollments/list
+ * - Anonymous users: fall back to localStorage (hh-module-* keys)
+ * - All CRM calls gated on waitForIdentityReady() and data-enable-crm="true"
+ * - HubDB used for display metadata only (names, descriptions, time estimates, ordering)
  */
 (function(){
   function ready(fn){ if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', fn); else fn(); }
   function fetchJSON(u){ return fetch(u, { credentials: 'include' }).then(function(r){ if(!r.ok) throw new Error('HTTP '+r.status); return r.json(); }); }
+
   function getConstants(){
     var ctx = document.getElementById('hhl-auth-context');
     var trackEventsUrl = ctx && ctx.getAttribute('data-track-events-url');
@@ -14,26 +19,25 @@
       TRACK_EVENTS_URL: trackEventsUrl || null,
       TRACK_EVENTS_ENABLED: !!trackEventsUrl,
       HUBDB_COURSES_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-courses-table-id')) || null,
-      HUBDB_MODULES_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-modules-table-id')) || null
+      HUBDB_MODULES_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-modules-table-id')) || null,
+      HUBDB_PATHWAYS_TABLE_ID: (ctx && ctx.getAttribute('data-hubdb-pathways-table-id')) || null
     });
   }
+
   function getAuth(){
-    // Use window.hhIdentity API for actual membership authentication
     var identity = window.hhIdentity ? window.hhIdentity.get() : null;
     var email = '';
     var contactId = '';
-    if (identity) {
-      email = identity.email || '';
-      contactId = identity.contactId || '';
-    }
-    // Get enableCrm from auth context div
+    if (identity) { email = identity.email || ''; contactId = identity.contactId || ''; }
     var el = document.getElementById('hhl-auth-context');
     var enableCrm = false;
+    var loginUrl = '';
     if (el) {
       var enableAttr = el.getAttribute('data-enable-crm');
       enableCrm = enableAttr && enableAttr.toString().toLowerCase() === 'true';
+      loginUrl = el.getAttribute('data-auth-login-url') || '';
     }
-    return { enableCrm: enableCrm, email: email, contactId: contactId };
+    return { enableCrm: enableCrm, email: email, contactId: contactId, loginUrl: loginUrl };
   }
 
   function waitForIdentityReady() {
@@ -44,18 +48,19 @@
     } catch (error) {}
     return Promise.resolve(null);
   }
+
   function getReadUrl(constants){
     var track = (constants && constants.TRACK_EVENTS_URL) || '';
-    // Derive: replace /events/track with /progress/read; fallback to relative
     if (track && track.indexOf('/events/track') >= 0) return track.replace('/events/track','/progress/read');
     return '/progress/read';
   }
+
   function getEnrollmentsUrl(constants){
     var track = (constants && constants.TRACK_EVENTS_URL) || '';
-    // Derive: replace /events/track with /enrollments/list; fallback to relative
     if (track && track.indexOf('/events/track') >= 0) return track.replace('/events/track','/enrollments/list');
     return '/enrollments/list';
   }
+
   function getAllProgress(){
     var prog = { inProgress: new Set(), completed: new Set() };
     try {
@@ -63,24 +68,23 @@
         var key = localStorage.key(i);
         if (key && key.startsWith('hh-module-')){
           var slug = key.replace('hh-module-','');
-          try { var data = JSON.parse(localStorage.getItem(key)||'{}');
-            if (data.completed) prog.completed.add(slug); else if (data.started) prog.inProgress.add(slug);
+          try {
+            var data = JSON.parse(localStorage.getItem(key)||'{}');
+            if (data.completed) prog.completed.add(slug);
+            else if (data.started) prog.inProgress.add(slug);
           } catch(e){}
         }
       }
     } catch(e){}
     return prog;
   }
+
   function setsFromCrm(progress){
     var res = { inProgress: new Set(), completed: new Set() };
     try {
       if (!progress) return res;
-
-      // Process each top-level key
       Object.keys(progress).forEach(function(key){
-        // Skip the 'courses' key as it's a container, not a pathway
         if (key === 'courses') {
-          // Process courses separately - they have nested structure
           var courses = progress.courses || {};
           Object.keys(courses).forEach(function(courseSlug){
             var courseModules = (courses[courseSlug] && courses[courseSlug].modules) || {};
@@ -91,61 +95,64 @@
             });
           });
         } else {
-          // Process pathway modules
-          var modules = (progress[key] && progress[key].modules) || {};
-          Object.keys(modules).forEach(function(slug){
-            var m = modules[slug] || {};
+          var flatMods = (progress[key] && progress[key].modules) || {};
+          Object.keys(flatMods).forEach(function(slug){
+            var m = flatMods[slug] || {};
             if (m.completed) res.completed.add(slug);
             else if (m.started) res.inProgress.add(slug);
+          });
+          var nestedCourses = (progress[key] && progress[key].courses) || {};
+          Object.keys(nestedCourses).forEach(function(courseSlug){
+            var courseModules = (nestedCourses[courseSlug] && nestedCourses[courseSlug].modules) || {};
+            Object.keys(courseModules).forEach(function(slug){
+              var m = courseModules[slug] || {};
+              if (m.completed) res.completed.add(slug);
+              else if (m.started) res.inProgress.add(slug);
+            });
           });
         }
       });
     } catch(e){}
     return res;
   }
-  function renderModuleCard(module, isCompleted){
-    var a = document.createElement('a');
-    a.href = '/learn/' + (module.path || module.hs_path || '');
-    a.className = 'module-card';
-    var minutes = (module.values && module.values.estimated_minutes) || module.estimated_minutes || 0;
-    var name = (module.values && module.values.hs_name) || module.hs_name || 'Untitled Module';
-    var desc = (module.values && module.values.meta_description) || module.meta_description || '';
-    a.innerHTML = '<div class="module-card-header">\
-        <span class="module-progress-badge '+(isCompleted?'completed':'')+'">'+(isCompleted?'Completed':'In Progress')+'</span>\
-        <span class="module-time">'+minutes+' min</span>\
-      </div>\
-      <h3>'+name+'</h3>' + (desc?('<p>'+desc.substring(0,150)+(desc.length>150?'...':'')+'</p>'):'') + '\
-      <span class="module-cta">'+(isCompleted?'Review Module':'Continue Learning')+' →</span>';
-    return a;
+
+  function buildModuleCourseContextMap(progress){
+    var map = {};
+    try {
+      if (!progress) return map;
+      Object.keys(progress).forEach(function(key){
+        if (key === 'courses') {
+          var courses = progress.courses || {};
+          Object.keys(courses).forEach(function(courseSlug){
+            var mods = (courses[courseSlug] && courses[courseSlug].modules) || {};
+            Object.keys(mods).forEach(function(slug){ map[slug] = courseSlug; });
+          });
+        } else {
+          var nestedCourses = (progress[key] && progress[key].courses) || {};
+          Object.keys(nestedCourses).forEach(function(courseSlug){
+            var mods = (nestedCourses[courseSlug] && nestedCourses[courseSlug].modules) || {};
+            Object.keys(mods).forEach(function(slug){ map[slug] = courseSlug; });
+          });
+          var flatMods = (progress[key] && progress[key].modules) || {};
+          Object.keys(flatMods).forEach(function(slug){ if (!map[slug]) map[slug] = key; });
+        }
+      });
+    } catch(e){}
+    return map;
   }
+
   function q(id){ return document.getElementById(id); }
-  function showResume(last){
-    try{
-      if (!last || !last.type || !last.slug) return;
-      var panel = q('last-viewed-panel');
-      var link = q('last-viewed-link');
-      var meta = q('last-viewed-meta');
-      var href = last.type === 'course' ? ('/learn/courses/' + last.slug) : ('/learn/' + last.slug);
-      link.href = href;
-      link.textContent = (last.type==='course'?'Course: ':'Module: ') + last.slug;
-      if (last.at) meta.textContent = '· viewed ' + last.at;
-      panel.style.display = 'block';
-    }catch(e){}
-  }
+
   function formatDate(isoString){
     if (!isoString) return '';
-    try {
-      var d = new Date(isoString);
-      return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    } catch(e) { return ''; }
+    try { return new Date(isoString).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }); }
+    catch(e) { return ''; }
   }
+
   function formatRelativeTime(isoString){
     if (!isoString) return '';
     try {
-      var now = new Date();
-      var then = new Date(isoString);
-      var diffMs = now - then;
-      var diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+      var diffDays = Math.floor((new Date() - new Date(isoString)) / (1000 * 60 * 60 * 24));
       if (diffDays === 0) return 'today';
       if (diffDays === 1) return 'yesterday';
       if (diffDays < 7) return diffDays + ' days ago';
@@ -153,103 +160,214 @@
       return formatDate(isoString);
     } catch(e) { return formatDate(isoString); }
   }
-  function renderEnrollmentCard(item, type, courseMetadata, progressData){
+
+  function formatMinutes(min){
+    if (!min || min <= 0) return '';
+    if (min < 60) return min + ' min';
+    var h = Math.floor(min / 60), m = min % 60;
+    return h + 'h' + (m ? ' ' + m + 'm' : '');
+  }
+
+  function slugToTitle(slug){
+    if (!slug) return '';
+    return slug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
+  }
+
+  function statusBadgeHtml(label, cssClass){
+    return '<span class="enrollment-status-badge '+cssClass+'">'+label+'</span>';
+  }
+
+  function showResume(last, constants){
+    try {
+      if (!last || !last.type || !last.slug) return;
+      var panel = q('last-viewed-panel');
+      if (!panel) return;
+      // Production paths: modules at /learn/<slug>, courses at /learn/courses/<slug>
+      var href = last.type === 'course' ? ('/learn/courses/' + last.slug) : ('/learn/' + last.slug);
+      var timeStr = last.at ? ('Last viewed ' + formatRelativeTime(last.at)) : '';
+      var typeLabel = last.type === 'course' ? 'Course' : 'Module';
+      var typeCss = last.type === 'course' ? 'resume-type-course' : 'resume-type-module';
+      var initialTitle = slugToTitle(last.slug);
+
+      panel.innerHTML = '\
+        <div class="resume-panel-inner">\
+          <div class="resume-panel-left">\
+            <span class="resume-type-badge '+typeCss+'">'+typeLabel+'</span>\
+            <div class="resume-title" id="resume-title">'+initialTitle+'</div>\
+            '+(timeStr?'<div class="resume-meta">'+timeStr+'</div>':'')+'\
+          </div>\
+          <a href="'+href+'" class="resume-cta">Continue \u2192</a>\
+        </div>';
+      panel.style.display = 'block';
+
+      var tableId = last.type === 'course' ? constants.HUBDB_COURSES_TABLE_ID : constants.HUBDB_MODULES_TABLE_ID;
+      if (tableId) {
+        fetchJSON('/hs/api/hubdb/v3/tables/'+tableId+'/rows?hs_path__eq='+encodeURIComponent(last.slug))
+          .then(function(data){
+            var row = data && data.results && data.results[0];
+            var title = row && ((row.values && row.values.hs_name) || row.hs_name);
+            if (title) { var el = q('resume-title'); if (el) el.textContent = title; }
+          })
+          .catch(function(){});
+      }
+    } catch(e){}
+  }
+
+  function renderModuleCard(module, isCompleted, courseContext){
+    var a = document.createElement('a');
+    // Production: module links use /learn/<slug> directly
+    a.href = '/learn/' + (module.path || module.hs_path || '');
+    a.className = 'module-card';
+    var minutes = (module.values && module.values.estimated_minutes) || module.estimated_minutes || 0;
+    var name = (module.values && module.values.hs_name) || module.hs_name || 'Untitled Module';
+    var desc = (module.values && module.values.meta_description) || module.meta_description || '';
+    var ctxHtml = courseContext ? '<div class="module-card-course"><span class="module-course-context">'+slugToTitle(courseContext)+'</span></div>' : '';
+    a.innerHTML = '<div class="module-card-header">\
+        <span class="module-progress-badge '+(isCompleted?'completed':'')+'">'+(isCompleted?'Completed':'In Progress')+'</span>\
+        <span class="module-time">'+minutes+' min</span>\
+      </div>\
+      '+ctxHtml+'\
+      <h3>'+name+'</h3>' + (desc?('<p>'+desc.substring(0,150)+(desc.length>150?'...':'')+'</p>'):'') + '\
+      <span class="module-cta">'+(isCompleted?'Review Module':'Continue Learning')+' \u2192</span>';
+    return a;
+  }
+
+  function renderEnrollmentCard(item, type, courseMetadata, progressData, pathwayHubDbData){
     var card = document.createElement('div');
     card.className = 'enrollment-card';
     var slug = item.slug || '';
     var enrolledAt = item.enrolled_at || '';
-    var source = item.enrollment_source || 'unknown';
-    var href = type === 'pathway' ? ('/learn/pathways/' + slug) : ('/learn/courses/' + slug);
-    var title = slug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
-    var sourceLabel = source.replace(/_/g, ' ');
 
-    // Build card header
-    var html = '<div class="enrollment-card-header">\
-        <h3><a href="'+href+'" style="color:#1a4e8a; text-decoration:none;">'+title+'</a></h3>\
-        <span class="enrollment-badge">'+type+'</span>\
-      </div>\
-      <div class="enrollment-meta">\
-        <div class="enrollment-date"><strong>Enrolled:</strong> '+formatDate(enrolledAt)+'</div>\
-        <div class="enrollment-source"><strong>Source:</strong> '+sourceLabel+'</div>\
-      </div>';
+    if (type === 'pathway') {
+      var href = '/learn/pathways/' + slug;
+      var title = slugToTitle(slug);
+      var pathwayCrm = (progressData && progressData.progress && progressData.progress[slug]) || {};
+      var crmCourses = pathwayCrm.courses || {};
+      var completedCount = Object.keys(crmCourses).filter(function(cs){ return crmCourses[cs] && crmCourses[cs].completed; }).length;
+      var courseSlugs = (pathwayHubDbData && pathwayHubDbData.course_slugs && pathwayHubDbData.course_slugs.length)
+        ? pathwayHubDbData.course_slugs : Object.keys(crmCourses);
+      var totalCount = courseSlugs.length;
+      var pct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+      var isComplete = !!pathwayCrm.completed;
+      var hasStarted = !!pathwayCrm.started || completedCount > 0;
 
-    // Add module listings if courseMetadata is provided
-    if (courseMetadata && courseMetadata.modules && courseMetadata.modules.length > 0){
+      var badge = isComplete ? statusBadgeHtml('Completed','status-completed') :
+                  (hasStarted ? statusBadgeHtml('In Progress','status-in-progress') :
+                  statusBadgeHtml('Not Started','status-not-started'));
+
+      var nextCourse = null;
+      for (var i = 0; i < courseSlugs.length; i++) {
+        var cs = courseSlugs[i];
+        if (!crmCourses[cs] || !crmCourses[cs].completed) { nextCourse = cs; break; }
+      }
+
+      var html = '<div class="enrollment-card-header">\
+          <h3><a href="'+href+'" style="color:#1a4e8a;text-decoration:none;">'+title+'</a></h3>\
+          <div class="enrollment-badges"><span class="enrollment-badge">pathway</span>'+badge+'</div>\
+        </div>';
+      if (enrolledAt) html += '<div class="enrollment-meta"><div class="enrollment-date">Enrolled '+formatDate(enrolledAt)+'</div></div>';
+      if (totalCount > 0) {
+        html += '<div class="enrollment-progress">\
+          <div class="enrollment-progress-label">'+completedCount+' of '+totalCount+' courses complete</div>\
+          <div class="enrollment-progress-bar"><div class="enrollment-progress-fill" style="width:'+pct+'%"></div></div>\
+        </div>';
+      }
+      if (isComplete) {
+        html += '<div class="enrollment-actions"><a href="'+href+'" class="enrollment-cta enrollment-cta--done">View Pathway \u2192</a></div>';
+      } else if (nextCourse) {
+        html += '<div class="enrollment-actions"><a href="/learn/courses/'+nextCourse+'" class="enrollment-cta">Continue Course \u2192</a></div>';
+      } else {
+        html += '<div class="enrollment-actions"><a href="'+href+'" class="enrollment-cta">Start Pathway \u2192</a></div>';
+      }
+
+      card.innerHTML = html;
+      return card;
+    }
+
+    // Course card
+    var href = '/learn/courses/' + slug;
+    var title = slugToTitle(slug);
+    var html = '';
+
+    if (courseMetadata && courseMetadata.modules && courseMetadata.modules.length > 0) {
       var modules = courseMetadata.modules;
-      var completedCount = 0;
-      var totalCount = modules.length;
-      var nextIncompleteModule = null;
+      var completedMods = 0;
+      var totalMods = modules.length;
+      var nextMod = null;
+      var remainMins = 0;
 
-      // Calculate completion count and find next incomplete
       modules.forEach(function(mod){
         if (mod.completed) {
-          completedCount++;
-        } else if (!nextIncompleteModule && mod.started) {
-          nextIncompleteModule = mod;
-        } else if (!nextIncompleteModule && !mod.started) {
-          nextIncompleteModule = mod;
+          completedMods++;
+        } else {
+          remainMins += mod.estimated_minutes || 0;
+          if (!nextMod) nextMod = mod;
         }
       });
 
-      var progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+      var pct = totalMods > 0 ? Math.round((completedMods / totalMods) * 100) : 0;
+      var isComplete = completedMods === totalMods;
+      var badge = isComplete ? statusBadgeHtml('Completed','status-completed') :
+                  (completedMods > 0 ? statusBadgeHtml('In Progress','status-in-progress') :
+                  statusBadgeHtml('Not Started','status-not-started'));
 
-      // Add progress bar
+      html = '<div class="enrollment-card-header">\
+          <h3><a href="'+href+'" style="color:#1a4e8a;text-decoration:none;">'+title+'</a></h3>\
+          <div class="enrollment-badges"><span class="enrollment-badge">course</span>'+badge+'</div>\
+        </div>';
+      if (enrolledAt) html += '<div class="enrollment-meta"><div class="enrollment-date">Enrolled '+formatDate(enrolledAt)+'</div></div>';
+
       html += '<div class="enrollment-progress">\
-        <div class="enrollment-progress-label">'+completedCount+' of '+totalCount+' modules complete ('+progressPercent+'%)</div>\
-        <div class="enrollment-progress-bar">\
-          <div class="enrollment-progress-fill" style="width:'+progressPercent+'%"></div>\
+        <div class="enrollment-progress-header">\
+          <span class="enrollment-progress-label">'+completedMods+' of '+totalMods+' modules complete</span>\
+          '+(remainMins>0&&!isComplete?'<span class="enrollment-time-remaining">'+formatMinutes(remainMins)+' left</span>':'')+'\
         </div>\
+        <div class="enrollment-progress-bar"><div class="enrollment-progress-fill" style="width:'+pct+'%"></div></div>\
       </div>';
 
-      // Add collapsible module list
       html += '<details class="enrollment-modules-toggle">\
-        <summary class="enrollment-modules-summary">View Modules</summary>\
+        <summary class="enrollment-modules-summary">View Modules ('+totalMods+')</summary>\
         <div class="enrollment-modules-list">';
-
       modules.forEach(function(mod){
         var modPath = mod.path || mod.hs_path || mod.slug;
-        var modName = mod.name || mod.hs_name || modPath.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); });
-        var modStatus = mod.completed ? '✓' : (mod.started ? '◐' : '○');
+        var modName = mod.name || mod.hs_name || slugToTitle(modPath);
+        var modStatus = mod.completed ? '\u2713' : (mod.started ? '\u25D0' : '\u25CB');
         var modStatusClass = mod.completed ? 'completed' : (mod.started ? 'in-progress' : 'not-started');
         html += '<div class="enrollment-module-item '+modStatusClass+'">\
           <span class="enrollment-module-status">'+modStatus+'</span>\
           <a href="/learn/'+modPath+'" class="enrollment-module-link">'+modName+'</a>\
         </div>';
       });
-
       html += '</div></details>';
 
-      // Update "Continue" button to link to next incomplete module
-      if (nextIncompleteModule) {
-        var nextPath = nextIncompleteModule.path || nextIncompleteModule.hs_path || nextIncompleteModule.slug;
-        html += '<div class="enrollment-actions">\
-          <a href="/learn/'+nextPath+'" class="enrollment-cta">Continue to Next Module →</a>\
-        </div>';
+      if (isComplete) {
+        html += '<div class="enrollment-actions"><a href="'+href+'" class="enrollment-cta enrollment-cta--done">Review Course \u2192</a></div>';
+      } else if (nextMod) {
+        var nextPath = nextMod.path || nextMod.hs_path || nextMod.slug;
+        html += '<div class="enrollment-actions"><a href="/learn/'+nextPath+'" class="enrollment-cta">Continue to Next Module \u2192</a></div>';
       } else {
-        html += '<div class="enrollment-actions">\
-          <a href="'+href+'" class="enrollment-cta">View Course →</a>\
-        </div>';
+        html += '<div class="enrollment-actions"><a href="'+href+'" class="enrollment-cta">Start Course \u2192</a></div>';
       }
     } else {
-      // No module metadata, show generic "Continue Learning" button
-      html += '<div class="enrollment-actions">\
-        <a href="'+href+'" class="enrollment-cta">Continue Learning →</a>\
-      </div>';
+      html = '<div class="enrollment-card-header">\
+          <h3><a href="'+href+'" style="color:#1a4e8a;text-decoration:none;">'+title+'</a></h3>\
+          <div class="enrollment-badges"><span class="enrollment-badge">course</span></div>\
+        </div>';
+      if (enrolledAt) html += '<div class="enrollment-meta"><div class="enrollment-date">Enrolled '+formatDate(enrolledAt)+'</div></div>';
+      html += '<div class="enrollment-actions"><a href="'+href+'" class="enrollment-cta">Continue Learning \u2192</a></div>';
     }
 
     card.innerHTML = html;
     return card;
   }
+
   function renderEnrolledContent(enrollments, constants, progressData){
     try {
       var pathways = enrollments.pathways || [];
       var courses = enrollments.courses || [];
       var enrolledSection = q('enrolled-section');
       var enrolledGrid = q('enrolled-grid');
-
       if (!enrolledSection || !enrolledGrid) return;
-
-      // Clear existing content
       enrolledGrid.innerHTML = '';
 
       if (pathways.length === 0 && courses.length === 0){
@@ -259,18 +377,19 @@
 
       var COURSES_TABLE_ID = constants.HUBDB_COURSES_TABLE_ID;
       var MODULES_TABLE_ID = constants.HUBDB_MODULES_TABLE_ID;
+      var PATHWAYS_TABLE_ID = constants.HUBDB_PATHWAYS_TABLE_ID;
 
       function getCourseProgress(courseSlug){
         if (!progressData || !progressData.progress || !courseSlug) return null;
         var prog = progressData.progress;
         if (prog.courses && prog.courses[courseSlug]) return prog.courses[courseSlug];
-        var nested = null;
-        Object.keys(prog).forEach(function(pathwaySlug){
-          if (pathwaySlug !== 'courses' && prog[pathwaySlug] && prog[pathwaySlug].courses && prog[pathwaySlug].courses[courseSlug]) {
-            nested = prog[pathwaySlug].courses[courseSlug];
+        var found = null;
+        Object.keys(prog).forEach(function(pk){
+          if (pk !== 'courses' && prog[pk] && prog[pk].courses && prog[pk].courses[courseSlug]) {
+            found = prog[pk].courses[courseSlug];
           }
         });
-        return nested;
+        return found;
       }
 
       function buildFallbackCourseMetadataMap(){
@@ -278,164 +397,128 @@
         courses.forEach(function(course){
           var courseSlug = (course && course.slug) || '';
           if (!courseSlug) return;
-          var courseProgress = getCourseProgress(courseSlug);
-          var moduleProgressMap = (courseProgress && courseProgress.modules) || {};
-          var moduleSlugs = Object.keys(moduleProgressMap);
-          if (moduleSlugs.length === 0) return;
+          var cp = getCourseProgress(courseSlug);
+          var modMap = (cp && cp.modules) || {};
+          var modSlugs = Object.keys(modMap);
+          if (!modSlugs.length) return;
           fallback[courseSlug] = {
-            modules: moduleSlugs.map(function(modSlug){
-              var modProgress = moduleProgressMap[modSlug] || {};
-              return {
-                slug: modSlug,
-                path: modSlug,
-                hs_path: modSlug,
-                name: modSlug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); }),
-                hs_name: modSlug.replace(/-/g, ' ').replace(/\b\w/g, function(l){ return l.toUpperCase(); }),
-                started: !!modProgress.started,
-                completed: !!modProgress.completed
-              };
+            modules: modSlugs.map(function(ms){
+              var mp = modMap[ms] || {};
+              return { slug:ms, path:ms, hs_path:ms, name:slugToTitle(ms), hs_name:slugToTitle(ms), estimated_minutes:0, started:!!mp.started, completed:!!mp.completed };
             })
           };
         });
         return Object.keys(fallback).length ? fallback : null;
       }
 
-      // Fetch course metadata for all enrolled courses
-      var coursePromises = courses.map(function(course){
-        var courseSlug = course.slug || '';
-        if (!COURSES_TABLE_ID || !courseSlug) return Promise.resolve(null);
-
-        return fetchJSON('/hs/api/hubdb/v3/tables/'+COURSES_TABLE_ID+'/rows?hs_path__eq='+encodeURIComponent(courseSlug))
-          .then(function(data){
-            if (!data || !data.results || data.results.length === 0) return null;
-            var courseRow = data.results[0];
-            var moduleSlugsJson = (courseRow.values && courseRow.values.module_slugs_json) || courseRow.module_slugs_json || '[]';
-            var moduleSlugs = [];
-            try {
-              moduleSlugs = JSON.parse(moduleSlugsJson);
-            } catch(e){}
-
-            return {
-              courseSlug: courseSlug,
-              moduleSlugs: moduleSlugs,
-              courseRow: courseRow
-            };
+      var pathwayFetches = pathways.map(function(pw){
+        var slug = pw.slug || '';
+        if (!PATHWAYS_TABLE_ID || !slug) return Promise.resolve(null);
+        return fetchJSON('/hs/api/hubdb/v3/tables/'+PATHWAYS_TABLE_ID+'/rows?hs_path__eq='+encodeURIComponent(slug))
+          .then(function(d){
+            if (!d || !d.results || !d.results.length) return null;
+            var row = d.results[0];
+            var json = (row.values && row.values.course_slugs_json) || row.course_slugs_json || '[]';
+            var slugs = []; try { slugs = JSON.parse(json); } catch(e){}
+            return { pathwaySlug: slug, course_slugs: slugs };
           })
           .catch(function(){ return null; });
       });
 
-      // Wait for all course metadata to load
-      Promise.all(coursePromises).then(function(coursesData){
-        // Fetch module metadata for all unique module slugs
-        var allModuleSlugs = [];
-        coursesData.forEach(function(courseData){
-          if (courseData && courseData.moduleSlugs) {
-            allModuleSlugs = allModuleSlugs.concat(courseData.moduleSlugs);
-          }
-        });
+      var courseFetches = courses.map(function(course){
+        var slug = course.slug || '';
+        if (!COURSES_TABLE_ID || !slug) return Promise.resolve(null);
+        return fetchJSON('/hs/api/hubdb/v3/tables/'+COURSES_TABLE_ID+'/rows?hs_path__eq='+encodeURIComponent(slug))
+          .then(function(d){
+            if (!d || !d.results || !d.results.length) return null;
+            var row = d.results[0];
+            var json = (row.values && row.values.module_slugs_json) || row.module_slugs_json || '[]';
+            var slugs = []; try { slugs = JSON.parse(json); } catch(e){}
+            return { courseSlug: slug, moduleSlugs: slugs };
+          })
+          .catch(function(){ return null; });
+      });
 
-        // Remove duplicates
-        allModuleSlugs = Array.from(new Set(allModuleSlugs));
+      Promise.all([Promise.all(pathwayFetches), Promise.all(courseFetches)]).then(function(res){
+        var pathwaysData = res[0];
+        var coursesData = res[1];
 
-        if (allModuleSlugs.length === 0 || !MODULES_TABLE_ID) {
-          // No HubDB module metadata available; fall back to progress state module slugs.
-          renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+        var allModSlugs = [];
+        coursesData.forEach(function(cd){ if (cd && cd.moduleSlugs) allModSlugs = allModSlugs.concat(cd.moduleSlugs); });
+        allModSlugs = Array.from(new Set(allModSlugs));
+
+        if (!allModSlugs.length || !MODULES_TABLE_ID) {
+          renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData, pathwaysData);
           return;
         }
 
-        // Fetch all module metadata in one batch
-        var filter = allModuleSlugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
+        var filter = allModSlugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
         fetchJSON('/hs/api/hubdb/v3/tables/'+MODULES_TABLE_ID+'/rows?'+filter+'&tags__not__icontains=archived')
-          .then(function(data){
-            var modules = (data && data.results) || [];
-
-            // Build a map of moduleSlug -> moduleData
-            var moduleMap = {};
-            modules.forEach(function(mod){
-              var slug = (mod.values && mod.values.hs_path) || mod.hs_path || mod.path;
-              if (slug) moduleMap[slug] = mod;
+          .then(function(d){
+            var modMap = {};
+            ((d && d.results) || []).forEach(function(m){
+              var s = (m.values && m.values.hs_path) || m.hs_path || m.path;
+              if (s) modMap[s] = m;
             });
 
-            // Build course metadata with modules and progress
             var courseMetadataMap = {};
-            coursesData.forEach(function(courseData){
-              if (!courseData) return;
-              var courseSlug = courseData.courseSlug;
-              var moduleSlugs = courseData.moduleSlugs;
-
-              // Get progress data for this course
-              var courseProgress = null;
-              if (progressData && progressData.progress) {
-                var prog = progressData.progress;
-                // Check in courses container
-                if (prog.courses && prog.courses[courseSlug]) {
-                  courseProgress = prog.courses[courseSlug];
-                }
-                // Also check in pathways
-                Object.keys(prog).forEach(function(pathwaySlug){
-                  if (pathwaySlug !== 'courses' && prog[pathwaySlug].courses && prog[pathwaySlug].courses[courseSlug]) {
-                    courseProgress = prog[pathwaySlug].courses[courseSlug];
-                  }
-                });
-              }
-
-              // Build module list with progress
-              var modulesWithProgress = moduleSlugs.map(function(modSlug){
-                var modData = moduleMap[modSlug] || {};
-                var modProgress = (courseProgress && courseProgress.modules && courseProgress.modules[modSlug]) || {};
-                return {
-                  slug: modSlug,
-                  path: (modData.values && modData.values.hs_path) || modData.hs_path || modSlug,
-                  hs_path: (modData.values && modData.values.hs_path) || modData.hs_path || modSlug,
-                  name: (modData.values && modData.values.hs_name) || modData.hs_name || '',
-                  hs_name: (modData.values && modData.values.hs_name) || modData.hs_name || '',
-                  started: modProgress.started || false,
-                  completed: modProgress.completed || false
-                };
-              });
-
-              courseMetadataMap[courseSlug] = {
-                modules: modulesWithProgress
+            coursesData.forEach(function(cd){
+              if (!cd) return;
+              var cp = getCourseProgress(cd.courseSlug);
+              courseMetadataMap[cd.courseSlug] = {
+                modules: cd.moduleSlugs.map(function(ms){
+                  var md = modMap[ms] || {};
+                  var mp = (cp && cp.modules && cp.modules[ms]) || {};
+                  return {
+                    slug: ms,
+                    path: (md.values && md.values.hs_path) || md.hs_path || ms,
+                    hs_path: (md.values && md.values.hs_path) || md.hs_path || ms,
+                    name: (md.values && md.values.hs_name) || md.hs_name || '',
+                    hs_name: (md.values && md.values.hs_name) || md.hs_name || '',
+                    estimated_minutes: (md.values && md.values.estimated_minutes) || md.estimated_minutes || 0,
+                    started: !!mp.started,
+                    completed: !!mp.completed
+                  };
+                })
               };
             });
 
-            renderEnrolledCards(pathways, courses, courseMetadataMap, progressData);
+            renderEnrolledCards(pathways, courses, courseMetadataMap, progressData, pathwaysData);
           })
           .catch(function(err){
             console.error('[hhl-my-learning] Error fetching module metadata:', err);
-            renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+            renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData, pathwaysData);
           });
       }).catch(function(err){
-        console.error('[hhl-my-learning] Error fetching course metadata:', err);
-        renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData);
+        console.error('[hhl-my-learning] Error fetching enrollment metadata:', err);
+        renderEnrolledCards(pathways, courses, buildFallbackCourseMetadataMap(), progressData, []);
       });
 
-      function renderEnrolledCards(pathways, courses, courseMetadataMap, progressData){
-        // Render pathways
-        pathways.forEach(function(pathway){
-          enrolledGrid.appendChild(renderEnrollmentCard(pathway, 'pathway', null, progressData));
-        });
+      function renderEnrolledCards(pathways, courses, courseMetadataMap, progressData, pathwaysData){
+        var pwMap = {};
+        (pathwaysData||[]).forEach(function(pd){ if (pd && pd.pathwaySlug) pwMap[pd.pathwaySlug] = pd; });
 
-        // Render courses with metadata
+        pathways.forEach(function(pw){
+          enrolledGrid.appendChild(renderEnrollmentCard(pw, 'pathway', null, progressData, pwMap[pw.slug]||null));
+        });
         courses.forEach(function(course){
-          var courseMetadata = courseMetadataMap ? courseMetadataMap[course.slug] : null;
-          enrolledGrid.appendChild(renderEnrollmentCard(course, 'course', courseMetadata, progressData));
+          var meta = courseMetadataMap ? courseMetadataMap[course.slug] : null;
+          enrolledGrid.appendChild(renderEnrollmentCard(course, 'course', meta, progressData, null));
         });
 
-        // Update count and show section
-        var totalEnrolled = pathways.length + courses.length;
-        var enrolledCount = q('enrolled-count');
-        if (enrolledCount) enrolledCount.textContent = '(' + totalEnrolled + ')';
+        var total = pathways.length + courses.length;
+        var countEl = q('enrolled-count');
+        if (countEl) countEl.textContent = '(' + total + ')';
         enrolledSection.style.display = 'block';
+
+        var statEl = q('stat-enrolled');
+        if (statEl) statEl.textContent = total;
       }
     } catch(e){
       console.error('[hhl-my-learning] Error rendering enrolled content:', e);
-      // Show error state to user
       var errorGrid = q('enrolled-grid');
       if (errorGrid) {
-        errorGrid.innerHTML = '<div style="padding:20px; text-align:center; color:#666;">\
-          <p>Unable to load enrollments. Please refresh the page to try again.</p>\
-        </div>';
+        errorGrid.innerHTML = '<div style="padding:20px;text-align:center;color:#666;"><p>Unable to load enrollments. Please refresh to try again.</p></div>';
       }
     }
   }
@@ -443,72 +526,91 @@
   ready(function(){
     waitForIdentityReady().finally(function(){
       Promise.resolve(getConstants()).then(function(constants){
-      var MODULES_TABLE_ID = constants.HUBDB_MODULES_TABLE_ID;
-      var auth = getAuth();
-      // default: localStorage fallback
-      var localSets = getAllProgress();
+        var MODULES_TABLE_ID = constants.HUBDB_MODULES_TABLE_ID;
+        var auth = getAuth();
+        var localSets = getAllProgress();
 
-      function renderFromSets(sets){
-        var slugs = Array.from(new Set([].concat(Array.from(sets.inProgress), Array.from(sets.completed))));
-        function done(modules){
-          q('loading-state').style.display = 'none';
-          q('main-content-container').style.display = 'block';
-          var inProg = modules.filter(function(m){ return sets.inProgress.has(m.path); });
-          var comp = modules.filter(function(m){ return sets.completed.has(m.path); });
-          q('stat-in-progress').textContent = inProg.length;
-          q('stat-completed').textContent = comp.length;
-          if (inProg.length===0 && comp.length===0){ q('empty-state').style.display = 'block'; return; }
-          if (inProg.length>0){
-            q('in-progress-count').textContent = '('+inProg.length+')';
-            var c1 = q('in-progress-modules'); inProg.forEach(function(m){ c1.appendChild(renderModuleCard(m,false)); });
-            q('in-progress-section').style.display = 'block';
+        function renderFromSets(sets, moduleCourseMap, hasEnrollments){
+          var slugs = Array.from(new Set([].concat(Array.from(sets.inProgress), Array.from(sets.completed))));
+          function done(modules){
+            q('loading-state').style.display = 'none';
+            q('main-content-container').style.display = 'block';
+            var inProg = modules.filter(function(m){ return sets.inProgress.has(m.path); });
+            var comp = modules.filter(function(m){ return sets.completed.has(m.path); });
+            q('stat-in-progress').textContent = inProg.length;
+            q('stat-completed').textContent = comp.length;
+            if (inProg.length===0 && comp.length===0){
+              if (!hasEnrollments) q('empty-state').style.display = 'block';
+              return;
+            }
+            if (inProg.length>0){
+              q('in-progress-count').textContent = '('+inProg.length+')';
+              var c1 = q('in-progress-modules');
+              inProg.forEach(function(m){
+                var ctx = moduleCourseMap ? moduleCourseMap[m.path] : null;
+                c1.appendChild(renderModuleCard(m, false, ctx));
+              });
+              q('in-progress-section').style.display = 'block';
+            }
+            if (comp.length>0){
+              q('completed-count').textContent = '('+comp.length+')';
+              var c2 = q('completed-modules');
+              comp.forEach(function(m){
+                var ctx = moduleCourseMap ? moduleCourseMap[m.path] : null;
+                c2.appendChild(renderModuleCard(m, true, ctx));
+              });
+              q('completed-section').style.display = 'block';
+            }
           }
-          if (comp.length>0){
-            q('completed-count').textContent = '('+comp.length+')';
-            var c2 = q('completed-modules'); comp.forEach(function(m){ c2.appendChild(renderModuleCard(m,true)); });
-            q('completed-section').style.display = 'block';
-          }
+          if (!MODULES_TABLE_ID || slugs.length===0){ return done([]); }
+          var filter = slugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
+          fetchJSON('/hs/api/hubdb/v3/tables/'+MODULES_TABLE_ID+'/rows?'+filter+'&tags__not__icontains=archived')
+            .then(function(data){ done((data && data.results)||[]); })
+            .catch(function(){ done([]); });
         }
-        if (!MODULES_TABLE_ID || slugs.length===0){ return done([]); }
-    var filter = slugs.map(function(s){ return 'hs_path__eq='+encodeURIComponent(s); }).join('&');
-        fetchJSON('/hs/api/hubdb/v3/tables/'+MODULES_TABLE_ID+'/rows?'+filter+'&tags__not__icontains=archived')
-          .then(function(data){ done((data && data.results)||[]); })
-          .catch(function(){ done([]); });
-      }
 
-      if (auth.enableCrm && (auth.email || auth.contactId)){
-        var readUrl = getReadUrl(constants);
-        var enrollUrl = getEnrollmentsUrl(constants);
-        var query = auth.contactId ? ('?contactId='+encodeURIComponent(auth.contactId)) : ('?email='+encodeURIComponent(auth.email));
+        if (auth.enableCrm && (auth.email || auth.contactId)){
+          var syncEl = document.querySelector('.synced-indicator');
+          if (syncEl) syncEl.style.display = 'flex';
 
-        // Fetch both progress and enrollments in parallel
-        Promise.all([
-          fetchJSON(readUrl + query).catch(function(){ return null; }),
-          fetchJSON(enrollUrl + query).catch(function(){ return null; })
-        ]).then(function(results){
-          var progressData = results[0];
-          var enrollmentData = results[1];
+          var readUrl = getReadUrl(constants);
+          var enrollUrl = getEnrollmentsUrl(constants);
+          var query = auth.contactId ? ('?contactId='+encodeURIComponent(auth.contactId)) : ('?email='+encodeURIComponent(auth.email));
 
-          // Show resume panel if available
-          if (progressData && progressData.mode === 'authenticated' && progressData.last_viewed){
-            showResume(progressData.last_viewed);
-          }
+          Promise.all([
+            fetchJSON(readUrl + query).catch(function(){ return null; }),
+            fetchJSON(enrollUrl + query).catch(function(){ return null; })
+          ]).then(function(results){
+            var progressData = results[0];
+            var enrollmentData = results[1];
 
-          // Render enrolled content if available
-          if (enrollmentData && enrollmentData.mode === 'authenticated' && enrollmentData.enrollments){
-            renderEnrolledContent(enrollmentData.enrollments, constants, progressData);
-          }
+            if (progressData && progressData.mode === 'authenticated' && progressData.last_viewed){
+              showResume(progressData.last_viewed, constants);
+            }
 
-          // Render module progress
-          if (progressData && progressData.mode === 'authenticated' && progressData.progress){
-            return renderFromSets(setsFromCrm(progressData.progress));
-          }
-          renderFromSets(localSets);
-        }).catch(function(){ renderFromSets(localSets); });
-      } else {
-        renderFromSets(localSets);
-      }
-    });
+            var hasEnrollments = !!(enrollmentData && enrollmentData.mode === 'authenticated' && enrollmentData.enrollments &&
+              ((enrollmentData.enrollments.pathways || []).length + (enrollmentData.enrollments.courses || []).length) > 0);
+
+            if (enrollmentData && enrollmentData.mode === 'authenticated' && enrollmentData.enrollments){
+              renderEnrolledContent(enrollmentData.enrollments, constants, progressData);
+            }
+
+            var moduleCourseMap = null;
+            if (progressData && progressData.progress) {
+              moduleCourseMap = buildModuleCourseContextMap(progressData.progress);
+            }
+
+            if (progressData && progressData.mode === 'authenticated' && progressData.progress){
+              return renderFromSets(setsFromCrm(progressData.progress), moduleCourseMap, hasEnrollments);
+            }
+            renderFromSets(localSets, null, hasEnrollments);
+          }).catch(function(){ renderFromSets(localSets, null, false); });
+        } else {
+          var authPrompt = q('auth-prompt');
+          if (authPrompt) authPrompt.style.display = 'block';
+          renderFromSets(localSets, null, false);
+        }
+      });
     });
   });
 })();

--- a/clean-x-hedgehog-templates/learn/my-learning.html
+++ b/clean-x-hedgehog-templates/learn/my-learning.html
@@ -474,6 +474,104 @@
     to { transform: rotate(360deg); }
   }
 
+  /* Resume panel — #383 redesign */
+  #last-viewed-panel {
+    margin: 0 0 24px 0;
+    padding: 16px 20px;
+    border: 1px solid #BFDBFE;
+    border-radius: 10px;
+    background: linear-gradient(135deg, #EFF6FF 0%, #DBEAFE 60%);
+  }
+  .resume-panel-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  .resume-panel-left {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+  }
+  .resume-type-badge {
+    display: inline-block;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    background: #DBEAFE;
+    color: #1E40AF;
+    width: fit-content;
+  }
+  .resume-type-course { background: #FEF3C7; color: #92400E; }
+  .resume-type-module { background: #DBEAFE; color: #1E40AF; }
+  .resume-title {
+    font-size: 1.0625rem;
+    font-weight: 700;
+    color: #111827;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .resume-meta { font-size: 0.8125rem; color: #6B7280; }
+  .resume-cta {
+    background: #1a4e8a;
+    color: #fff;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    padding: 10px 20px;
+    border-radius: 8px;
+    white-space: nowrap;
+    transition: background 0.2s;
+    flex-shrink: 0;
+  }
+  .resume-cta:hover { background: #154171; color: #fff; }
+
+  /* Status badges — #383 redesign */
+  .enrollment-badges { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; flex-shrink: 0; }
+  .enrollment-status-badge {
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 3px 8px;
+    border-radius: 10px;
+    white-space: nowrap;
+  }
+  .status-completed { background: #D1FAE5; color: #065F46; }
+  .status-in-progress { background: #DBEAFE; color: #1E40AF; }
+  .status-not-started { background: #F3F4F6; color: #6B7280; }
+
+  /* Course time-remaining badge — #383 redesign */
+  .enrollment-progress-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+  .enrollment-time-remaining {
+    font-size: 0.8125rem;
+    color: #0369A1;
+    font-weight: 600;
+    background: #E0F2FE;
+    padding: 2px 8px;
+    border-radius: 10px;
+    white-space: nowrap;
+  }
+  .enrollment-cta--done { color: #059669; }
+  .enrollment-cta--done:hover { color: #047857; }
+
+  /* Module card course context badge — #383 redesign */
+  .module-card-course { margin: 2px 0 8px; }
+  .module-course-context {
+    font-size: 0.75rem;
+    color: #6B7280;
+    background: #F3F4F6;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-weight: 500;
+  }
+
   @media (max-width: 900px) {
     .learn-header-content, .learn-container {
       padding: 0 16px;
@@ -487,6 +585,15 @@
     }
     .progress-stats {
       gap: 32px;
+    }
+    .resume-panel-inner {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .resume-cta {
+      width: 100%;
+      text-align: center;
+      justify-content: center;
     }
   }
 </style>
@@ -511,7 +618,7 @@
 
       <!-- Main content (hidden until loaded) -->
       <div id="main-content-container" style="display: none;">
-        <!-- Progress Summary -->
+        <!-- Progress Summary — #383: added Enrolled stat; auth-prompt or synced-indicator activated by JS -->
         <div class="progress-summary">
           <div class="progress-stats">
             <div class="progress-stat">
@@ -522,8 +629,12 @@
               <div class="progress-stat-number" id="stat-completed">0</div>
               <div class="progress-stat-label">Completed</div>
             </div>
+            <div class="progress-stat">
+              <div class="progress-stat-number" id="stat-enrolled">0</div>
+              <div class="progress-stat-label">Enrolled</div>
+            </div>
           </div>
-          {# Issue #345: Auth state and prompts driven by Cognito JS client-side #}
+          {# Issue #345 / #383: synced-indicator shown for CRM auth users; auth-prompt for anonymous #}
           <div class="synced-indicator" style="display: none;">
             <span class="synced-indicator-icon">✓</span>
             <span>Progress synced across devices</span>
@@ -533,12 +644,8 @@
           </div>
         </div>
 
-        <!-- Resume Panel (authenticated only) -->
-        <div id="last-viewed-panel" style="display:none; margin: 16px 0 8px 0; padding: 12px 16px; border:1px solid #E5E7EB; border-radius:8px; background:#F9FAFB;">
-          <span style="color:#374151; font-weight:600;">Resume: </span>
-          <a id="last-viewed-link" href="#" style="color:#0066CC; font-weight:600; text-decoration:none;"></a>
-          <span id="last-viewed-meta" style="color:#6B7280; margin-left:8px;"></span>
-        </div>
+        <!-- Resume Panel (authenticated only) — #383: JS regenerates full innerHTML -->
+        <div id="last-viewed-panel" style="display:none;"></div>
 
         <!-- Enrolled Content Section (authenticated only) -->
         <section id="enrolled-section" style="display: none;">
@@ -592,10 +699,11 @@
      data-auth-me-url="{{ auth_me_url }}"
      data-auth-login-url="{{ auth_login_url }}"
      data-auth-logout-url="{{ auth_logout_url }}"
-     data-enable-crm="true"
-     data-track-events-url="https://api.hedgehog.cloud/events/track"
+     data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}"
+     data-track-events-url="{{ constants.TRACK_EVENTS_URL }}"
      data-hubdb-courses-table-id="135381433"
      data-hubdb-modules-table-id="135621904"
+     data-hubdb-pathways-table-id="135381504"
      style="display:none"></div>
 <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/login-helper.js') }}"></script>
 {# Line 609 - Cognito auth replaces membership auth (Issue #345) - NO defer to load before my-learning.js #}

--- a/verification-output/issue-383-prod/prod-rollout-verification.md
+++ b/verification-output/issue-383-prod/prod-rollout-verification.md
@@ -1,0 +1,142 @@
+# Issue #383 — My Learning UX Redesign: Production Rollout Verification
+
+Date: 2026-04-09  
+Branch: issue-383-prod-rollout  
+Approved shadow baseline: issue-383-shadow-only (PR #393, project-lead approved 2026-04-09)
+
+---
+
+## 1. Rollout Scope
+
+This is a production-only port of the approved shadow implementation (#393).  
+Shadow files are unchanged. Only production files are modified.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `clean-x-hedgehog-templates/assets/js/my-learning.js` | Production JS ported from approved shadow version |
+| `clean-x-hedgehog-templates/learn/my-learning.html` | Production template ported from approved shadow version |
+
+### Files Unchanged (shadow preserved)
+
+| File | Status |
+|------|--------|
+| `clean-x-hedgehog-templates/assets/shadow/js/my-learning.js` | Unchanged — approved shadow version |
+| `clean-x-hedgehog-templates/learn-shadow/my-learning.html` | Unchanged — approved shadow version |
+| `docs/my-learning.md` | Unchanged — already updated in #393 |
+
+---
+
+## 2. Shadow → Production Diff (URL paths only)
+
+All logic is identical between shadow and production. The only differences are URL paths:
+
+| Context | Shadow | Production |
+|---------|--------|------------|
+| Module links | `/learn-shadow/modules/<slug>` | `/learn/<slug>` |
+| Course links | `/learn-shadow/courses/<slug>` | `/learn/courses/<slug>` |
+| Pathway links | `/learn-shadow/pathways/<slug>` | `/learn/pathways/<slug>` |
+| Resume module href | `/learn-shadow/modules/<slug>` | `/learn/<slug>` |
+| Resume course href | `/learn-shadow/courses/<slug>` | `/learn/courses/<slug>` |
+| Empty state CTA | `/learn-shadow/pathways` | `/learn/pathways` |
+
+### Template-level differences
+
+| Aspect | Shadow | Production |
+|--------|--------|------------|
+| `ENABLE_CRM_PROGRESS` | `false` | `true` |
+| `TRACK_EVENTS_ENABLED` | `false` | `true` |
+| `TRACK_EVENTS_URL` | `''` | `'https://api.hedgehog.cloud/events/track'` |
+| `ACTION_RUNNER_URL` | `/learn-shadow/action-runner` | `/learn/action-runner` |
+| Left nav macro | `learn-shadow/macros/left-nav.html` | `learn/macros/left-nav.html` |
+| CSS/JS assets | `assets/shadow/css|js/` | `assets/css|js/` |
+| `cognito-auth-integration.js` | `learn-shadow/assets/js/` | `learn/assets/js/` |
+| `noindex, nofollow` meta | Present | Absent |
+| Canonical URL | `/learn-shadow/my-learning` | `/learn/my-learning` |
+
+---
+
+## 3. Pre-Publish Safety Checks (verified by code inspection)
+
+### No shadow paths in production files
+- `grep learn-shadow assets/js/my-learning.js` → 0 matches ✅
+- `grep learn-shadow learn/my-learning.html` → 0 matches ✅
+
+### CRM enabled
+- `data-enable-crm` evaluates to `"true"` (ENABLE_CRM_PROGRESS: true) ✅
+- `TRACK_EVENTS_URL` is set → `/progress/read` and `/enrollments/list` derived correctly ✅
+
+### No noindex in production template
+- `grep noindex learn/my-learning.html` → 0 matches ✅
+
+### Auth flow unchanged
+- `waitForIdentityReady()` still awaited before any CRM calls ✅
+- CRM gate: `auth.enableCrm && (auth.email || auth.contactId)` — same as approved shadow ✅
+- `synced-indicator` shown for CRM auth users ✅
+- `auth-prompt` shown for anonymous users (same as shadow, but on prod this is the fallback path) ✅
+
+### Backward compatibility
+- `setsFromCrm()` handles both flat and hierarchical CRM progress models ✅
+- `getAllProgress()` localStorage fallback unchanged ✅
+- No CRM schema changes; read-only redesign ✅
+
+---
+
+## 4. Validated Directly (shadow approval)
+
+The following were validated on the live shadow site by the project lead on 2026-04-09:
+
+- Page loads without JS errors
+- Loading spinner shown initially
+- Empty state shown when localStorage has no progress
+- Module cards render correctly with badge/CTA after adding localStorage test entries
+- Progress summary stats (In Progress, Completed, Enrolled=0) correct
+- Auth-prompt banner shown (was dead code before #383 — now activated by JS)
+- Shadow links use `/learn-shadow/` prefix — verified no `/learn/` leak in shadow
+
+---
+
+## 5. Production-Only Behaviors (code-path inspection only)
+
+These require an authenticated CRM user on production and cannot be shadow-verified:
+
+| Behavior | Basis |
+|----------|-------|
+| `synced-indicator` shown for authenticated users | JS:syncEl.style.display='flex' when CRM path taken |
+| Resume panel renders with real title | `showResume()` uses CRM `last_viewed` + async HubDB title fetch |
+| Pathway enrollment cards show course progress | `renderEnrollmentCard(type='pathway')` reads CRM courses + HubDB course_slugs_json |
+| Course enrollment cards show time remaining | `renderEnrollmentCard(type='course')` sums `estimated_minutes` for incomplete modules |
+| Module cards show course context badge | `buildModuleCourseContextMap()` builds map from CRM progress |
+| Empty state suppressed when enrollments present | `hasEnrollments` flag from `/enrollments/list` response |
+| Enrolled stat shows > 0 | Set in `renderEnrolledCards()` after enrollment API returns |
+| CRM fallback to localStorage on API failure | `.catch(function(){ renderFromSets(localSets, null, false); })` |
+
+---
+
+## 6. Known Limitations (unchanged from shadow, data model constraints)
+
+| Limitation | Impact |
+|------------|--------|
+| Single `last_viewed` per CRM user | Resume panel shows only one item, not per-pathway context |
+| No `estimated_minutes` fallback | Time remaining badge only shows when HubDB has field populated |
+| Course completion is Lambda/content-driven | Content changes to `content/courses/*.json` retroactively affect completion |
+| `module_slugs_json` HubDB must match `content/courses/*.json` | Drift breaks enrollment card module order |
+
+---
+
+## 7. Publish Command (when approved)
+
+```bash
+# Production JS
+npm run publish:template -- \
+  --path "CLEAN x HEDGEHOG/templates/assets/js/my-learning.js" \
+  --local "clean-x-hedgehog-templates/assets/js/my-learning.js"
+
+# Production template
+npm run publish:template -- \
+  --path "CLEAN x HEDGEHOG/templates/learn/my-learning.html" \
+  --local "clean-x-hedgehog-templates/learn/my-learning.html"
+```
+
+Do NOT publish shadow files as part of this rollout. Shadow was published as part of #393.


### PR DESCRIPTION
## Summary

Production rollout of the project-lead-approved My Learning UX redesign.

**Shadow implementation approved by project lead on 2026-04-09 (PR #393).**  
This PR is production-only. Shadow files are unchanged.

Closes #394.

## Diff vs main — exactly 3 files

```
clean-x-hedgehog-templates/assets/js/my-learning.js
clean-x-hedgehog-templates/learn/my-learning.html
verification-output/issue-383-prod/prod-rollout-verification.md
```

No shadow files. No unrelated docs. No prior shadow-environment work.

## Approved shadow baseline

- PR #393 (`issue-383-shadow-only`) — project-lead approved 2026-04-09
- Shadow logic is identical; only URL paths and template constants differ

## Shadow → Production differences (complete list)

| Aspect | Shadow | Production |
|--------|--------|------------|
| Module links | `/learn-shadow/modules/<slug>` | `/learn/<slug>` |
| Course links | `/learn-shadow/courses/<slug>` | `/learn/courses/<slug>` |
| Pathway links | `/learn-shadow/pathways/<slug>` | `/learn/pathways/<slug>` |
| `ENABLE_CRM_PROGRESS` | `false` | `true` |
| `TRACK_EVENTS_URL` | `''` | `'https://api.hedgehog.cloud/events/track'` |
| `ACTION_RUNNER_URL` | `/learn-shadow/action-runner` | `/learn/action-runner` |
| Left nav macro | `learn-shadow/macros/` | `learn/macros/` |
| CSS/JS asset paths | `assets/shadow/` | `assets/` |
| `cognito-auth-integration.js` | `learn-shadow/assets/js/` | `learn/assets/js/` |
| `noindex` meta | Present | **Absent** |
| Canonical URL | `/learn-shadow/my-learning` | `/learn/my-learning` |

## Pre-publish safety checks (all pass)

- `grep learn-shadow assets/js/my-learning.js` → **0 matches** ✅
- `grep learn-shadow learn/my-learning.html` → **0 matches** ✅
- `grep noindex learn/my-learning.html` → **0 matches** ✅
- `ENABLE_CRM_PROGRESS: true` ✅
- `TRACK_EVENTS_URL: 'https://api.hedgehog.cloud/events/track'` ✅
- `data-hubdb-pathways-table-id="135381504"` present ✅
- `assets/js/my-learning.js` loaded (not shadow path) ✅

## UX features (same as approved shadow)

- Pathway enrollment cards: course progress bar, status badge, CTA to first incomplete course
- Course enrollment cards: module progress bar, time remaining badge, collapsible module list, status badge, smart CTA
- Resume panel: type badge, real title (async HubDB fetch), relative time, "Continue →" CTA
- Module cards: course context badge (from CRM state, no extra API calls)
- Progress summary: 3 stats (In Progress, Completed, Enrolled)
- Fixed `synced-indicator` / `auth-prompt` activation (were dead code before #383)
- `setsFromCrm()` extended to walk hierarchical pathway→course→module model
- Empty state suppressed when enrollments present

## Publish commands (after approval)

```bash
npm run publish:template -- \
  --path "CLEAN x HEDGEHOG/templates/assets/js/my-learning.js" \
  --local "clean-x-hedgehog-templates/assets/js/my-learning.js"

npm run publish:template -- \
  --path "CLEAN x HEDGEHOG/templates/learn/my-learning.html" \
  --local "clean-x-hedgehog-templates/learn/my-learning.html"
```

**No publish has happened. Production is still on pre-#383 state.**

## Related

- Approved shadow PR: #393
- Rollout issue: #394
- Supersedes: #395 (stacked on shadow branch — closing)
- Parent: #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)