### PR TITLE
feat(infra): #405 shadow DynamoDB tables for completion framework

### DIFF
--- a/infrastructure/dynamodb/entity-completions-shadow-table.json
+++ b/infrastructure/dynamodb/entity-completions-shadow-table.json
@@ -1,0 +1,63 @@
+{
+  "TableName": "hedgehog-learn-entity-completions-shadow",
+  "BillingMode": "PAY_PER_REQUEST",
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "PK",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "SK",
+      "AttributeType": "S"
+    }
+  ],
+  "KeySchema": [
+    {
+      "AttributeName": "PK",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "SK",
+      "KeyType": "RANGE"
+    }
+  ],
+  "PointInTimeRecoverySpecification": {
+    "PointInTimeRecoveryEnabled": true
+  },
+  "SSESpecification": {
+    "SSEEnabled": true
+  },
+  "Tags": [
+    {
+      "Key": "Project",
+      "Value": "hedgehog-learn"
+    },
+    {
+      "Key": "Environment",
+      "Value": "shadow"
+    },
+    {
+      "Key": "ManagedBy",
+      "Value": "serverless-framework"
+    },
+    {
+      "Key": "Component",
+      "Value": "completion-framework"
+    }
+  ],
+  "Schema": {
+    "PK": "USER#<userId>",
+    "SK": "COMPLETION#MODULE#<moduleSlug>",
+    "description": "Module-level completion status derived from task records. One record per learner per module. Updated whenever a task record changes. Module-keyed — not course-keyed (shared-module reuse semantics per domain model #402).",
+    "shadowOnly": true,
+    "condition": "CloudFormation Condition: IsShadowStage (only provisioned when stage=shadow)",
+    "attributes": {
+      "PK": "Partition key: USER#<Cognito sub>",
+      "SK": "Sort key: COMPLETION#MODULE#<moduleSlug>",
+      "status": "not_started | in_progress | complete — module-level computed status",
+      "task_statuses": "Map: {<taskSlug>: {status, score?, attempts}} — per-task snapshot for fast My Learning reads",
+      "last_updated_at": "ISO 8601 timestamp of most recent status recomputation",
+      "completion_tasks_version": "String hash or timestamp of completion.json at computation time — used to detect when task declarations change"
+    }
+  }
+}

--- a/infrastructure/dynamodb/task-attempts-shadow-table.json
+++ b/infrastructure/dynamodb/task-attempts-shadow-table.json
@@ -1,0 +1,66 @@
+{
+  "TableName": "hedgehog-learn-task-attempts-shadow",
+  "BillingMode": "PAY_PER_REQUEST",
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "PK",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "SK",
+      "AttributeType": "S"
+    }
+  ],
+  "KeySchema": [
+    {
+      "AttributeName": "PK",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "SK",
+      "KeyType": "RANGE"
+    }
+  ],
+  "PointInTimeRecoverySpecification": {
+    "PointInTimeRecoveryEnabled": true
+  },
+  "SSESpecification": {
+    "SSEEnabled": true
+  },
+  "Tags": [
+    {
+      "Key": "Project",
+      "Value": "hedgehog-learn"
+    },
+    {
+      "Key": "Environment",
+      "Value": "shadow"
+    },
+    {
+      "Key": "ManagedBy",
+      "Value": "serverless-framework"
+    },
+    {
+      "Key": "Component",
+      "Value": "completion-framework"
+    }
+  ],
+  "Schema": {
+    "PK": "USER#<userId>",
+    "SK": "ATTEMPT#MODULE#<moduleSlug>#<taskSlug>#<isoTimestamp>",
+    "description": "Immutable append-only record of every task attempt. Never updated after write.",
+    "shadowOnly": true,
+    "condition": "CloudFormation Condition: IsShadowStage (only provisioned when stage=shadow)",
+    "attributes": {
+      "PK": "Partition key: USER#<Cognito sub>",
+      "SK": "Sort key: ATTEMPT#MODULE#<moduleSlug>#<taskSlug>#<ISO-8601-timestamp> — timestamp ensures uniqueness for retakes",
+      "task_type": "quiz | lab_attestation | knowledge_check",
+      "answers": "List of submitted answers [{id, value}] — quiz tasks only; empty for attestations",
+      "score": "Number 0-100 — computed quiz score (quiz tasks only)",
+      "pass": "Boolean — whether score >= passing_score (graded tasks only)",
+      "attested_at": "ISO 8601 timestamp — for lab_attestation tasks",
+      "attempted_at": "ISO 8601 timestamp — when this attempt was recorded",
+      "learner_identity": "Map: {userId, email} — snapshot of learner identity at time of attempt"
+    }
+  }
+}

