### PR TITLE
feat(api): #427 shadow certificate issuance and verification [shadow-phase-6]

### DIFF
--- a/clean-x-hedgehog-templates/assets/shadow/js/shadow-my-learning.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/shadow-my-learning.js
@@ -129,6 +129,24 @@
   }
 
   // ----------------------------------------------------------------
+  // Build certificate badge HTML for a completed module.
+  // certId comes from the tasks/status single-module endpoint (cert_id field).
+  // When certId is available the badge links directly to the verification page.
+  // When certId is absent (batch endpoint used) the badge is display-only.
+  // ----------------------------------------------------------------
+  function buildCertBadgeHtml(certId) {
+    var label = '\uD83C\uDF93 Certificate earned';
+    if (certId) {
+      return '<div class="shadow-cert-badge">' +
+        '<a href="/shadow/certificate/' + encodeURIComponent(certId) + '" ' +
+          'class="shadow-cert-link" target="_blank" rel="noopener noreferrer">' +
+          label + ' &mdash; View Certificate</a>' +
+        '</div>';
+    }
+    return '<div class="shadow-cert-badge">' + label + '</div>';
+  }
+
+  // ----------------------------------------------------------------
   // Build task breakdown pills HTML for a module
   // ----------------------------------------------------------------
   function buildTaskBreakdownHtml(shadowStatus, taskTypes) {
@@ -227,6 +245,11 @@
           ? '\u25D0'
           : (dispStatus === 'no-tasks' ? '\u2013' : '\u25CB'));
       var breakdown = buildTaskBreakdownHtml(shadowStatus, taskTypes);
+      // cert_id is present in single-module tasks/status responses but not in batch responses.
+      // Show the badge whenever the module is complete; link to verify page when certId is available.
+      var certBadge = (dispStatus === 'complete')
+        ? buildCertBadgeHtml((shadowStatus && shadowStatus.cert_id) || null)
+        : '';
       var modLink = '/learn-shadow/modules/' + modPath;
 
       return '<div class="enrollment-module-item ' + dispStatus + '">' +
@@ -235,6 +258,7 @@
           '<a href="' + modLink + '" class="enrollment-module-link">' + modName + '</a>' +
         '</div>' +
         (breakdown || '') +
+        (certBadge || '') +
         '</div>';
     });
 
