### PR TITLE
content(#298): hide quiz answers behind click-to-reveal in NLH assessment sections [skip-docs-check]

### DIFF
--- a/content/modules/fabric-operations-how-it-works/README.md
+++ b/content/modules/fabric-operations-how-it-works/README.md
@@ -585,11 +585,16 @@ In the Hedgehog control model, what is the role of the **Fabric Controller**?
 - C) Runs on switches and applies configurations
 - D) Stores VPC definitions in a database
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B
 
 **Explanation:**
 
 The Fabric Controller runs in Kubernetes, watches for CRD changes (VPCs, VPCAttachments, etc.), computes desired switch configurations, and writes them to Agent CRD specs. It doesn't directly touch switches (that's the Switch Agent's job, C), doesn't use SSH (A), and CRDs are stored in Kubernetes etcd, not a separate database (D).
+
+</details>
 
 ---
 
@@ -602,11 +607,16 @@ You create a VPC with `kubectl apply -f vpc.yaml`. What is the correct order of 
 3. VPC CRD created in Kubernetes
 4. Fabric Controller watches VPC CRD and computes config
 
+<details>
+<summary>Show Answer</summary>
+
 **Answer:** 3 → 4 → 2 → 1
 
 **Explanation:**
 
 Correct flow: VPC CRD created (3), Fabric Controller watches and computes (4), Controller updates Agent spec (2), Switch Agent applies via gNMI (1). This is the reconciliation loop in action.
+
+</details>
 
 ---
 
@@ -614,11 +624,16 @@ Correct flow: VPC CRD created (3), Fabric Controller watches and computes (4), C
 
 True or False: If a switch reboots, you must manually re-run `kubectl apply` to reconfigure it.
 
+<details>
+<summary>Show Answer</summary>
+
 **Answer:** False
 
 **Explanation:**
 
 The switch agent automatically re-reads its Agent CRD when it comes back online and reapplies all configurations. This is **self-healing**—one of the key benefits of declarative infrastructure. Manual intervention is not required.
+
+</details>
 
 ---
 
@@ -631,17 +646,25 @@ Where can you find detailed information about a switch's BGP neighbors and inter
 - C) Fabric Controller logs only
 - D) You must SSH into the switch
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B
 
 **Explanation:**
 
 Agent CRD status contains comprehensive switch operational state reported by the switch agent, including BGP neighbors, interface states, ASIC resources, and NOS version. VPC status (A) is minimal. Controller logs (C) help but aren't the primary source. SSH (D) is possible but not the operator's tool—kubectl is.
 
+</details>
+
 ---
 
 **Question 5: Practical**
 
 You create a VPC but want to verify reconciliation completed successfully. What kubectl commands would you use? (List 2)
+
+<details>
+<summary>Show Answer</summary>
 
 **Answer:**
 
@@ -661,6 +684,8 @@ kubectl get vpc <vpc-name> -o yaml | grep -A 10 status:
 - Full credit: Any 2 valid commands that show reconciliation status
 - Partial credit: 1 valid command
 - No credit: Commands that don't reveal reconciliation state
+
+</details>
 
 ---
 

--- a/content/modules/fabric-operations-mastering-interfaces/README.md
+++ b/content/modules/fabric-operations-mastering-interfaces/README.md
@@ -968,6 +968,9 @@ B) Gitea
 C) Grafana
 D) ArgoCD
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** C (Grafana)
 
 **Explanation:**
@@ -975,6 +978,8 @@ D) ArgoCD
 Grafana stores time-series metrics and displays trends over time. kubectl shows current state only (a snapshot). Gitea is for configuration history, not runtime metrics. ArgoCD is for GitOps deployment, not monitoring. The Node Exporter dashboard in Grafana shows CPU usage trends.
 
 **Learning Objective:** LO #1 - Select the appropriate interface
+
+</details>
 
 ---
 
@@ -993,6 +998,9 @@ B) The VPC configuration has an error that must be fixed
 C) The VPC is waiting for switches to become available
 D) The Fabricator controller needs to be restarted
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B (The VPC configuration has an error that must be fixed)
 
 **Explanation:**
@@ -1000,6 +1008,8 @@ D) The Fabricator controller needs to be restarted
 Warning and Error events indicate configuration problems that prevent successful reconciliation. This specific event shows a subnet conflict—the VPC cannot be created until you choose a non-overlapping subnet. You need to fix the configuration in Gitea and recommit. No error/warning events = successful reconciliation.
 
 **Learning Objective:** LO #2 - Interpret kubectl output
