### PR TITLE
feat(completion-framework): content prep — completion.json + quiz.json for all modules + HubDB sync

### DIFF
--- a/content/modules/accessing-the-hedgehog-virtual-ai-data-center/completion.json
+++ b/content/modules/accessing-the-hedgehog-virtual-ai-data-center/completion.json
@@ -1,0 +1,3 @@
+{
+  "completion_tasks": []
+}

--- a/content/modules/accessing-the-hedgehog-virtual-lab-with-amazon-web-services/completion.json
+++ b/content/modules/accessing-the-hedgehog-virtual-lab-with-amazon-web-services/completion.json
@@ -1,0 +1,3 @@
+{
+  "completion_tasks": []
+}

--- a/content/modules/accessing-the-hedgehog-virtual-lab-with-google-cloud/completion.json
+++ b/content/modules/accessing-the-hedgehog-virtual-lab-with-google-cloud/completion.json
@@ -1,0 +1,3 @@
+{
+  "completion_tasks": []
+}

--- a/content/modules/accessing-the-hedgehog-virtual-lab-with-microsoft-azure/completion.json
+++ b/content/modules/accessing-the-hedgehog-virtual-lab-with-microsoft-azure/completion.json
@@ -1,0 +1,3 @@
+{
+  "completion_tasks": []
+}