@@ -293,6 +317,7 @@
     }
 
     if (isComplete) {
+      html += '<div class="enrollment-cert-section">' + buildCertBadgeHtml(null) + '</div>';
       html += '<div class="enrollment-actions"><a href="' + href + '" class="enrollment-cta enrollment-cta--done">Review Course \u2192</a></div>';
     } else if (nextModPath) {
       html += '<div class="enrollment-actions"><a href="/learn-shadow/modules/' + nextModPath + '" class="enrollment-cta">Continue to Next Module \u2192</a></div>';

--- a/dist-lambda/src/api/lambda/index.js
+++ b/dist-lambda/src/api/lambda/index.js
@@ -11,6 +11,7 @@ const tasks_lab_attest_js_1 = require("./tasks-lab-attest.js");
 const tasks_status_js_1 = require("./tasks-status.js");
 const tasks_status_batch_js_1 = require("./tasks-status-batch.js");
 const admin_test_reset_js_1 = require("./admin-test-reset.js");
+const certificate_verify_js_1 = require("./certificate-verify.js");
 // Allowed origins for CORS
 const ALLOWED_ORIGINS = [
     'https://hedgehog.cloud',
@@ -170,6 +171,9 @@ const handler = async (event) => {
             return await (0, tasks_status_js_1.handleTasksStatus)(event);
         if (path.endsWith('/admin/test/reset') && method === 'POST')
             return await (0, admin_test_reset_js_1.handleAdminTestReset)(event);
+        // Shadow certificate verification endpoint (Issue #427)
+        if (path.includes('/shadow/certificate/') && method === 'GET')
+            return await (0, certificate_verify_js_1.handleCertificateVerify)(event);
         // Legacy POST endpoints
         if (method !== 'POST')
             return bad(405, 'Method not allowed', origin);

--- a/infrastructure/dynamodb/certificates-shadow-table.json
+++ b/infrastructure/dynamodb/certificates-shadow-table.json
@@ -1,0 +1,86 @@
+{
+  "TableName": "hedgehog-learn-certificates-shadow",
+  "BillingMode": "PAY_PER_REQUEST",
+  "AttributeDefinitions": [
+    {
+      "AttributeName": "PK",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "SK",
+      "AttributeType": "S"
+    },
+    {
+      "AttributeName": "certId",
+      "AttributeType": "S"
+    }
+  ],
+  "KeySchema": [
+    {
+      "AttributeName": "PK",
+      "KeyType": "HASH"
+    },
+    {
+      "AttributeName": "SK",
+      "KeyType": "RANGE"
+    }
+  ],
+  "GlobalSecondaryIndexes": [
+    {
+      "IndexName": "certId-index",
+      "KeySchema": [
+        {
+          "AttributeName": "certId",
+          "KeyType": "HASH"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      }
+    }
+  ],
+  "PointInTimeRecoverySpecification": {
+    "PointInTimeRecoveryEnabled": true
+  },
+  "SSESpecification": {
+    "SSEEnabled": true
+  },
+  "Tags": [
+    {
+      "Key": "Project",
+      "Value": "hedgehog-learn"
+    },
+    {
+      "Key": "Environment",
+      "Value": "shadow"
+    },
+    {
+      "Key": "ManagedBy",
+      "Value": "serverless-framework"
+    },
+    {
+      "Key": "Component",
+      "Value": "certificate-framework"
+    }
+  ],
+  "Schema": {
+    "PK": "USER#<cognitoSub>",
+    "SK": "CERT#<entityType>#<entitySlug>",
+    "description": "Issued certificates for module and course completion. One record per learner per entity. Idempotent — re-completion does not overwrite an existing certificate.",
+    "shadowOnly": true,
+    "condition": "CloudFormation Condition: IsShadowStage (only provisioned when stage=shadow)",
+    "attributes": {
+      "PK": "Partition key: USER#<Cognito sub>",
+      "SK": "Sort key: CERT#<entityType>#<entitySlug>  (entityType: 'module' | 'course')",
+      "certId": "UUID v4 — globally unique certificate identifier; also the GSI partition key for public verification lookup",
+      "learnerId": "Cognito sub of the learner who earned the certificate",
+      "entityType": "'module' | 'course'",
+      "entitySlug": "Slug of the module or course for which the certificate was issued",
+      "issuedAt": "ISO 8601 timestamp when the certificate was first issued",
+      "evidenceSummary": "Map: {<taskSlug>: <status>} snapshot at time of issuance — immutable evidence of completion state"
+    },
+    "indexes": {
+      "certId-index": "GSI on certId (HASH only, projection ALL) — used by GET /shadow/certificate/:certId for public verification without PII exposure"
+    }
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,10 +8,12 @@ params:
     taskRecordsTable: ${self:service}-task-records-shadow
     taskAttemptsTable: ${self:service}-task-attempts-shadow
     entityCompletionsTable: ${self:service}-entity-completions-shadow
+    certificatesTable: ${self:service}-certificates-shadow
   default:
     taskRecordsTable: ''
     taskAttemptsTable: ''
     entityCompletionsTable: ''
+    certificatesTable: ''
 
 provider:
   name: aws
@@ -41,12 +43,15 @@ provider:
     ENABLE_TEST_BYPASS: ${env:ENABLE_TEST_BYPASS, 'false'}
     APP_STAGE: ${env:APP_STAGE, 'dev'}
     HUBDB_MODULES_TABLE_ID: ${env:HUBDB_MODULES_TABLE_ID}
+    HUBDB_COURSES_TABLE_ID: ${env:HUBDB_COURSES_TABLE_ID, ''}
     # Shadow completion framework tables (Issue #405 / #397)
     # Values resolve to the table names only when stage=shadow (via params block above);
     # all other stages receive empty string — table names never injected into dev/prod runtime.
     TASK_RECORDS_TABLE: ${param:taskRecordsTable}
     TASK_ATTEMPTS_TABLE: ${param:taskAttemptsTable}
     ENTITY_COMPLETIONS_TABLE: ${param:entityCompletionsTable}
+    # Shadow certificate table (Issue #427)
+    CERTIFICATES_TABLE: ${param:certificatesTable}
   iam:
     role:
       statements:
@@ -89,6 +94,9 @@ provider:
             - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-task-records-shadow"
             - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-task-attempts-shadow"
             - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-entity-completions-shadow"
+            # Shadow certificate table + certId-index GSI (Issue #427)
+            - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-certificates-shadow"
+            - Fn::Sub: "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${self:service}-certificates-shadow/index/*"
         - Effect: Allow
           Action:
             - cognito-idp:AdminCreateUser
@@ -175,6 +183,10 @@ functions:
       - httpApi:
           path: /admin/test/reset
           method: POST
+      # Shadow certificate verification endpoint (Issue #427)
+      - httpApi:
+          path: /shadow/certificate/{certId}
+          method: GET
 
 package:
   individually: true
@@ -431,6 +443,48 @@ resources:
             Value: serverless-framework
           - Key: Component
             Value: completion-framework
+
+    # Issued certificates for module and course completion (one record per learner per entity)
+    # PK: USER#<userId>  SK: CERT#<entityType>#<entitySlug>
+    # GSI certId-index: certId → used for public certificate verification (Issue #427)
+    CertificatesShadowTable:
+      Type: AWS::DynamoDB::Table
+      Condition: IsShadowStage
+      Properties:
+        TableName: ${self:service}-certificates-shadow
+        BillingMode: PAY_PER_REQUEST
+        AttributeDefinitions:
+          - AttributeName: PK
+            AttributeType: S
+          - AttributeName: SK
+            AttributeType: S
+          - AttributeName: certId
+            AttributeType: S
+        KeySchema:
+          - AttributeName: PK
+            KeyType: HASH
+          - AttributeName: SK
+            KeyType: RANGE
+        GlobalSecondaryIndexes:
+          - IndexName: certId-index
+            KeySchema:
+              - AttributeName: certId
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        SSESpecification:
+          SSEEnabled: true
+        Tags:
+          - Key: Project
+            Value: hedgehog-learn
+          - Key: Environment
+            Value: shadow
+          - Key: ManagedBy
+            Value: serverless-framework
+          - Key: Component
+            Value: certificate-framework
 
     # -------------------------------------------------------------------------
     # Shadow API path mapping on api.hedgehog.cloud (Issue #421)

--- a/src/api/lambda/certificate-issuance.ts
+++ b/src/api/lambda/certificate-issuance.ts
@@ -1,0 +1,314 @@
+/**
+ * Certificate issuance helpers for shadow completion framework (Issue #427)
+ *
+ * Shared by tasks-quiz-submit.ts and tasks-lab-attest.ts.
+ *
+ * issueCertificateIfComplete:
+ *   - Called after every entity-completion write
+ *   - Checks if moduleStatus === 'complete'
+ *   - Idempotent: skips issuance if a certificate already exists for user×entity
+ *   - Writes to hedgehog-learn-certificates-shadow
+ *   - Then checks if any course that contains this module is now fully complete
+ *     and issues a course-level certificate if so
+ *
+ * All failures are caught and logged; they do NOT propagate to the caller
+ * (certificate issuance is best-effort — the task write has already succeeded).
+ *
+ * @see Issue #427
+ * @see infrastructure/dynamodb/certificates-shadow-table.json
+ */
+
+import { randomUUID } from 'crypto';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { getHubSpotClient } from '../../shared/hubspot.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CertificateIssuanceResult {
+  /** Whether a new module certificate was issued (false = already existed or not complete) */
+  moduleCertIssued: boolean;
+  /** The certId of the module certificate (new or existing) — undefined if module not complete */
+  moduleCertId?: string;
+  /** Whether a new course certificate was issued */
+  courseCertIssued: boolean;
+  /** The certId of the course certificate if issued */
+  courseCertId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: issue a single certificate (idempotent)
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a certificate record if one does not already exist for this user+entity.
+ * Returns { issued: boolean, certId: string }.
+ *
+ * Uses a conditional PutItem (attribute_not_exists(PK)) so that concurrent
+ * completions cannot create duplicate certificates.
+ */
+async function issueOneCert(
+  dynamo: DynamoDBDocumentClient,
+  certsTable: string,
+  userId: string,
+  entityType: 'module' | 'course',
+  entitySlug: string,
+  evidenceSummary: Record<string, string>,
+  now: string
+): Promise<{ issued: boolean; certId: string }> {
+  const pk = `USER#${userId}`;
+  const sk = `CERT#${entityType}#${entitySlug}`;
+
+  // Check if certificate already exists (idempotency check)
+  const existing = await dynamo.send(
+    new GetCommand({
+      TableName: certsTable,
+      Key: { PK: pk, SK: sk },
+      ProjectionExpression: 'certId',
+    })
+  );
+
+  if (existing.Item?.certId) {
+    // Already issued — return existing certId without writing
+    return { issued: false, certId: existing.Item.certId as string };
+  }
+
+  const certId = randomUUID();
+
+  try {
+    await dynamo.send(
+      new PutCommand({
+        TableName: certsTable,
+        Item: {
+          PK: pk,
+          SK: sk,
+          certId,
+          learnerId: userId,
+          entityType,
+          entitySlug,
+          issuedAt: now,
+          evidenceSummary,
+        },
+        // Guard against races: only write if no cert exists yet
+        ConditionExpression: 'attribute_not_exists(PK) AND attribute_not_exists(SK)',
+      })
+    );
+    return { issued: true, certId };
+  } catch (err: any) {
+    if (err.name === 'ConditionalCheckFailedException') {
+      // Lost the race — another concurrent write beat us; fetch the winner's certId
+      const winner = await dynamo.send(
+        new GetCommand({
+          TableName: certsTable,
+          Key: { PK: pk, SK: sk },
+          ProjectionExpression: 'certId',
+        })
+      );
+      return { issued: false, certId: (winner.Item?.certId as string) || certId };
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: check course completion and issue course cert
+// ---------------------------------------------------------------------------
+
+/**
+ * For each course that contains moduleSlug, check if all modules in that course
+ * have a 'complete' entity-completion record for this learner.
+ * If yes, issue a course-level certificate (idempotent).
+ *
+ * Returns the first course certId issued (or undefined if none).
+ */
+async function checkAndIssueCourseCompletion(
+  dynamo: DynamoDBDocumentClient,
+  entityCompletionsTable: string,
+  certsTable: string,
+  userId: string,
+  moduleSlug: string,
+  taskStatusesMap: Record<string, string>,
+  now: string
+): Promise<{ issued: boolean; certId?: string }> {
+  const coursesTableId = process.env.HUBDB_COURSES_TABLE_ID;
+  if (!coursesTableId) {
+    console.warn('[CertIssuance] HUBDB_COURSES_TABLE_ID not set — skipping course cert check');
+    return { issued: false };
+  }
+
+  let coursesWithModule: Array<{ slug: string; moduleSlugs: string[] }> = [];
+
+  try {
+    const hubspot = getHubSpotClient();
+    const rowsResponse = await (hubspot as any).cms.hubdb.rowsApi.getTableRows(
+      coursesTableId,
+      undefined,
+      undefined,
+      undefined
+    );
+    const rows: any[] = rowsResponse.results || [];
+
+    for (const row of rows) {
+      const courseSlug: string = (row.path || row.values?.hs_path || '').toLowerCase();
+      if (!courseSlug) continue;
+
+      const slugsJson: string = row.values?.module_slugs_json || '[]';
+      let slugs: string[] = [];
+      try { slugs = JSON.parse(slugsJson); } catch { continue; }
+
+      if (slugs.some((s: string) => s.toLowerCase() === moduleSlug.toLowerCase())) {
+        coursesWithModule.push({ slug: courseSlug, moduleSlugs: slugs });
+      }
+    }
+  } catch (err: any) {
+    console.warn('[CertIssuance] HubDB courses fetch failed — skipping course cert:', err?.message || err);
+    return { issued: false };
+  }
+
+  if (coursesWithModule.length === 0) return { issued: false };
+
+  // For each candidate course, check if every module has a complete entity-completion
+  for (const course of coursesWithModule) {
+    if (course.moduleSlugs.length === 0) continue;
+
+    let allComplete = true;
+    for (const slug of course.moduleSlugs) {
+      try {
+        const result = await dynamo.send(
+          new GetCommand({
+            TableName: entityCompletionsTable,
+            Key: {
+              PK: `USER#${userId}`,
+              SK: `COMPLETION#MODULE#${slug}`,
+            },
+            ProjectionExpression: '#s',
+            ExpressionAttributeNames: { '#s': 'status' },
+          })
+        );
+        if (!result.Item || result.Item['status'] !== 'complete') {
+          allComplete = false;
+          break;
+        }
+      } catch (err: any) {
+        console.warn(`[CertIssuance] EntityCompletion check failed for ${slug}:`, err?.message || err);
+        allComplete = false;
+        break;
+      }
+    }
+
+    if (allComplete) {
+      try {
+        const courseCertResult = await issueOneCert(
+          dynamo,
+          certsTable,
+          userId,
+          'course',
+          course.slug,
+          taskStatusesMap, // snapshot of triggering module's task statuses
+          now
+        );
+        if (courseCertResult.issued) {
+          console.info(`[CertIssuance] Course cert issued: user=${userId} course=${course.slug} certId=${courseCertResult.certId}`);
+          return { issued: true, certId: courseCertResult.certId };
+        }
+      } catch (err: any) {
+        console.error(`[CertIssuance] Failed to issue course cert for ${course.slug}:`, err?.message || err);
+      }
+    }
+  }
+
+  return { issued: false };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Main entry point called by task write endpoints after every entity-completion upsert.
+ *
+ * - If moduleStatus !== 'complete', returns immediately with no-op result
+ * - Issues module cert (idempotent)
+ * - Checks and issues course cert if all modules in any course are now complete
+ *
+ * Never throws — all errors are caught and logged.
+ */
+export async function issueCertificateIfComplete(params: {
+  dynamo: DynamoDBDocumentClient;
+  userId: string;
+  moduleSlug: string;
+  moduleStatus: string;
+  taskStatusesMap: Record<string, string>;
+  now: string;
+}): Promise<CertificateIssuanceResult> {
+  const { dynamo, userId, moduleSlug, moduleStatus, taskStatusesMap, now } = params;
+
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  const ENTITY_COMPLETIONS_TABLE = process.env.ENTITY_COMPLETIONS_TABLE;
+
+  if (moduleStatus !== 'complete') {
+    return { moduleCertIssued: false, courseCertIssued: false };
+  }
+
+  if (!CERTS_TABLE) {
+    console.warn('[CertIssuance] CERTIFICATES_TABLE not set — skipping cert issuance');
+    return { moduleCertIssued: false, courseCertIssued: false };
+  }
+
+  let moduleCertId: string | undefined;
+  let moduleCertIssued = false;
+
+  // Issue module certificate
+  try {
+    const result = await issueOneCert(
+      dynamo,
+      CERTS_TABLE,
+      userId,
+      'module',
+      moduleSlug,
+      taskStatusesMap,
+      now
+    );
+    moduleCertId = result.certId;
+    moduleCertIssued = result.issued;
+
+    if (moduleCertIssued) {
+      console.info(`[CertIssuance] Module cert issued: user=${userId} module=${moduleSlug} certId=${moduleCertId}`);
+    }
+  } catch (err: any) {
+    console.error('[CertIssuance] Failed to issue module cert:', err?.message || err);
+    // Return partial result — do not fail the overall response
+    return { moduleCertIssued: false, courseCertIssued: false };
+  }
+
+  // Check for course completion (best-effort)
+  let courseCertIssued = false;
+  let courseCertId: string | undefined;
+
+  if (ENTITY_COMPLETIONS_TABLE) {
+    try {
+      const courseResult = await checkAndIssueCourseCompletion(
+        dynamo,
+        ENTITY_COMPLETIONS_TABLE,
+        CERTS_TABLE,
+        userId,
+        moduleSlug,
+        taskStatusesMap,
+        now
+      );
+      courseCertIssued = courseResult.issued;
+      courseCertId = courseResult.certId;
+    } catch (err: any) {
+      console.error('[CertIssuance] Course cert check failed:', err?.message || err);
+      // Non-fatal — module cert was already issued
+    }
+  }
+
+  return {
+    moduleCertIssued,
+    moduleCertId,
+    courseCertIssued,
+    courseCertId,
+  };
+}

--- a/src/api/lambda/certificate-verify.ts
+++ b/src/api/lambda/certificate-verify.ts
@@ -1,0 +1,146 @@
+/**
+ * GET /shadow/certificate/:certId
+ *
+ * Shadow-only public verification endpoint: looks up a certificate by its UUID
+ * via the certId-index GSI on the certificates-shadow DynamoDB table.
+ *
+ * No auth required — certificates are public proofs of completion.
+ * Only non-PII fields are returned: certId, entityType, entitySlug, issuedAt.
+ *
+ * Shadow guard: returns 403 when APP_STAGE !== 'shadow'.
+ * Returns 404 when certId is not found.
+ *
+ * @see Issue #427
+ * @see infrastructure/dynamodb/certificates-shadow-table.json
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+
+// ---------------------------------------------------------------------------
+// DynamoDB client (lazy init for testability)
+// ---------------------------------------------------------------------------
+
+let _dynamoClient: DynamoDBDocumentClient | undefined;
+export function getDynamo(): DynamoDBDocumentClient {
+  if (!_dynamoClient) {
+    const region =
+      process.env.COGNITO_REGION || process.env.AWS_REGION || 'us-west-2';
+    _dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+  }
+  return _dynamoClient;
+}
+
+// ---------------------------------------------------------------------------
+// CORS helpers
+// ---------------------------------------------------------------------------
+
+const ALLOWED_ORIGINS = [
+  'https://hedgehog.cloud',
+  'https://www.hedgehog.cloud',
+];
+const HUBSPOT_CDN_PATTERN =
+  /^https:\/\/.*\.hubspotusercontent(?:-na1|00|20|30|40)\.net$/;
+
+function getAllowedOrigin(origin: string | undefined): string {
+  if (!origin) return 'https://hedgehog.cloud';
+  if (ALLOWED_ORIGINS.includes(origin) || HUBSPOT_CDN_PATTERN.test(origin)) {
+    return origin;
+  }
+  return 'https://hedgehog.cloud';
+}
+
+function jsonResp(
+  status: number,
+  body: unknown,
+  origin?: string
+): { statusCode: number; headers: Record<string, string>; body: string } {
+  return {
+    statusCode: status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': getAllowedOrigin(origin),
+      'Access-Control-Allow-Credentials': 'true',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Response type (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export type CertificateVerifyResponse = {
+  certId: string;
+  entityType: 'module' | 'course';
+  entitySlug: string;
+  issuedAt: string;
+};
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleCertificateVerify(event: any) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+
+  // --- Shadow guard ---
+  if (process.env.APP_STAGE !== 'shadow') {
+    return jsonResp(403, { error: 'Not available in this environment' }, origin);
+  }
+
+  // --- Extract certId from path parameters ---
+  // API Gateway v2 path param: /shadow/certificate/{certId}
+  // After the /shadow base-path mapping strips /shadow, the Lambda sees
+  // /certificate/{certId}.  API GW puts the raw param in event.pathParameters.
+  const certId = (
+    event.pathParameters?.certId ||
+    // Fallback: parse from rawPath for local testing
+    (event.rawPath || '').split('/').pop()
+  )?.trim();
+
+  if (!certId) {
+    return jsonResp(400, { error: 'certId is required' }, origin);
+  }
+
+  // Basic UUID v4 format validation (prevents injection / oversized input)
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(certId)) {
+    return jsonResp(400, { error: 'Invalid certId format' }, origin);
+  }
+
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  if (!CERTS_TABLE) {
+    console.error('[CertVerify] CERTIFICATES_TABLE not set');
+    return jsonResp(500, { error: 'Server configuration error' }, origin);
+  }
+
+  try {
+    const result = await getDynamo().send(
+      new QueryCommand({
+        TableName: CERTS_TABLE,
+        IndexName: 'certId-index',
+        KeyConditionExpression: 'certId = :certId',
+        ExpressionAttributeValues: { ':certId': certId },
+        Limit: 1,
+      })
+    );
+
+    const item = result.Items?.[0];
+    if (!item) {
+      return jsonResp(404, { error: 'Certificate not found' }, origin);
+    }
+
+    const response: CertificateVerifyResponse = {
+      certId: item.certId as string,
+      entityType: item.entityType as 'module' | 'course',
+      entitySlug: item.entitySlug as string,
+      issuedAt: item.issuedAt as string,
+    };
+
+    return jsonResp(200, response, origin);
+  } catch (err: any) {
+    console.error('[CertVerify] DynamoDB query failed:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to verify certificate' }, origin);
+  }
+}

--- a/src/api/lambda/index.ts
+++ b/src/api/lambda/index.ts
@@ -37,6 +37,7 @@ import { handleLabAttest } from './tasks-lab-attest.js';
 import { handleTasksStatus } from './tasks-status.js';
 import { handleTasksStatusBatch } from './tasks-status-batch.js';
 import { handleAdminTestReset } from './admin-test-reset.js';
+import { handleCertificateVerify } from './certificate-verify.js';
 
 // Allowed origins for CORS
 const ALLOWED_ORIGINS = [
@@ -202,6 +203,8 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     if (path.endsWith('/tasks/status/batch') && method === 'GET') return await handleTasksStatusBatch(event);
     if (path.endsWith('/tasks/status') && method === 'GET') return await handleTasksStatus(event);
     if (path.endsWith('/admin/test/reset') && method === 'POST') return await handleAdminTestReset(event);
+    // Shadow certificate verification endpoint (Issue #427)
+    if (path.includes('/shadow/certificate/') && method === 'GET') return await handleCertificateVerify(event);
 
     // Legacy POST endpoints
     if (method !== 'POST') return bad(405, 'Method not allowed', origin);

--- a/src/api/lambda/tasks-lab-attest.ts
+++ b/src/api/lambda/tasks-lab-attest.ts
@@ -29,6 +29,7 @@ import {
 import { getHubSpotClient } from '../../shared/hubspot.js';
 import { verifyCookieAuth } from './cognito-auth.js';
 import { computeModuleStatus, type CompletionTask } from './tasks-quiz-submit.js';
+import { issueCertificateIfComplete } from './certificate-issuance.js';
 
 // ---------------------------------------------------------------------------
 // DynamoDB client (lazy init for testability)
@@ -272,15 +273,33 @@ export async function handleLabAttest(event: any) {
       })
     );
 
-    return jsonResp(
-      200,
-      {
-        attested: true,
-        task_slug,
-        module_complete: moduleStatus === 'complete',
-      },
-      origin
-    );
+    // Step 5: Certificate issuance (best-effort — never fails the response)
+    // Build a flat slug→status map for the evidenceSummary snapshot
+    const evidenceSummary: Record<string, string> = {};
+    for (const [slug, detail] of Object.entries(taskStatusesMap)) {
+      evidenceSummary[slug] = detail.status;
+    }
+
+    const certResult = await issueCertificateIfComplete({
+      dynamo,
+      userId,
+      moduleSlug: module_slug,
+      moduleStatus,
+      taskStatusesMap: evidenceSummary,
+      now,
+    });
+
+    const responseBody: Record<string, unknown> = {
+      attested: true,
+      task_slug,
+      module_complete: moduleStatus === 'complete',
+    };
+
+    if (certResult.moduleCertId) {
+      responseBody.cert_id = certResult.moduleCertId;
+    }
+
+    return jsonResp(200, responseBody, origin);
   } catch (err: any) {
     console.error('[LabAttest] DynamoDB write failed:', err?.message || err);
     return jsonResp(500, { error: 'Failed to persist attestation' }, origin);

--- a/src/api/lambda/tasks-quiz-submit.ts
+++ b/src/api/lambda/tasks-quiz-submit.ts
@@ -25,6 +25,7 @@ import {
 } from '@aws-sdk/lib-dynamodb';
 import { getHubSpotClient } from '../../shared/hubspot.js';
 import { verifyCookieAuth } from './cognito-auth.js';
+import { issueCertificateIfComplete } from './certificate-issuance.js';
 
 // ---------------------------------------------------------------------------
 // DynamoDB client (lazy init for testability)
@@ -410,16 +411,34 @@ export async function handleQuizSubmit(event: any) {
       })
     );
 
-    return jsonResp(
-      200,
-      {
-        score,
-        pass,
-        attempts: attemptCount,
-        module_complete: moduleStatus === 'complete',
-      },
-      origin
-    );
+    // Step 5: Certificate issuance (best-effort — never fails the response)
+    // Build a flat slug→status map for the evidenceSummary snapshot
+    const evidenceSummary: Record<string, string> = {};
+    for (const [slug, detail] of Object.entries(taskStatusesMap)) {
+      evidenceSummary[slug] = detail.status;
+    }
+
+    const certResult = await issueCertificateIfComplete({
+      dynamo,
+      userId,
+      moduleSlug: module_slug,
+      moduleStatus,
+      taskStatusesMap: evidenceSummary,
+      now,
+    });
+
+    const responseBody: Record<string, unknown> = {
+      score,
+      pass,
+      attempts: attemptCount,
+      module_complete: moduleStatus === 'complete',
+    };
+
+    if (certResult.moduleCertId) {
+      responseBody.cert_id = certResult.moduleCertId;
+    }
+
+    return jsonResp(200, responseBody, origin);
   } catch (err: any) {
     console.error('[QuizSubmit] DynamoDB write failed:', err?.message || err);
     return jsonResp(500, { error: 'Failed to persist attempt' }, origin);

--- a/src/api/lambda/tasks-status.ts
+++ b/src/api/lambda/tasks-status.ts
@@ -18,7 +18,7 @@
  */
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { getHubSpotClient } from '../../shared/hubspot.js';
 import { verifyCookieAuth } from './cognito-auth.js';
 
@@ -85,6 +85,8 @@ export type TaskStatusResponse = {
   module_slug: string;
   module_status: 'not_started' | 'in_progress' | 'complete';
   tasks: Record<string, TaskStatusEntry>;
+  /** Present when module_status === 'complete' and a certificate has been issued */
+  cert_id?: string;
 };
 
 /**
@@ -133,6 +135,40 @@ export function buildResponseFromRecord(
 }
 
 // ---------------------------------------------------------------------------
+// Certificate lookup helper (best-effort — never throws to caller)
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up an existing certificate certId for a user+module combination.
+ * Returns undefined if not found or if CERTIFICATES_TABLE is not configured.
+ */
+async function lookupModuleCertId(
+  dynamo: DynamoDBDocumentClient,
+  userId: string,
+  moduleSlug: string
+): Promise<string | undefined> {
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  if (!CERTS_TABLE) return undefined;
+
+  try {
+    const result = await dynamo.send(
+      new GetCommand({
+        TableName: CERTS_TABLE,
+        Key: {
+          PK: `USER#${userId}`,
+          SK: `CERT#module#${moduleSlug}`,
+        },
+        ProjectionExpression: 'certId',
+      })
+    );
+    return result.Item?.certId as string | undefined;
+  } catch (err: any) {
+    console.warn('[TasksStatus] cert lookup failed:', err?.message || err);
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Handler
 // ---------------------------------------------------------------------------
 
@@ -175,6 +211,11 @@ export async function handleTasksStatus(event: any) {
 
     if (result.Item) {
       const response = buildResponseFromRecord(module_slug, result.Item);
+      // Augment with cert_id if module is complete and a certificate exists
+      if (response.module_status === 'complete') {
+        const certId = await lookupModuleCertId(getDynamo(), userId, module_slug);
+        if (certId) response.cert_id = certId;
+      }
       return jsonResp(200, response, origin);
     }
   } catch (err: any) {

--- a/tests/unit/certificate-issuance.test.ts
+++ b/tests/unit/certificate-issuance.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Unit tests for shadow certificate issuance and verification (Issue #427)
+ *
+ * Tests cover:
+ *   - Module cert generated when all tasks pass (moduleStatus === 'complete')
+ *   - Module cert NOT generated when only some tasks pass (moduleStatus !== 'complete')
+ *   - Course cert generated when all modules in a course complete
+ *   - Idempotent: re-completion returns existing certId without writing a new cert
+ *   - Public verification endpoint returns correct payload
+ *   - 404 on unknown certId
+ *   - 403 when APP_STAGE !== 'shadow'
+ *   - 400 on invalid certId format
+ */
+
+import { issueCertificateIfComplete } from '../../src/api/lambda/certificate-issuance';
+import { handleCertificateVerify } from '../../src/api/lambda/certificate-verify';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('crypto', () => ({
+  randomUUID: jest.fn().mockReturnValue('00000000-0000-4000-a000-000000000001'),
+}));
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+// Mutable mock so individual tests can override send behavior
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+  PutCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'PutCommand' })),
+  QueryCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'QueryCommand' })),
+  UpdateCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'UpdateCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDynamo(): DynamoDBDocumentClient {
+  return DynamoDBDocumentClient.from({} as any);
+}
+
+const NOW = '2026-04-14T00:00:00.000Z';
+const USER_ID = 'test-user-sub-123';
+const MODULE_SLUG = 'fabric-operations-welcome';
+const CERTS_TABLE = 'hedgehog-learn-certificates-shadow';
+const ENTITY_COMPLETIONS_TABLE = 'hedgehog-learn-entity-completions-shadow';
+
+// ---------------------------------------------------------------------------
+// issueCertificateIfComplete
+// ---------------------------------------------------------------------------
+
+describe('issueCertificateIfComplete', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+    process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+    process.env.HUBDB_COURSES_TABLE_ID = 'test-courses-table';
+  });
+
+  afterEach(() => {
+    delete process.env.CERTIFICATES_TABLE;
+    delete process.env.ENTITY_COMPLETIONS_TABLE;
+    delete process.env.HUBDB_COURSES_TABLE_ID;
+  });
+
+  it('returns no-op when moduleStatus is not complete', async () => {
+    const dynamo = makeDynamo();
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'in_progress',
+      taskStatusesMap: { 'quiz-1': 'passed' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(false);
+    expect(result.moduleCertId).toBeUndefined();
+    expect(result.courseCertIssued).toBe(false);
+    expect(mockDynamoSend).not.toHaveBeenCalled();
+  });
+
+  it('issues module cert when moduleStatus is complete (no existing cert)', async () => {
+    const dynamo = makeDynamo();
+
+    // Sequence of DynamoDB calls:
+    // 1. GetCommand (cert existence check) → no item
+    // 2. PutCommand (write new cert) → success
+    // 3. GetCommand (entity-completion for module in course check — course lookup goes via HubDB)
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })  // cert existence check
+      .mockResolvedValueOnce({});                   // PutCommand succeeds
+
+    // HubDB courses: no course contains this module
+    mockGetHubSpotClient.mockReturnValueOnce({
+      cms: {
+        hubdb: {
+          rowsApi: {
+            getTableRows: jest.fn().mockResolvedValueOnce({ results: [] }),
+          },
+        },
+      },
+    } as any);
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'complete',
+      taskStatusesMap: { 'quiz-1': 'passed', 'lab-main': 'attested' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(true);
+    expect(result.moduleCertId).toBe('00000000-0000-4000-a000-000000000001');
+    expect(result.courseCertIssued).toBe(false);
+  });
+
+  it('does NOT issue module cert when only some tasks pass (not_complete status)', async () => {
+    const dynamo = makeDynamo();
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'not_started',
+      taskStatusesMap: {},
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(false);
+    expect(mockDynamoSend).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: returns existing certId without writing when cert already exists', async () => {
+    const dynamo = makeDynamo();
+    const existingCertId = 'aaaaaaaa-0000-4000-a000-000000000099';
+
+    // GetCommand returns an existing cert
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: { certId: existingCertId } });  // cert exists
+
+    // HubDB courses: none match
+    mockGetHubSpotClient.mockReturnValueOnce({
+      cms: {
+        hubdb: {
+          rowsApi: {
+            getTableRows: jest.fn().mockResolvedValueOnce({ results: [] }),
+          },
+        },
+      },
+    } as any);
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'complete',
+      taskStatusesMap: { 'quiz-1': 'passed', 'lab-main': 'attested' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(false);   // not newly issued
+    expect(result.moduleCertId).toBe(existingCertId);
+    // PutCommand should NOT have been called
+    const putCalls = mockDynamoSend.mock.calls.filter(
+      (call) => call[0]?._tag === 'PutCommand'
+    );
+    expect(putCalls.length).toBe(0);
+  });
+
+  it('issues course cert when all modules in course are complete', async () => {
+    const dynamo = makeDynamo();
+
+    // randomUUID will be called twice: once for module cert, once for course cert
+    const { randomUUID } = require('crypto');
+    (randomUUID as jest.Mock)
+      .mockReturnValueOnce('mod-cert-uuid-0000-4000-a000-000000000002')
+      .mockReturnValueOnce('course-cert-uuid-0004000-a000-000000000003');
+
+    // DynamoDB call sequence:
+    // 1. GetCommand: module cert existence check → no item (not yet issued)
+    // 2. PutCommand: write module cert → success
+    // 3. GetCommand: entity-completion for 'module-a' → complete
+    // 4. GetCommand: entity-completion for 'module-b' (= MODULE_SLUG, just completed) → complete
+    // 5. GetCommand: course cert existence check → no item
+    // 6. PutCommand: write course cert → success
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })                           // (1) module cert check
+      .mockResolvedValueOnce({})                                            // (2) module PutCommand
+      .mockResolvedValueOnce({ Item: { status: 'complete' } })             // (3) module-a entity check
+      .mockResolvedValueOnce({ Item: { status: 'complete' } })             // (4) MODULE_SLUG entity check
+      .mockResolvedValueOnce({ Item: undefined })                           // (5) course cert check
+      .mockResolvedValueOnce({});                                           // (6) course PutCommand
+
+    // HubDB returns one course containing MODULE_SLUG and 'module-a'
+    mockGetHubSpotClient.mockReturnValueOnce({
+      cms: {
+        hubdb: {
+          rowsApi: {
+            getTableRows: jest.fn().mockResolvedValueOnce({
+              results: [
+                {
+                  path: 'network-like-hyperscaler-foundations',
+                  values: {
+                    module_slugs_json: JSON.stringify(['module-a', MODULE_SLUG]),
+                  },
+                },
+              ],
+            }),
+          },
+        },
+      },
+    } as any);
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'complete',
+      taskStatusesMap: { 'quiz-1': 'passed', 'lab-main': 'attested' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(true);
+    expect(result.courseCertIssued).toBe(true);
+    expect(result.courseCertId).toBeDefined();
+  });
+
+  it('does NOT issue course cert when some modules in course are not complete', async () => {
+    const dynamo = makeDynamo();
+
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })                           // module cert check → not exists
+      .mockResolvedValueOnce({})                                            // module PutCommand
+      .mockResolvedValueOnce({ Item: { status: 'in_progress' } })         // module-a entity check → not complete
+      // course loop short-circuits after first non-complete module
+
+    // HubDB returns one course containing MODULE_SLUG and 'module-a'
+    mockGetHubSpotClient.mockReturnValueOnce({
+      cms: {
+        hubdb: {
+          rowsApi: {
+            getTableRows: jest.fn().mockResolvedValueOnce({
+              results: [
+                {
+                  path: 'network-like-hyperscaler-foundations',
+                  values: {
+                    module_slugs_json: JSON.stringify(['module-a', MODULE_SLUG]),
+                  },
+                },
+              ],
+            }),
+          },
+        },
+      },
+    } as any);
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'complete',
+      taskStatusesMap: { 'quiz-1': 'passed', 'lab-main': 'attested' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(true);
+    expect(result.courseCertIssued).toBe(false);
+  });
+
+  it('returns no-op when CERTIFICATES_TABLE env is not set', async () => {
+    delete process.env.CERTIFICATES_TABLE;
+    const dynamo = makeDynamo();
+
+    const result = await issueCertificateIfComplete({
+      dynamo,
+      userId: USER_ID,
+      moduleSlug: MODULE_SLUG,
+      moduleStatus: 'complete',
+      taskStatusesMap: { 'quiz-1': 'passed' },
+      now: NOW,
+    });
+
+    expect(result.moduleCertIssued).toBe(false);
+    expect(mockDynamoSend).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCertificateVerify — GET /shadow/certificate/:certId
+// ---------------------------------------------------------------------------
+
+describe('handleCertificateVerify', () => {
+  const VALID_CERT_ID = 'a1b2c3d4-0000-4000-a000-000000000001';
+
+  const baseEvent = {
+    headers: { origin: 'https://hedgehog.cloud' },
+    pathParameters: { certId: VALID_CERT_ID },
+    rawPath: `/shadow/certificate/${VALID_CERT_ID}`,
+    requestContext: { http: { method: 'GET' } },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  });
+
+  afterEach(() => {
+    delete process.env.CERTIFICATES_TABLE;
+  });
+
+  it('returns 403 when APP_STAGE !== shadow', async () => {
+    process.env.APP_STAGE = 'dev';
+    const result = await handleCertificateVerify(baseEvent);
+    expect(result.statusCode).toBe(403);
+    delete process.env.APP_STAGE;
+  });
+
+  it('returns 403 when APP_STAGE is undefined', async () => {
+    delete process.env.APP_STAGE;
+    const result = await handleCertificateVerify(baseEvent);
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('returns 400 on invalid certId format (not a UUID)', async () => {
+    process.env.APP_STAGE = 'shadow';
+    const badEvent = {
+      ...baseEvent,
+      pathParameters: { certId: 'not-a-uuid' },
+    };
+    const result = await handleCertificateVerify(badEvent);
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toBe('Invalid certId format');
+    delete process.env.APP_STAGE;
+  });
+
+  it('returns 404 when certId is not found in DynamoDB', async () => {
+    process.env.APP_STAGE = 'shadow';
+    mockDynamoSend.mockResolvedValueOnce({ Items: [] }); // GSI query returns nothing
+
+    const result = await handleCertificateVerify(baseEvent);
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.error).toBe('Certificate not found');
+    delete process.env.APP_STAGE;
+  });
+
+  it('returns 200 with certificate fields (no PII) when certId is found', async () => {
+    process.env.APP_STAGE = 'shadow';
+
+    mockDynamoSend.mockResolvedValueOnce({
+      Items: [
+        {
+          certId: VALID_CERT_ID,
+          learnerId: USER_ID,           // PII — should NOT appear in response
+          entityType: 'module',
+          entitySlug: MODULE_SLUG,
+          issuedAt: NOW,
+          evidenceSummary: { 'quiz-1': 'passed' },  // internal — should NOT appear
+        },
+      ],
+    });
+
+    const result = await handleCertificateVerify(baseEvent);
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.certId).toBe(VALID_CERT_ID);
+    expect(body.entityType).toBe('module');
+    expect(body.entitySlug).toBe(MODULE_SLUG);
+    expect(body.issuedAt).toBe(NOW);
+
+    // PII fields must NOT be in response
+    expect(body.learnerId).toBeUndefined();
+    expect(body.evidenceSummary).toBeUndefined();
+    delete process.env.APP_STAGE;
+  });
+
+  it('returns 200 for a course certificate', async () => {
+    process.env.APP_STAGE = 'shadow';
+    const COURSE_CERT_ID = 'b2c3d4e5-0000-4000-a000-000000000002';
+    const COURSE_SLUG = 'network-like-hyperscaler-foundations';
+
+    mockDynamoSend.mockResolvedValueOnce({
+      Items: [
+        {
+          certId: COURSE_CERT_ID,
+          learnerId: USER_ID,
+          entityType: 'course',
+          entitySlug: COURSE_SLUG,
+          issuedAt: NOW,
+        },
+      ],
+    });
+
+    const courseEvent = {
+      ...baseEvent,
+      pathParameters: { certId: COURSE_CERT_ID },
+    };
+
+    const result = await handleCertificateVerify(courseEvent);
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.certId).toBe(COURSE_CERT_ID);
+    expect(body.entityType).toBe('course');
+    expect(body.entitySlug).toBe(COURSE_SLUG);
+    expect(body.learnerId).toBeUndefined();
+    delete process.env.APP_STAGE;
+  });
+
+  it('returns 500 on DynamoDB error', async () => {
+    process.env.APP_STAGE = 'shadow';
+    mockDynamoSend.mockRejectedValueOnce(new Error('DynamoDB unavailable'));
+
+    const result = await handleCertificateVerify(baseEvent);
+    expect(result.statusCode).toBe(500);
+    delete process.env.APP_STAGE;
+  });
+});

--- a/verification-output/issue-427/verification.md
+++ b/verification-output/issue-427/verification.md
@@ -1,0 +1,214 @@
+# Issue #427 — Shadow Certificate Issuance and Verification
+
+Shadow phase 6 of Epic #397. Adds certificate generation on top of the task recording infrastructure.
+
+---
+
+## DynamoDB Schema
+
+### `hedgehog-learn-certificates-shadow`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `PK` | String | `USER#<cognitoSub>` — partition key |
+| `SK` | String | `CERT#<entityType>#<entitySlug>` — sort key |
+| `certId` | String (UUID v4) | Globally unique certificate identifier; GSI partition key |
+| `learnerId` | String | Cognito sub of the learner |
+| `entityType` | String | `"module"` or `"course"` |
+| `entitySlug` | String | Slug of the module or course |
+| `issuedAt` | String | ISO 8601 timestamp |
+| `evidenceSummary` | Map | `{ <taskSlug>: <status> }` snapshot at issuance time |
+
+**GSI**: `certId-index` — PK: `certId` (HASH), projection: ALL  
+Used by the public verification endpoint to look up certs without knowing the learner's sub.
+
+**Condition**: `IsShadowStage` — only provisioned in the shadow stage.
+
+---
+
+## API Endpoints
+
+### GET /shadow/certificate/:certId (public — no auth required)
+
+Looks up a certificate by `certId` via the GSI. Returns only non-PII fields.
+
+**Request**:
+```
+GET https://api.hedgehog.cloud/shadow/shadow/certificate/a1b2c3d4-1234-4abc-8def-000000000001
+```
+
+**200 Response**:
+```json
+{
+  "certId": "a1b2c3d4-1234-4abc-8def-000000000001",
+  "entityType": "module",
+  "entitySlug": "fabric-operations-welcome",
+  "issuedAt": "2026-04-14T12:34:56.789Z"
+}
+```
+
+**Error responses**:
+- `403` — `APP_STAGE !== 'shadow'`
+- `400` — missing or non-UUID certId
+- `404` — certId not found
+- `500` — DynamoDB error
+
+---
+
+### POST /tasks/quiz/submit (augmented — now returns cert_id)
+
+When submission causes module completion, the response includes `cert_id`:
+
+```json
+{
+  "score": 100,
+  "pass": true,
+  "attempts": 1,
+  "module_complete": true,
+  "cert_id": "a1b2c3d4-1234-4abc-8def-000000000001"
+}
+```
+
+`cert_id` is absent when `module_complete: false`.
+
+---
+
+### POST /tasks/lab/attest (augmented — now returns cert_id)
+
+Same cert_id augmentation:
+
+```json
+{
+  "attested": true,
+  "task_slug": "lab-main",
+  "module_complete": true,
+  "cert_id": "a1b2c3d4-1234-4abc-8def-000000000001"
+}
+```
+
+---
+
+### GET /tasks/status?module_slug=... (augmented — now returns cert_id)
+
+When `module_status === "complete"` and a certificate exists:
+
+```json
+{
+  "module_slug": "fabric-operations-welcome",
+  "module_status": "complete",
+  "tasks": { ... },
+  "cert_id": "a1b2c3d4-1234-4abc-8def-000000000001"
+}
+```
+
+---
+
+## Certificate Issuance Logic
+
+### Module-level (in `certificate-issuance.ts`)
+
+1. Called by `tasks-quiz-submit.ts` and `tasks-lab-attest.ts` after every entity-completion write.
+2. If `moduleStatus !== 'complete'`, returns immediately (no-op).
+3. Checks `GET certificates-shadow` for `PK=USER#<sub>, SK=CERT#module#<slug>`.
+4. If not found: calls `PutItem` with `ConditionExpression: attribute_not_exists(PK) AND attribute_not_exists(SK)` (race guard).
+5. Returns `{ moduleCertIssued, moduleCertId }`.
+
+### Course-level (in `certificate-issuance.ts`)
+
+6. Fetches HubDB `courses` table rows via `HUBDB_COURSES_TABLE_ID`.
+7. Finds courses whose `module_slugs_json` contains the just-completed module.
+8. For each such course, does a `GetItem` on `entity-completions-shadow` for every module in the course.
+9. If all modules have `status: 'complete'`, issues a course certificate (idempotent PutItem).
+
+### Idempotency
+
+Both module and course certificate issuance use `GetItem` before `PutItem`. If the item already exists, the existing `certId` is returned without writing. A `ConditionalCheckFailedException` on `PutItem` (concurrent race) fetches the winning record's `certId`.
+
+---
+
+## How to Test Manually
+
+### Prerequisites
+
+- Shadow stack deployed (`APP_STAGE=shadow`)
+- Learner authenticated (Cognito httpOnly cookie set)
+- Module with `completion_tasks_json` in HubDB
+
+### Step 1: Complete all tasks for a module
+
+```bash
+# Submit a passing quiz
+curl -X POST https://api.hedgehog.cloud/shadow/tasks/quiz/submit \
+  -H "Content-Type: application/json" \
+  -b "hhl_access_token=<token>" \
+  -d '{"module_slug":"fabric-operations-welcome","quiz_ref":"quiz-1","answers":[...]}'
+# → response should include "module_complete":true and "cert_id":"<uuid>"
+```
+
+```bash
+# Attest lab (if also required)
+curl -X POST https://api.hedgehog.cloud/shadow/tasks/lab/attest \
+  -H "Content-Type: application/json" \
+  -b "hhl_access_token=<token>" \
+  -d '{"module_slug":"fabric-operations-welcome","task_slug":"lab-main"}'
+```
+
+### Step 2: Verify the certificate
+
+```bash
+curl https://api.hedgehog.cloud/shadow/shadow/certificate/<uuid-from-step-1>
+# → 200 { certId, entityType, entitySlug, issuedAt }
+```
+
+### Step 3: Check idempotency
+
+Re-submit the same quiz passing again:
+```bash
+curl -X POST https://api.hedgehog.cloud/shadow/tasks/quiz/submit ...
+# → response should include same cert_id (not a new UUID)
+```
+
+### Step 4: Check My Learning page
+
+Visit `https://hedgehog.cloud/learn-shadow/my-learning` — completed modules should show 🎓 certificate earned badge.
+
+### Step 5: Check DynamoDB directly
+
+```bash
+aws dynamodb get-item \
+  --table-name hedgehog-learn-certificates-shadow \
+  --key '{"PK":{"S":"USER#<sub>"},"SK":{"S":"CERT#module#fabric-operations-welcome"}}'
+```
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `infrastructure/dynamodb/certificates-shadow-table.json` | New — DynamoDB schema doc |
+| `serverless.yml` | Added params, env vars, IAM policy, CloudFormation table, httpApi route |
+| `src/api/lambda/certificate-issuance.ts` | New — shared cert issuance logic |
+| `src/api/lambda/certificate-verify.ts` | New — GET /shadow/certificate/:certId handler |
+| `src/api/lambda/tasks-quiz-submit.ts` | Import + call `issueCertificateIfComplete`, add cert_id to response |
+| `src/api/lambda/tasks-lab-attest.ts` | Import + call `issueCertificateIfComplete`, add cert_id to response |
+| `src/api/lambda/tasks-status.ts` | Add cert_id to response when module complete |
+| `src/api/lambda/index.ts` | Import handleCertificateVerify, add route dispatch |
+| `clean-x-hedgehog-templates/assets/shadow/js/shadow-my-learning.js` | Add certificate badge for completed modules/courses |
+| `tests/unit/certificate-issuance.test.ts` | New — 14 unit tests covering all spec scenarios |
+
+---
+
+## Decisions / Deviations from Spec
+
+1. **Certificate issuance as shared module**: Instead of duplicating logic in both `tasks-quiz-submit.ts` and `tasks-lab-attest.ts`, the issuance logic lives in `certificate-issuance.ts`. Both handlers import it. This keeps the handlers DRY.
+
+2. **Best-effort issuance**: Certificate issuance failures are caught and logged but do not fail the task write response. The task write already succeeded; cert issuance is durable-enough via DynamoDB conditional writes. This prevents a HubDB or DynamoDB blip from blocking the learner's grade response.
+
+3. **tasks/status cert_id augmentation**: The spec said "if the response includes cert_id" — this implied the status endpoint should return cert_id. Added a `GetItem` on the certificates table when `module_status === 'complete'`. This is a single extra DynamoDB read on the happy path only.
+
+4. **My Learning batch endpoint**: The `tasks/status/batch` endpoint does not return cert_ids (that would require N extra DynamoDB reads). The My Learning page shows the 🎓 badge for `module_status === 'complete'` modules without a direct cert link. The course-level badge is shown when `isComplete === true`. Individual module pages (which use the single-module `/tasks/status` endpoint) get the full cert link.
+
+5. **HUBDB_COURSES_TABLE_ID in serverless.yml**: Was already in `.env` but not wired into the Lambda environment. Added it with a safe default of `''` so it doesn't break non-shadow stages.
+
+6. **Public endpoint path**: The spec says `GET /shadow/certificate/:certId`. In the Lambda after the `/shadow` path mapping strips the prefix, the route is `/certificate/{certId}`. The route dispatch in `index.ts` uses `path.includes('/shadow/certificate/')` to match the full path before stripping.


### PR DESCRIPTION
## Summary

- **Phase 6A**: Adds `hedgehog-learn-certificates-shadow` DynamoDB table with `certId-index` GSI (PK: certId, projection: ALL) for public cert lookup. Wired into `serverless.yml` with params, env vars (`CERTIFICATES_TABLE`, `HUBDB_COURSES_TABLE_ID`), IAM policy including GSI ARN, and CloudFormation resource under `IsShadowStage` condition.
- **Phase 6B**: New `certificate-issuance.ts` shared helper; `tasks-quiz-submit.ts` and `tasks-lab-attest.ts` now call `issueCertificateIfComplete` after every entity-completion write. Module cert issued on first completion; course cert issued when all modules in a course complete. Both endpoints return `cert_id` in their response when the module is newly or previously completed. `tasks-status.ts` also returns `cert_id` on the single-module read path.
- **Phase 6C**: New `certificate-verify.ts` — `GET /shadow/certificate/:certId` — no-auth public endpoint; queries via GSI; returns `certId, entityType, entitySlug, issuedAt` (no PII). Routed in `index.ts`.
- **Phase 6D**: `shadow-my-learning.js` shows 🎓 "Certificate earned" badge on completed modules and courses. Badge links to `/shadow/certificate/<certId>` when certId is available (single-module status path); display-only badge when only batch status is available.
- **Phase 6E**: 14 unit tests in `tests/unit/certificate-issuance.test.ts` covering all spec scenarios.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm test` (unit) — 81 tests pass (14 new)
- [ ] `npx eslint src/api/lambda/certificate-verify.ts src/api/lambda/certificate-issuance.ts tests/unit/certificate-issuance.test.ts` — zero errors
- [ ] Smoke: deploy shadow stack, complete all module tasks, verify `cert_id` in quiz-submit response
- [ ] Smoke: `GET /shadow/certificate/<certId>` returns 200 with correct non-PII payload
- [ ] Smoke: re-completing a module returns the same `cert_id` (idempotency)
- [ ] Smoke: complete all modules in a course, verify a course cert is issued
- [ ] Smoke: `GET /shadow/certificate/<unknown-uuid>` returns 404
- [ ] Smoke: `GET /shadow/certificate/<uuid>` from non-shadow stage returns 403
- [ ] UI: visit `/learn-shadow/my-learning` — completed modules show 🎓 badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)