--- a/infrastructure/dynamodb/task-records-shadow-table.json
+++ b/infrastructure/dynamodb/task-records-shadow-table.json
@@ -1,0 +1,66 @@
+{
+  "TableName": "hedgehog-learn-task-records-shadow",
+  "BillingMode": "PAY_PER_REQUEST",
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "PK",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "SK",
+      "AttributeType": "S"
+    }
+  ],
+  "KeySchema": [
+    {
+      "AttributeName": "PK",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "SK",
+      "KeyType": "RANGE"
+    }
+  ],
+  "PointInTimeRecoverySpecification": {
+    "PointInTimeRecoveryEnabled": true
+  },
+  "SSESpecification": {
+    "SSEEnabled": true
+  },
+  "Tags": [
+    {
+      "Key": "Project",
+      "Value": "hedgehog-learn"
+    },
+    {
+      "Key": "Environment",
+      "Value": "shadow"
+    },
+    {
+      "Key": "ManagedBy",
+      "Value": "serverless-framework"
+    },
+    {
+      "Key": "Component",
+      "Value": "completion-framework"
+    }
+  ],
+  "Schema": {
+    "PK": "USER#<userId>",
+    "SK": "TASK#MODULE#<moduleSlug>#<taskSlug>",
+    "description": "Current task status per learner per task. Mutable — updated on each attempt.",
+    "shadowOnly": true,
+    "condition": "CloudFormation Condition: IsShadowStage (only provisioned when stage=shadow)",
+    "attributes": {
+      "PK": "Partition key: USER#<Cognito sub>",
+      "SK": "Sort key: TASK#MODULE#<moduleSlug>#<taskSlug>",
+      "task_type": "quiz | lab_attestation | knowledge_check",
+      "graded": "Boolean — whether this task is scored",
+      "status": "not_started | in_progress | passed | failed | attested",
+      "best_score": "Number 0-100 — best quiz score across all attempts (quiz tasks only)",
+      "last_attempt_at": "ISO 8601 timestamp of most recent attempt",
+      "attempt_count": "Number — total attempts for this task",
+      "updated_at": "ISO 8601 timestamp of last record update"
+    }
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,6 +1,18 @@
 service: hedgehog-learn
 frameworkVersion: "3"
 
+# Stage-specific params — shadow gets real table names; all other stages get empty string
+# so the completion framework env vars carry no table references outside shadow.
+params:
+  shadow:
+    taskRecordsTable: ${self:service}-task-records-shadow
+    taskAttemptsTable: ${self:service}-task-attempts-shadow
+    entityCompletionsTable: ${self:service}-entity-completions-shadow
+  default:
+    taskRecordsTable: ''
+    taskAttemptsTable: ''
+    entityCompletionsTable: ''
+
 provider:
   name: aws
   runtime: nodejs20.x
@@ -29,11 +41,11 @@ provider:
     ENABLE_TEST_BYPASS: ${env:ENABLE_TEST_BYPASS, 'false'}
     APP_STAGE: ${env:APP_STAGE, 'dev'}
     # Shadow completion framework tables (Issue #405 / #397)
-    # Tables only created when stage=shadow (CloudFormation Condition: IsShadowStage)
-    # Lambda code guards all reads/writes with APP_STAGE=shadow check before using these vars
-    TASK_RECORDS_TABLE: ${self:service}-task-records-shadow
-    TASK_ATTEMPTS_TABLE: ${self:service}-task-attempts-shadow
-    ENTITY_COMPLETIONS_TABLE: ${self:service}-entity-completions-shadow
+    # Values resolve to the table names only when stage=shadow (via params block above);
+    # all other stages receive empty string — table names never injected into dev/prod runtime.
+    TASK_RECORDS_TABLE: ${param:taskRecordsTable}
+    TASK_ATTEMPTS_TABLE: ${param:taskAttemptsTable}
+    ENTITY_COMPLETIONS_TABLE: ${param:entityCompletionsTable}
   iam:
     role:
       statements:

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,6 +27,13 @@ provider:
     COGNITO_REDIRECT_URI: ${env:COGNITO_REDIRECT_URI}
     COGNITO_ISSUER: ${env:COGNITO_ISSUER}
     ENABLE_TEST_BYPASS: ${env:ENABLE_TEST_BYPASS, 'false'}
+    APP_STAGE: ${env:APP_STAGE, 'dev'}
+    # Shadow completion framework tables (Issue #405 / #397)
+    # Tables only created when stage=shadow (CloudFormation Condition: IsShadowStage)
+    # Lambda code guards all reads/writes with APP_STAGE=shadow check before using these vars
+    TASK_RECORDS_TABLE: ${self:service}-task-records-shadow
+    TASK_ATTEMPTS_TABLE: ${self:service}-task-attempts-shadow
+    ENTITY_COMPLETIONS_TABLE: ${self:service}-entity-completions-shadow
   iam:
     role:
       statements:
@@ -52,6 +59,21 @@ provider:
                 - 'index/*'
             - Fn::GetAtt: [ProgressTable, Arn]
             - Fn::GetAtt: [BadgesTable, Arn]
+        # Shadow completion framework tables (Issue #405 / #397)
+        # ARNs hardcoded (not Fn::GetAtt) so this statement deploys to all stages safely;
+        # tables themselves are Condition: IsShadowStage and only exist in the shadow stack
+        - Effect: Allow
+          Action:
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+            - dynamodb:DeleteItem
+            - dynamodb:Query
+            - dynamodb:Scan
+          Resource:
+            - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-task-records-shadow"
+            - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-task-attempts-shadow"
+            - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-entity-completions-shadow"
         - Effect: Allow
           Action:
             - cognito-idp:AdminCreateUser
@@ -273,7 +295,112 @@ package:
     - '!scratch.txt'
 
 resources:
+  # CloudFormation condition: shadow-only resources gated on stage == shadow
+  Conditions:
+    IsShadowStage: !Equals ['${sls:stage}', 'shadow']
+
   Resources:
+    # -------------------------------------------------------------------------
+    # Shadow Completion Framework Tables (Issue #405 / #397)
+    # Condition: IsShadowStage — only provisioned when sls:stage == shadow
+    # -------------------------------------------------------------------------
+
+    # Stores current task status per learner per task (mutable, updated on each attempt)
+    # PK: USER#<userId>  SK: TASK#MODULE#<moduleSlug>#<taskSlug>
+    TaskRecordsShadowTable:
+      Type: AWS::DynamoDB::Table
+      Condition: IsShadowStage
+      Properties:
+        TableName: ${self:service}-task-records-shadow
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: PK
+            AttributeType: S
+          - AttributeName: SK
+            AttributeType: S
+        KeySchema:
+          - AttributeName: PK
+            KeyType: HASH
+          - AttributeName: SK
+            KeyType: RANGE
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        SSESpecification:
+          SSEEnabled: true
+        Tags:
+          - Key: Project
+            Value: hedgehog-learn
+          - Key: Environment
+            Value: shadow
+          - Key: ManagedBy
+            Value: serverless-framework
+          - Key: Component
+            Value: completion-framework
+
+    # Immutable append-only record of every task attempt (quiz answers, lab attestations)
+    # PK: USER#<userId>  SK: ATTEMPT#MODULE#<moduleSlug>#<taskSlug>#<isoTimestamp>
+    TaskAttemptsShadowTable:
+      Type: AWS::DynamoDB::Table
+      Condition: IsShadowStage
+      Properties:
+        TableName: ${self:service}-task-attempts-shadow
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: PK
+            AttributeType: S
+          - AttributeName: SK
+            AttributeType: S
+        KeySchema:
+          - AttributeName: PK
+            KeyType: HASH
+          - AttributeName: SK
+            KeyType: RANGE
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        SSESpecification:
+          SSEEnabled: true
+        Tags:
+          - Key: Project
+            Value: hedgehog-learn
+          - Key: Environment
+            Value: shadow
+          - Key: ManagedBy
+            Value: serverless-framework
+          - Key: Component
+            Value: completion-framework
+
+    # Module-level completion status derived from task records (one record per learner per module)
+    # PK: USER#<userId>  SK: COMPLETION#MODULE#<moduleSlug>
+    EntityCompletionsShadowTable:
+      Type: AWS::DynamoDB::Table
+      Condition: IsShadowStage
+      Properties:
+        TableName: ${self:service}-entity-completions-shadow
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: PK
+            AttributeType: S
+          - AttributeName: SK
+            AttributeType: S
+        KeySchema:
+          - AttributeName: PK
+            KeyType: HASH
+          - AttributeName: SK
+            KeyType: RANGE
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        SSESpecification:
+          SSEEnabled: true
+        Tags:
+          - Key: Project
+            Value: hedgehog-learn
+          - Key: Environment
+            Value: shadow
+          - Key: ManagedBy
+            Value: serverless-framework
+          - Key: Component
+            Value: completion-framework
+
     # DynamoDB Tables for External SSO + Progress Store (Issue #302)
     UsersTable:
       Type: AWS::DynamoDB::Table

--- a/verification-output/issue-405/verification.md
+++ b/verification-output/issue-405/verification.md
@@ -1,0 +1,72 @@
+# Issue #405 Verification — Shadow DynamoDB Tables
+
+**Date:** 2026-04-12
+**Branch:** issue-405-shadow-dynamodb-tables
+**Stage deployed:** shadow
+
+---
+
+## Goal
+
+Provision three shadow-only DynamoDB tables for the completion framework, wire shadow-stage environment variables into Lambda, and keep production/non-shadow stages unaffected.
+
+---
+
+## DynamoDB Tables — AWS Status
+
+All three tables confirmed ACTIVE in us-west-2:
+
+| Table | Status | Billing | SSE | PITR |
+|---|---|---|---|---|
+| hedgehog-learn-task-records-shadow | ACTIVE | PAY_PER_REQUEST | Enabled | ENABLED |
+| hedgehog-learn-task-attempts-shadow | ACTIVE | PAY_PER_REQUEST | Enabled | ENABLED |
+| hedgehog-learn-entity-completions-shadow | ACTIVE | PAY_PER_REQUEST | Enabled | ENABLED |
+
+PITR status verified via `aws dynamodb describe-continuous-backups` (not `describe-table`, which shows DISABLED until first write).
+
+---
+
+## Lambda Environment Variables
+
+Confirmed via `aws lambda get-function-configuration --function-name hedgehog-learn-shadow-api`:
+
+```
+APP_STAGE: shadow
+TASK_RECORDS_TABLE: hedgehog-learn-task-records-shadow
+TASK_ATTEMPTS_TABLE: hedgehog-learn-task-attempts-shadow
+ENTITY_COMPLETIONS_TABLE: hedgehog-learn-entity-completions-shadow
+ENABLE_TEST_BYPASS: false
+```
+
+`APP_STAGE: shadow` ensures all completion framework Lambda guards (`process.env.APP_STAGE !== 'shadow'`) pass correctly at runtime.
+
+---
+
+## Stage Isolation Verification
+
+CloudFormation Condition `IsShadowStage: !Equals ['${sls:stage}', 'shadow']` gates all three tables.
+
+Verified by packaging both stages before deploy:
+- **dev stage:** `Fn::Equals: ['dev', 'shadow']` → condition false → tables not created
+- **shadow stage:** `Fn::Equals: ['shadow', 'shadow']` → condition true → tables created
+
+IAM statements use hardcoded `Fn::Sub` ARNs (not `Fn::GetAtt`) so the policy deploys safely to all stages without referencing conditionally non-existent resources.
+
+---
+
+## Files Changed
+
+- `serverless.yml` — three edits:
+  1. Added `APP_STAGE`, `TASK_RECORDS_TABLE`, `TASK_ATTEMPTS_TABLE`, `ENTITY_COMPLETIONS_TABLE` to `provider.environment`
+  2. Added IAM statement for shadow table access using `Fn::Sub` ARNs
+  3. Added `Conditions.IsShadowStage` and three `AWS::DynamoDB::Table` resources with `Condition: IsShadowStage`
+
+- `infrastructure/dynamodb/task-records-shadow-table.json` — schema doc
+- `infrastructure/dynamodb/task-attempts-shadow-table.json` — schema doc
+- `infrastructure/dynamodb/entity-completions-shadow-table.json` — schema doc
+
+---
+
+## Production Impact
+
+None. The three new DynamoDB tables are shadow-only (CloudFormation Condition). The new env vars are present in production Lambda but only used when code checks `APP_STAGE === 'shadow'` first. IAM policy grants access to shadow table ARNs in all stages, which is harmless since those tables only exist in the shadow stack.

--- a/verification-output/issue-405/verification.md
+++ b/verification-output/issue-405/verification.md
@@ -1,6 +1,6 @@
 # Issue #405 Verification — Shadow DynamoDB Tables
 
-**Date:** 2026-04-12
+**Date:** 2026-04-12 (rev 2 — shadow-only env var scoping)
 **Branch:** issue-405-shadow-dynamodb-tables
 **Stage deployed:** shadow
 
@@ -8,7 +8,7 @@
 
 ## Goal
 
-Provision three shadow-only DynamoDB tables for the completion framework, wire shadow-stage environment variables into Lambda, and keep production/non-shadow stages unaffected.
+Provision three shadow-only DynamoDB tables for the completion framework, wire shadow-stage environment variables into Lambda, and keep production/non-shadow stages unaffected — including ensuring the table-name env vars are absent outside shadow.
 
 ---
 
@@ -22,11 +22,11 @@ All three tables confirmed ACTIVE in us-west-2:
 | hedgehog-learn-task-attempts-shadow | ACTIVE | PAY_PER_REQUEST | Enabled | ENABLED |
 | hedgehog-learn-entity-completions-shadow | ACTIVE | PAY_PER_REQUEST | Enabled | ENABLED |
 
-PITR status verified via `aws dynamodb describe-continuous-backups` (not `describe-table`, which shows DISABLED until first write).
+PITR status verified via `aws dynamodb describe-continuous-backups`.
 
 ---
 
-## Lambda Environment Variables
+## Lambda Environment Variables (shadow stage)
 
 Confirmed via `aws lambda get-function-configuration --function-name hedgehog-learn-shadow-api`:
 
@@ -35,20 +35,51 @@ APP_STAGE: shadow
 TASK_RECORDS_TABLE: hedgehog-learn-task-records-shadow
 TASK_ATTEMPTS_TABLE: hedgehog-learn-task-attempts-shadow
 ENTITY_COMPLETIONS_TABLE: hedgehog-learn-entity-completions-shadow
-ENABLE_TEST_BYPASS: false
 ```
-
-`APP_STAGE: shadow` ensures all completion framework Lambda guards (`process.env.APP_STAGE !== 'shadow'`) pass correctly at runtime.
 
 ---
 
-## Stage Isolation Verification
+## Shadow-Only Env Var Scoping (rev 2 fix)
 
-CloudFormation Condition `IsShadowStage: !Equals ['${sls:stage}', 'shadow']` gates all three tables.
+The three table env vars are now scoped via Serverless Framework v3 `params` block:
 
-Verified by packaging both stages before deploy:
-- **dev stage:** `Fn::Equals: ['dev', 'shadow']` → condition false → tables not created
-- **shadow stage:** `Fn::Equals: ['shadow', 'shadow']` → condition true → tables created
+```yaml
+params:
+  shadow:
+    taskRecordsTable: ${self:service}-task-records-shadow
+    taskAttemptsTable: ${self:service}-task-attempts-shadow
+    entityCompletionsTable: ${self:service}-entity-completions-shadow
+  default:
+    taskRecordsTable: ''
+    taskAttemptsTable: ''
+    entityCompletionsTable: ''
+```
+
+`provider.environment` references them as `${param:taskRecordsTable}` etc.
+
+**Resolution verified by packaging both stages and inspecting the CloudFormation templates:**
+
+Dev stage (`APP_STAGE=dev`):
+```
+TASK_RECORDS_TABLE: ''
+TASK_ATTEMPTS_TABLE: ''
+ENTITY_COMPLETIONS_TABLE: ''
+```
+
+Shadow stage (`APP_STAGE=shadow`):
+```
+TASK_RECORDS_TABLE: hedgehog-learn-task-records-shadow
+TASK_ATTEMPTS_TABLE: hedgehog-learn-task-attempts-shadow
+ENTITY_COMPLETIONS_TABLE: hedgehog-learn-entity-completions-shadow
+```
+
+Shadow table names are never injected into dev or prod Lambda runtime configuration.
+
+---
+
+## Stage Isolation — DynamoDB Tables
+
+CloudFormation Condition `IsShadowStage: !Equals ['${sls:stage}', 'shadow']` gates all three tables. Tables only provisioned when deploying the shadow stack. Dev/prod stacks do not create these tables.
 
 IAM statements use hardcoded `Fn::Sub` ARNs (not `Fn::GetAtt`) so the policy deploys safely to all stages without referencing conditionally non-existent resources.
 
@@ -56,10 +87,12 @@ IAM statements use hardcoded `Fn::Sub` ARNs (not `Fn::GetAtt`) so the policy dep
 
 ## Files Changed
 
-- `serverless.yml` — three edits:
-  1. Added `APP_STAGE`, `TASK_RECORDS_TABLE`, `TASK_ATTEMPTS_TABLE`, `ENTITY_COMPLETIONS_TABLE` to `provider.environment`
-  2. Added IAM statement for shadow table access using `Fn::Sub` ARNs
-  3. Added `Conditions.IsShadowStage` and three `AWS::DynamoDB::Table` resources with `Condition: IsShadowStage`
+- `serverless.yml` — four edits:
+  1. Added `params` block at top with per-stage resolution for the three table params
+  2. Added `APP_STAGE` to `provider.environment`
+  3. Added `TASK_RECORDS_TABLE/TASK_ATTEMPTS_TABLE/ENTITY_COMPLETIONS_TABLE` using `${param:...}` references
+  4. Added IAM statement for shadow table access using `Fn::Sub` ARNs
+  5. Added `Conditions.IsShadowStage` and three `AWS::DynamoDB::Table` resources with `Condition: IsShadowStage`
 
 - `infrastructure/dynamodb/task-records-shadow-table.json` — schema doc
 - `infrastructure/dynamodb/task-attempts-shadow-table.json` — schema doc
@@ -69,4 +102,4 @@ IAM statements use hardcoded `Fn::Sub` ARNs (not `Fn::GetAtt`) so the policy dep
 
 ## Production Impact
 
-None. The three new DynamoDB tables are shadow-only (CloudFormation Condition). The new env vars are present in production Lambda but only used when code checks `APP_STAGE === 'shadow'` first. IAM policy grants access to shadow table ARNs in all stages, which is harmless since those tables only exist in the shadow stack.
+None. DynamoDB tables are gated by `Condition: IsShadowStage` (absent from dev/prod stacks). Table-name env vars resolve to empty string in dev/prod — shadow table names are not present in non-shadow Lambda runtime config.


### PR DESCRIPTION
## Summary

Closes #405

- Adds three shadow-only DynamoDB tables (`task-records`, `task-attempts`, `entity-completions`) gated by CloudFormation Condition `IsShadowStage` — tables only provisioned when `sls:stage == shadow`
- Wires `APP_STAGE`, `TASK_RECORDS_TABLE`, `TASK_ATTEMPTS_TABLE`, `ENTITY_COMPLETIONS_TABLE` as Lambda environment variables so completion framework endpoints (#407–#409) have the runtime context they need
- IAM policy uses hardcoded `Fn::Sub` ARNs (not `Fn::GetAtt`) so it deploys safely to all stages without referencing conditionally non-existent resources
- Adds `infrastructure/dynamodb/` schema docs for all three tables

## Tables deployed to AWS (shadow stage)

| Table | Status | Billing | SSE | PITR |
|---|---|---|---|---|
| `hedgehog-learn-task-records-shadow` | ACTIVE | PAY_PER_REQUEST | ✓ | ✓ |
| `hedgehog-learn-task-attempts-shadow` | ACTIVE | PAY_PER_REQUEST | ✓ | ✓ |
| `hedgehog-learn-entity-completions-shadow` | ACTIVE | PAY_PER_REQUEST | ✓ | ✓ |

Lambda `APP_STAGE: shadow` confirmed in `hedgehog-learn-shadow-api` — shadow guards in completion endpoints will pass at runtime.

## Production impact

None. Tables are gated by `Condition: IsShadowStage`. Env vars exist in all stages but completion endpoints gate all reads/writes on `APP_STAGE === 'shadow'`.

## Test plan

- [ ] Verify tables exist in AWS console: DynamoDB → Tables → filter `shadow`
- [ ] Confirm Lambda env vars via `aws lambda get-function-configuration --function-name hedgehog-learn-shadow-api`
- [ ] Deploy dev stage and confirm dev CloudFormation stack does NOT include the three shadow tables
- [ ] Full verification artifact: `verification-output/issue-405/verification.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)