--- a/content/modules/fabric-operations-connectivity-validation/completion.json
+++ b/content/modules/fabric-operations-connectivity-validation/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-dashboard-interpretation/completion.json
+++ b/content/modules/fabric-operations-dashboard-interpretation/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-decommission-cleanup/completion.json
+++ b/content/modules/fabric-operations-decommission-cleanup/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-diagnosis-lab/completion.json
+++ b/content/modules/fabric-operations-diagnosis-lab/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-diagnosis-lab/quiz.json
+++ b/content/modules/fabric-operations-diagnosis-lab/quiz.json
@@ -1,0 +1,59 @@
+{
+  "quiz_id": "quiz-1",
+  "module_slug": "fabric-operations-diagnosis-lab",
+  "passing_score": 75,
+  "questions": [
+    {
+      "id": "q1",
+      "type": "multiple_choice",
+      "stem": "Server-03 in VPC prod-vpc cannot reach server-04 in the same VPC. Both VPCAttachments exist and all agents are converged (APPLIEDG == CURRENTG). What is your NEXT diagnostic step using systematic methodology?",
+      "options": [
+        {"id": "a", "text": "Restart the fabric controller"},
+        {"id": "b", "text": "Check Agent CRD to verify VLANs configured on both switch interfaces"},
+        {"id": "c", "text": "Escalate to support immediately"},
+        {"id": "d", "text": "Delete and recreate both VPCAttachments"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    },
+    {
+      "id": "q2",
+      "type": "multiple_choice",
+      "stem": "VPCPeering between vpc-a and vpc-b exists. kubectl describe shows no errors. Server in vpc-a can ping its own gateway but CANNOT ping server in vpc-b. Which failure mode is most likely?",
+      "options": [
+        {"id": "a", "text": "BGP peering problem (sessions down)"},
+        {"id": "b", "text": "VPC isolation settings or permit list misconfiguration"},
+        {"id": "c", "text": "Interface errors (physical layer issue)"},
+        {"id": "d", "text": "Configuration drift (GitOps reconciliation failure)"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    },
+    {
+      "id": "q3",
+      "type": "multiple_choice",
+      "stem": "Using Decision Tree 3, you have verified: VPCAttachment references correct connection, subnet exists in VPC, and Agent CRD shows VLAN configured on interface. According to the decision tree, what should you check NEXT?",
+      "options": [
+        {"id": "a", "text": "Controller logs for reconciliation errors"},
+        {"id": "b", "text": "Grafana Interface Dashboard for errors"},
+        {"id": "c", "text": "nativeVLAN setting matches server expectation"},
+        {"id": "d", "text": "Escalate immediately (all checks passed)"}
+      ],
+      "correct_answer": "c",
+      "points": 1
+    },
+    {
+      "id": "q4",
+      "type": "multiple_choice",
+      "stem": "Resources exist, agents are converged, and Agent CRD shows all interfaces up with VLANs configured correctly, but the server still cannot communicate. Why should you check Grafana BEFORE checking controller logs?",
+      "options": [
+        {"id": "a", "text": "Grafana is faster to load than kubectl logs"},
+        {"id": "b", "text": "Grafana provides visual trends and historical context (e.g., intermittent errors over time)"},
+        {"id": "c", "text": "Controller logs are unreliable"},
+        {"id": "d", "text": "Grafana is always the first troubleshooting step"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    }
+  ]
+}

--- a/content/modules/fabric-operations-events-status/completion.json
+++ b/content/modules/fabric-operations-events-status/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-foundations-recap/completion.json
+++ b/content/modules/fabric-operations-foundations-recap/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "knowledge-check-1",
+      "task_type": "knowledge_check",
+      "graded": false,
+      "required": false,
+      "label": "Knowledge Check (optional)"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-how-it-works/completion.json
+++ b/content/modules/fabric-operations-how-it-works/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-mastering-interfaces/completion.json
+++ b/content/modules/fabric-operations-mastering-interfaces/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-post-incident-review/completion.json
+++ b/content/modules/fabric-operations-post-incident-review/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-pre-support-diagnostics/completion.json
+++ b/content/modules/fabric-operations-pre-support-diagnostics/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-rollback-recovery/completion.json
+++ b/content/modules/fabric-operations-rollback-recovery/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-telemetry-overview/completion.json
+++ b/content/modules/fabric-operations-telemetry-overview/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-troubleshooting-framework/completion.json
+++ b/content/modules/fabric-operations-troubleshooting-framework/completion.json
@@ -1,0 +1,3 @@
+{
+  "completion_tasks": []
+}

--- a/content/modules/fabric-operations-vpc-attachments/completion.json
+++ b/content/modules/fabric-operations-vpc-attachments/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-vpc-provisioning/completion.json
+++ b/content/modules/fabric-operations-vpc-provisioning/completion.json
@@ -1,0 +1,11 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-welcome/completion.json
+++ b/content/modules/fabric-operations-welcome/completion.json
@@ -1,0 +1,21 @@
+{
+  "completion_tasks": [
+    {
+      "task_slug": "quiz-1",
+      "task_type": "quiz",
+      "graded": true,
+      "required": true,
+      "label": "Module Assessment",
+      "passing_score": 75,
+      "max_attempts": null,
+      "quiz_ref": "quiz-1"
+    },
+    {
+      "task_slug": "lab-main",
+      "task_type": "lab_attestation",
+      "graded": false,
+      "required": true,
+      "label": "Hands-On Lab"
+    }
+  ]
+}

--- a/content/modules/fabric-operations-welcome/quiz.json
+++ b/content/modules/fabric-operations-welcome/quiz.json
@@ -1,0 +1,54 @@
+{
+  "quiz_id": "quiz-1",
+  "module_slug": "fabric-operations-welcome",
+  "passing_score": 75,
+  "questions": [
+    {
+      "id": "q1",
+      "type": "multiple_choice",
+      "stem": "What is the primary role of a Hedgehog Fabric Operator?",
+      "options": [
+        {"id": "a", "text": "Design network topologies and select switch hardware"},
+        {"id": "b", "text": "Provision VPCs, validate connectivity, and monitor fabric health"},
+        {"id": "c", "text": "Manually configure BGP peering on each switch"},
+        {"id": "d", "text": "Write custom Kubernetes controllers for network automation"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    },
+    {
+      "id": "q2",
+      "type": "multiple_choice",
+      "stem": "True or False: In Hedgehog, you must manually log into each switch to configure VLANs when creating a new VPC.",
+      "options": [
+        {"id": "a", "text": "True"},
+        {"id": "b", "text": "False"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    },
+    {
+      "id": "q3",
+      "type": "multiple_choice",
+      "stem": "According to the Hedgehog learning philosophy, which statement is correct?",
+      "options": [
+        {"id": "a", "text": "You must master all edge cases before attempting basic operations"},
+        {"id": "b", "text": "Focus on common, high-impact tasks to build confidence and immediate productivity"},
+        {"id": "c", "text": "Avoid using support — figure everything out independently"},
+        {"id": "d", "text": "Memorize all kubectl commands before trying labs"}
+      ],
+      "correct_answer": "b",
+      "points": 1
+    }
+  ],
+  "_omitted_questions": [
+    {
+      "original_q": 2,
+      "reason": "Open-ended command question (kubectl get switches) — no encodable single correct answer for MC format; omitted from MVP quiz.json"
+    },
+    {
+      "original_q": 5,
+      "reason": "Practical open-ended question (count switches from lab output) — rubric-graded, no single MC option; omitted from MVP quiz.json"
+    }
+  ]
+}

--- a/hubdb-schemas/modules.schema.json
+++ b/hubdb-schemas/modules.schema.json
@@ -17,6 +17,8 @@
     {"name": "meta_description", "type": "TEXT"},
     {"name": "social_image_url", "type": "TEXT"},
     {"name": "prerequisites_json", "type": "TEXT"},
-    {"name": "media_json", "type": "JSON"}
+    {"name": "media_json", "type": "JSON"},
+    {"name": "completion_tasks_json", "type": "TEXT"},
+    {"name": "quiz_schema_json", "type": "TEXT"}
   ]
 }

--- a/src/sync/markdown-to-hubdb.ts
+++ b/src/sync/markdown-to-hubdb.ts
@@ -177,6 +177,30 @@ async function syncModules(dryRun: boolean = false) {
         // meta.json is optional
       }
 
+      // Read optional completion.json (CompletionTask declarations for the module)
+      let completionTasksJson = '';
+      try {
+        const completionPath = join(modulesDir, moduleSlug, 'completion.json');
+        const completionContent = await readFile(completionPath, 'utf-8');
+        const completionData = JSON.parse(completionContent);
+        completionTasksJson = JSON.stringify(completionData.completion_tasks ?? []);
+      } catch {
+        // completion.json is optional; absence treated as no tasks declared
+      }
+
+      // Read optional quiz.json (quiz questions with correct answers — server-side only)
+      // IMPORTANT: quiz.json contains correct answers and must NEVER be served to the client.
+      // It is synced to HubDB quiz_schema_json and read only by the Lambda grading endpoint.
+      let quizSchemaJson = '';
+      try {
+        const quizPath = join(modulesDir, moduleSlug, 'quiz.json');
+        const quizContent = await readFile(quizPath, 'utf-8');
+        JSON.parse(quizContent); // validate JSON before storing
+        quizSchemaJson = quizContent.trim();
+      } catch {
+        // quiz.json is optional; absence means no graded quiz for this module
+      }
+
       // Convert markdown to HTML
       let html = await marked(markdown);
       const stripH1 = (process.env.SYNC_STRIP_LEADING_H1 || 'true').toLowerCase() === 'true';
@@ -219,7 +243,11 @@ async function syncModules(dryRun: boolean = false) {
         full_content: html,
         display_order: fm.order || 999,
         social_image_url: fm.social_image || '',
-        prerequisites_json: prerequisitesJson
+        prerequisites_json: prerequisitesJson,
+        // Completion framework fields (shadow-only consumers; safe to populate for all stages)
+        completion_tasks_json: completionTasksJson,
+        // quiz_schema_json contains correct answers — server-side read only; never exposed to client
+        quiz_schema_json: quizSchemaJson
       };
 
       if (mediaItems.length) {


### PR DESCRIPTION
## Summary

Phase 1 of the shadow-only completion framework (#397). Closes #406.

- Add `completion.json` for all 20 active modules (CompletionTask declarations)
- Add `quiz.json` (server-side only, correct answers) for 2 pilot modules
- Extend `sync:content` to populate new HubDB columns: `completion_tasks_json` and `quiz_schema_json`
- Add column definitions to `hubdb-schemas/modules.schema.json`

## Files Changed

| File | Change |
|------|--------|
| `content/modules/*/completion.json` | 20 new files — task declarations for all active modules |
| `content/modules/fabric-operations-welcome/quiz.json` | New — 3 MC/T-F questions with correct answers |
| `content/modules/fabric-operations-diagnosis-lab/quiz.json` | New — 4 MC questions with correct answers |
| `src/sync/markdown-to-hubdb.ts` | Extended to read and sync `completion_tasks_json` + `quiz_schema_json` |
| `hubdb-schemas/modules.schema.json` | Added `completion_tasks_json` and `quiz_schema_json` column definitions |

## Completion Task Coverage

| Module type | Modules | Tasks declared |
|-------------|---------|----------------|
| Quiz + Lab (Pattern A) | welcome, how-it-works, mastering-interfaces | quiz-1 (graded, required), lab-main (attestation, required) |
| Quiz + Lab (Pattern B) | diagnosis-lab, rollback-recovery, post-incident-review | quiz-1 (graded, required), lab-main (attestation, required) |
| Lab only (Provisioning/Observability) | 8 modules | lab-main (attestation, required) |
| Knowledge check only | foundations-recap | knowledge-check-1 (ungraded, not required) |
| No tasks (complete on view) | troubleshooting-framework, vAIDC, 3 setup modules | `completion_tasks: []` |

## Quiz Content Notes (welcome module)

Questions 2 (command answer) and 5 (rubric open-ended) from the README were omitted from `quiz.json` — these have no single encodable correct MC answer. The omissions are documented in `_omitted_questions` in `quiz.json`. The encoded 3 questions cover the module's key conceptual content.

## Security / Client Exposure

- `quiz_schema_json` contains correct answers and is **not referenced in any production template**
- Zero occurrences in `module-page.html` or `my-learning.html` (verified via grep)
- Column is populated in HubDB but only consumed by the shadow Lambda grading endpoint (not yet built — that is #407)

## HubDB Verification

Sync ran successfully: 20 modules updated, 0 failed. Spot-checked via SDK:

- `fabric-operations-welcome`: `completion_tasks_json` = 2 tasks (quiz-1, lab-main); `quiz_schema_json` = 3 questions ✓
- `fabric-operations-diagnosis-lab`: `completion_tasks_json` = 2 tasks; `quiz_schema_json` = 4 questions ✓
- `fabric-operations-vpc-provisioning`: `completion_tasks_json` = 1 task (lab-main); `quiz_schema_json` = null ✓
- `fabric-operations-troubleshooting-framework`: `completion_tasks_json` = 0 tasks; `quiz_schema_json` = null ✓

## Production Impact

None. New HubDB columns are added but not referenced by any existing template or Lambda handler. Production behavior is identical to pre-PR state.

## Test Plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npm run sync:content -- --dry-run` — 20 modules, 0 failures
- [x] `npm run sync:content` — 20 modules updated, HubDB published
- [x] HubDB columns verified for 4 representative modules (quiz + lab, lab-only, no-tasks)
- [x] `quiz_schema_json` not referenced in production templates (grep: 0 matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)