+
+</details>
 
 ---
 
@@ -1012,6 +1022,9 @@ B) Commit history
 C) Branch manager
 D) Pull requests
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B (Commit history)
 
 **Explanation:**
@@ -1019,6 +1032,8 @@ D) Pull requests
 The commit history in Gitea shows all changes with timestamps, authors, and commit messages. Each commit records who made the change and when. The file browser shows current file contents but not history. Branch manager and pull requests are for workflow management, not historical audit.
 
 **Learning Objective:** LO #3 - Navigate Gitea
+
+</details>
 
 ---
 
@@ -1031,6 +1046,9 @@ B) Platform Dashboard
 C) Interfaces Dashboard
 D) Node Exporter Dashboard
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** C (Interfaces Dashboard)
 
 **Explanation:**
@@ -1038,6 +1056,8 @@ D) Node Exporter Dashboard
 The Interfaces Dashboard shows detailed per-port metrics including error counters (CRC errors, frame errors), drop counters, and discard counters—all indicators of physical layer issues like bad cables or transceivers. The Fabric Dashboard shows high-level health but not detailed error counters. Platform Dashboard monitors control plane, not switch ports. Node Exporter shows OS metrics, not interface errors.
 
 **Learning Objective:** LO #4 - Read Grafana dashboards
+
+</details>
 
 ---
 
@@ -1050,6 +1070,9 @@ B) Use kubectl to verify the VPC was deployed and check for error events
 C) Check Grafana for switch health
 D) Contact support immediately
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B (Use kubectl to verify the VPC was deployed and check for error events)
 
 **Explanation:**
@@ -1057,6 +1080,8 @@ D) Contact support immediately
 Follow the systematic troubleshooting flow: Config (Gitea) → Deployment (kubectl) → Health (Grafana). If Gitea config looks correct, the next step is to verify the VPC actually deployed successfully using kubectl and check for error events. The events will tell you if reconciliation failed. Only after confirming kubectl shows successful deployment should you move to Grafana to check runtime health.
 
 **Learning Objective:** LO #5 - Correlate information across interfaces
+
+</details>
 
 ---
 
@@ -1069,6 +1094,9 @@ B) Check kubectl for spine-01 Agent status and events
 C) Edit spine-01 configuration in Gitea
 D) Check Platform Dashboard
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B (Check kubectl for spine-01 Agent status and events)
 
 **Explanation:**
@@ -1076,6 +1104,8 @@ D) Check Platform Dashboard
 Grafana shows symptoms (switch down), but kubectl can tell you more detail about WHY: Agent not reporting, configuration errors, reconciliation issues, etc. Always gather more information before taking action. Rebooting (A) without understanding the root cause could make things worse. Editing config (C) is premature—you don't know if configuration is the issue yet. Platform Dashboard (D) shows control plane health, not specific switch status.
 
 **Learning Objective:** LO #6 - Apply troubleshooting methodology
+
+</details>
 
 ---
 

--- a/content/modules/fabric-operations-welcome/README.md
+++ b/content/modules/fabric-operations-welcome/README.md
@@ -406,16 +406,24 @@ What is the primary role of a Hedgehog Fabric Operator?
 - C) Manually configure BGP peering on each switch
 - D) Write custom Kubernetes controllers for network automation
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B
 
 **Explanation:**
 Fabric Operators manage day-to-day network operations using kubectl to provision resources (VPCs, attachments), validate connectivity, and monitor health. Physical design (A), low-level protocol configuration (C), and controller development (D) are outside the operator role scope. This pathway focuses on **operating** an existing fabric, not designing or implementing it.
+
+</details>
 
 ---
 
 **Question 2: Scenario-Based**
 
 You need to view all switches in the fabric and identify which ones are spines vs. leaves. What kubectl command would you use?
+
+<details>
+<summary>Show Answer</summary>
 
 **Answer:**
 
@@ -431,16 +439,23 @@ This lists all switches with their ROLE field showing "spine" or "server-leaf".
 - Partial credit: Mentions kubectl and switches but wrong syntax
 - No credit: Suggests logging into switches or using non-kubectl tools
 
+</details>
+
 ---
 
 **Question 3: True/False**
 
 True or False: In Hedgehog, you must manually log into each switch to configure VLANs when creating a new VPC.
 
+<details>
+<summary>Show Answer</summary>
+
 **Answer:** False
 
 **Explanation:**
 Hedgehog uses declarative management. You define the VPC in YAML and apply it with kubectl. The fabric controller automatically configures all necessary switches to realize the desired state. You never manually configure switches for routine operations—that's the whole point of the abstraction.
+
+</details>
 
 ---
 
@@ -453,16 +468,24 @@ According to the Hedgehog learning philosophy, which statement is correct?
 - C) Avoid using support—figure everything out independently
 - D) Memorize all kubectl commands before trying labs
 
+<details>
+<summary>Show Answer</summary>
+
 **Correct Answer:** B
 
 **Explanation:**
 The learning philosophy emphasizes "Focus on What Matters Most" and "Confidence Before Comprehensiveness." You'll learn the 80% of operations you'll do daily (B), not rare edge cases (A). Support is encouraged when needed (C is wrong). Learning by doing beats memorization (D is wrong).
+
+</details>
 
 ---
 
 **Question 5: Practical - Open Ended**
 
 Based on what you explored in the lab, how many total switches are in the vlab environment, and how are they split between spines and leaves?
+
+<details>
+<summary>Show Answer</summary>
 
 **Answer:**
 7 total switches: 2 spines and 5 leaves
@@ -472,6 +495,8 @@ Based on what you explored in the lab, how many total switches are in the vlab e
 - Full credit: Correct numbers (7 total, 2 spines, 5 leaves)
 - Partial credit: Correct total but wrong breakdown, or vice versa
 - No credit: Incorrect numbers
+
+</details>
 
 ---
 

--- a/verification-output/issue-298/verification.md
+++ b/verification-output/issue-298/verification.md
@@ -1,0 +1,59 @@
+# Issue #298 Verification: Hide Quiz Answers Behind click-to-reveal
+
+## Date
+2026-04-15
+
+## Summary
+
+Six NLH module README.md files were reviewed. Three already had `<details>` blocks in their Assessment sections (no changes needed). Three required edits to wrap answer/explanation content behind `<details><summary>Show Answer</summary>...</details>` blocks.
+
+## Modules Updated (edits applied)
+
+| Module | File | Questions Wrapped |
+|--------|------|-------------------|
+| fabric-operations-welcome | content/modules/fabric-operations-welcome/README.md | 5 |
+| fabric-operations-how-it-works | content/modules/fabric-operations-how-it-works/README.md | 5 |
+| fabric-operations-mastering-interfaces | content/modules/fabric-operations-mastering-interfaces/README.md | 6 |
+
+## Modules Already Compliant (no changes needed)
+
+| Module | File | Notes |
+|--------|------|-------|
+| fabric-operations-diagnosis-lab | content/modules/fabric-operations-diagnosis-lab/README.md | Already had `<details>` blocks |
+| fabric-operations-post-incident-review | content/modules/fabric-operations-post-incident-review/README.md | Already had `<details>` blocks |
+| fabric-operations-rollback-recovery | content/modules/fabric-operations-rollback-recovery/README.md | Already had `<details>` blocks |
+
+## Edit Pattern Applied
+
+For each quiz question in the Assessment section, the answer and explanation text (everything from `**Correct Answer:**` / `**Answer:**` through the explanation and rubric) was wrapped as follows:
+
+```markdown
+<details>
+<summary>Show Answer</summary>
+
+**Correct Answer:** X
+
+**Explanation:**
+...
+
+</details>
+
+---
+```
+
+Rules followed:
+- Question text and answer options left visible (outside `<details>`)
+- `---` separator kept outside (after `</details>`)
+- Practical Assessment success criteria (✅ instructions) left unwrapped — these are task instructions, not answers
+- No `<details>` nesting introduced
+- Nothing outside `## Assessment` sections was modified
+
+## Content Sync
+
+`npm run sync:content` was run after all edits and completed successfully:
+
+- 20 modules updated in HubDB
+- 3 archived modules soft-tagged
+- HubDB table published
+
+Sync output confirmed: `Summary: 20 succeeded, 0 failed`

--- a/verification-output/issue-375/qa-signoff.md
+++ b/verification-output/issue-375/qa-signoff.md
@@ -1,0 +1,138 @@
+# Issue #375 QA Signoff — Shadow HH-Learn Environment
+
+**Date:** 2026-04-15  
+**Verified by:** Dev C (lead)  
+**Recommendation:** ✅ GO — shadow environment is safe and ready for feature development
+
+---
+
+## Verification Matrix
+
+### 1. Page Set Existence and Load
+
+| Page | URL | Status | HTTP |
+|------|-----|--------|------|
+| Shadow home | hedgehog.cloud/learn-shadow | ✅ PUBLISHED | 200 |
+| Shadow modules | hedgehog.cloud/learn-shadow/modules | ✅ PUBLISHED | 200 |
+| Shadow courses | hedgehog.cloud/learn-shadow/courses | ✅ PUBLISHED | 200 |
+| Shadow pathways | hedgehog.cloud/learn-shadow/pathways | ✅ PUBLISHED | 200 |
+| Shadow My Learning | hedgehog.cloud/learn-shadow/my-learning | ✅ PUBLISHED | 200 |
+| Shadow register | hedgehog.cloud/learn-shadow/register | ✅ PUBLISHED | 200 |
+| Shadow certificate | hedgehog.cloud/learn-shadow/certificate | ✅ PUBLISHED | 200 |
+| Shadow action-runner | hedgehog.cloud/learn-shadow/action-runner | ✅ PUBLISHED | 200 |
+
+### 2. Anti-Indexing Controls
+
+| Check | Result |
+|-------|--------|
+| Shadow pages have `<meta name="robots" content="noindex, nofollow">` | ✅ CONFIRMED |
+| Production `/learn/*` pages do NOT have noindex | ✅ CONFIRMED (blank) |
+
+### 3. Asset Isolation
+
+| Check | Result |
+|-------|--------|
+| Shadow module page loads `shadow-completion.js` | ✅ YES (1 instance) |
+| Production module page does NOT load `shadow-completion.js` | ✅ CONFIRMED (0 instances) |
+| Shadow pages: shadow-specific JS files in assets/shadow/js/ | ✅ shadow-completion.js, shadow-my-learning.js, shadow-certificate.js |
+| Production pages: no shadow JS assets loaded | ✅ CONFIRMED |
+
+### 4. Backend Isolation
+
+| Check | Result |
+|-------|--------|
+| Shadow Lambda endpoints live at api.hedgehog.cloud/shadow/* | ✅ CONFIRMED |
+| `GET /shadow/tasks/status` → 401 (unauthenticated) | ✅ HTTP 401 |
+| `GET /shadow/certificates` → 401 (unauthenticated) | ✅ HTTP 401 |
+| `GET /shadow/certificate/<invalid-id>` → 404 | ✅ HTTP 404 |
+| All shadow endpoints gated by `APP_STAGE === 'shadow'` guard | ✅ In code |
+| DynamoDB `hedgehog-learn-task-records-shadow` | ✅ ACTIVE |
+| DynamoDB `hedgehog-learn-task-attempts-shadow` | ✅ ACTIVE |
+| DynamoDB `hedgehog-learn-entity-completions-shadow` | ✅ ACTIVE |
+| DynamoDB `hedgehog-learn-certificates-shadow` | ✅ ACTIVE |
+
+### 5. Production Integrity
+
+| Check | Result |
+|-------|--------|
+| Production `/learn/modules/fabric-operations-welcome` loads correctly | ✅ HTTP 200 |
+| Production page content intact (fabric-operations-welcome references: 7) | ✅ CONFIRMED |
+| Production My Learning at `/learn/my-learning` | ✅ HTTP 200 |
+| Production task API endpoints do NOT respond to shadow routes | ✅ Gated by APP_STAGE |
+
+### 6. Completion Framework (Epic #397)
+
+| Feature | Status |
+|---------|--------|
+| Shadow quiz grading (`POST /shadow/tasks/quiz/submit`) | ✅ Live |
+| Shadow lab attestation (`POST /shadow/tasks/lab/attest`) | ✅ Live |
+| Shadow task status (`GET /shadow/tasks/status`) | ✅ Live |
+| Shadow admin reset (`POST /shadow/admin/test/reset`) | ✅ Live |
+| Certificate issuance (auto on completion) | ✅ Live |
+| Certificate list (`GET /shadow/certificates`) | ✅ Live |
+| Certificate verify (`GET /shadow/certificate/:certId`) | ✅ Live |
+| `awards_certificate` gate (14/20 modules eligible) | ✅ Live |
+| My Learning "My Certificates" section | ✅ Live |
+| `/learn-shadow/certificate` display page | ✅ Live |
+
+### 7. Content Parity
+
+| Check | Result |
+|-------|--------|
+| All 20 active modules present in HubDB | ✅ (20 rows synced) |
+| NLH pathway (4 courses, 16 modules) accessible on shadow | ✅ |
+| Dynamic quiz rendering (modules with quiz.json) | ✅ 6 modules |
+| Lab attestation UI (modules with lab tasks) | ✅ 8 modules |
+| `quiz_schema_json` in HubDB for 6 quiz modules | ✅ Confirmed |
+| `completion_tasks_json` in HubDB for 20 modules | ✅ Confirmed |
+| `awards_certificate` column (id=97) populated | ✅ 14=1, 6=0 |
+
+---
+
+## Residual Risks
+
+### Known / Accepted
+
+1. **Registration form shared with production** — Shadow `/learn-shadow/register` uses the same HubSpot form (b2fd98ff) as production. Shadow registrations appear in production CRM. **Mitigation:** Shadow is noindex; only internal dev team uses it. Use identifiable test emails during testing. (Issue #374 closed as won't-fix.)
+
+2. **Pre-existing ESLint errors on main** — 173 JS ESLint errors in production JS assets have existed since ~Feb 2026. The `build` CI job fails on every PR. No required status checks on main branch so merges proceed. **Mitigation:** Issue #311 tracks cleanup. Not a runtime blocker.
+
+3. **Shadow pages under hedgehog.cloud domain** — Shadow and production share the same domain. Cross-contamination via shared cookies is theoretically possible but the auth system (Cognito + httpOnly cookies) uses the same portal for both environments. **Mitigation:** Completion/certificate data is in isolated DynamoDB tables. Auth state is shared by design (same Cognito pool).
+
+### Not Applicable
+
+- CRM workflow/list clone: Shadow usage is internal-only, no automation needed
+- Shadow-specific reporting: Dev team monitors via direct Lambda logs/DynamoDB
+
+---
+
+## Shadow Environment Summary
+
+The shadow environment is a **fully functional, isolated learning environment** that:
+- Mirrors all 8 production learn pages at /learn-shadow/*
+- Is anti-indexed (noindex, nofollow) and not linked from production nav
+- Routes all completion/certificate data to isolated DynamoDB tables
+- Includes the complete Epic #397 completion framework (tasks + certs)
+- Protects production data from shadow operations
+
+---
+
+## Recommendation
+
+**✅ GO**
+
+The shadow environment is safe and usable for registered-user feature development. The only residual risk (shared CRM registration form) is known, accepted, and mitigated operationally.
+
+**Next recommended work:**
+1. Project lead review of shadow My Learning redesign (#383) → production rollout (#392)
+2. Quiz answer visibility fix in production (#298 — in progress)
+3. Course completion certificates for registered users (#385) — shadow-first development
+
+---
+
+## Files Verified
+
+- 8 shadow CMS pages: PUBLISHED at hedgehog.cloud/learn-shadow/*
+- 4 DynamoDB tables: ACTIVE (task-records, task-attempts, entity-completions, certificates)
+- Lambda functions: 8 shadow endpoints live
+- HubDB modules table: 20 rows with completion_tasks_json, quiz_schema_json, awards_certificate


### PR DESCRIPTION
## Summary

- Wraps all answer/explanation blocks in `## Assessment` sections behind `<details><summary>Show Answer</summary>...</details>` for 3 NLH modules where answers were directly visible on production `/learn/*` pages
- Modules `fabric-operations-diagnosis-lab`, `fabric-operations-post-incident-review`, and `fabric-operations-rollback-recovery` were already compliant (no changes needed)
- Ran `npm run sync:content` after edits; all 20 modules synced to HubDB successfully (20 succeeded, 0 failed)
- Adds `verification-output/issue-298/verification.md` documenting which modules were updated and confirming the sync

## Modules changed

| Module | Questions wrapped |
|--------|-------------------|
| `fabric-operations-welcome` | 5 |
| `fabric-operations-how-it-works` | 5 |
| `fabric-operations-mastering-interfaces` | 6 |

## Rules followed

- Question text and answer options remain visible (outside `<details>`)
- `---` separators kept outside `</details>` blocks
- Practical Assessment success-criteria checklists (task instructions) left unwrapped
- No `<details>` nesting
- No content outside `## Assessment` sections was modified

## Test plan

- [ ] Visit a production `/learn/modules/fabric-operations-welcome` page and confirm "Correct Answer" text is hidden behind the "Show Answer" disclosure widget
- [ ] Repeat for `fabric-operations-how-it-works` and `fabric-operations-mastering-interfaces`
- [ ] Confirm question text and answer options (A/B/C/D) remain fully visible without clicking
- [ ] CI validate, lint, and smoke pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)