### PR TITLE
feat(templates): #434 #435 production completion JS and module template [skip-docs-check]

### DIFF
--- a/clean-x-hedgehog-templates/assets/js/production-completion.js
+++ b/clean-x-hedgehog-templates/assets/js/production-completion.js
@@ -1,0 +1,352 @@
+/**
+ * Production Completion Framework UI (Issue #434)
+ *
+ * Handles quiz + lab attestation UX for production module pages.
+ * Ported from shadow-completion.js; uses production API paths (no /shadow/ prefix).
+ *
+ * On page load:
+ *   - Reads module_slug from #hhl-module-context data attribute
+ *   - Calls GET /tasks/status to restore prior task state
+ * On quiz submit:
+ *   - Collects radio answers from server-rendered quiz form
+ *   - POSTs to /tasks/quiz/submit; shows pass/fail feedback
+ * On lab attest:
+ *   - POSTs to /tasks/lab/attest; replaces button with "Lab Completed" indicator
+ *
+ * When both tasks are done, shows a module-complete banner at top of page.
+ *
+ * Gracefully no-ops when #hhl-module-context is absent (i.e., on list pages).
+ *
+ * Auth: all API calls use credentials:'include' so the browser sends the
+ * hhl_access_token httpOnly cookie set at /auth/callback.
+ *
+ * @see Issue #434
+ * @see /tasks/quiz/submit, /tasks/lab/attest, /tasks/status
+ */
+(function () {
+  'use strict';
+
+  // Production task endpoints are served directly on the custom domain.
+  var API_BASE = 'https://api.hedgehog.cloud';
+  var LOGIN_URL = 'https://api.hedgehog.cloud/auth/login';
+
+  // ----------------------------------------------------------------
+  // Bootstrap: read module context
+  // ----------------------------------------------------------------
+
+  var ctxEl = document.getElementById('hhl-module-context');
+  if (!ctxEl) return; // Guard: not a production module detail page
+
+  var moduleSlug = ctxEl.getAttribute('data-module-slug');
+  if (!moduleSlug) return;
+
+  var quizSection = document.getElementById('hhl-quiz-section');
+  var labSection = document.getElementById('hhl-lab-section');
+
+  // Always hide legacy CTA buttons on production module detail pages.
+  var legacyComplete = document.getElementById('hhl-mark-complete');
+  if (legacyComplete) legacyComplete.style.display = 'none';
+  var legacyStarted = document.getElementById('hhl-mark-started');
+  if (legacyStarted) legacyStarted.style.display = 'none';
+
+  // No-task module: when neither quiz nor lab is present, replace the
+  // hidden legacy button area with a coherent neutral-state note.
+  if (!quizSection && !labSection) {
+    var ctaEl = document.querySelector('.module-progress-cta');
+    if (ctaEl) {
+      ctaEl.innerHTML = '<p id="hhl-no-task-note" style="' +
+        'color:#6B7280;font-size:0.9rem;font-style:italic;margin:0;">' +
+        'No required tasks \u2014 read through the content and use any knowledge checks below.' +
+        '</p>';
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Bind event handlers
+  // ----------------------------------------------------------------
+
+  if (quizSection) {
+    var submitBtn = document.getElementById('hhl-quiz-submit');
+    if (submitBtn) submitBtn.addEventListener('click', handleQuizSubmit);
+  }
+
+  if (labSection) {
+    var labBtn = document.getElementById('hhl-lab-attest-btn');
+    if (labBtn) labBtn.addEventListener('click', handleLabAttest);
+  }
+
+  // ----------------------------------------------------------------
+  // Restore task state on page load
+  // ----------------------------------------------------------------
+
+  restoreTaskState();
+
+  function restoreTaskState() {
+    fetch(API_BASE + '/tasks/status?module_slug=' + encodeURIComponent(moduleSlug), {
+      method: 'GET',
+      credentials: 'include',
+    })
+      .then(function (resp) {
+        if (resp.status === 401) return null; // Not signed in: show initial state silently
+        if (!resp.ok) return null;
+        return resp.json();
+      })
+      .then(function (data) {
+        if (!data) return;
+
+        if (data.module_status === 'complete') {
+          restoreAllDone(data.tasks || {});
+          showModuleComplete(data.cert_id || null);
+          return;
+        }
+
+        if (data.module_status === 'in_progress') {
+          var tasks = data.tasks || {};
+
+          var quizTask = tasks['quiz-1'];
+          if (quizTask) {
+            if (quizTask.status === 'passed') {
+              showQuizPassed(quizTask.score !== undefined ? quizTask.score + '%' : '');
+            } else if (quizTask.status === 'failed') {
+              showQuizFailed(
+                quizTask.score !== undefined ? quizTask.score + '%' : '',
+                quizTask.attempts
+              );
+            }
+          }
+
+          var labTask = tasks['lab-main'];
+          if (labTask && labTask.status === 'attested') {
+            showLabCompleted();
+          }
+        }
+        // not_started: keep initial server-rendered state
+      })
+      .catch(function () {
+        // Network error: keep initial state — fail open, don't block the page
+      });
+  }
+
+  function restoreAllDone(tasks) {
+    if (quizSection) {
+      var quizTask = tasks['quiz-1'] || {};
+      showQuizPassed(quizTask.score !== undefined ? quizTask.score + '%' : '');
+    }
+    if (labSection) {
+      showLabCompleted();
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Quiz submission
+  // ----------------------------------------------------------------
+
+  function handleQuizSubmit() {
+    var btn = document.getElementById('hhl-quiz-submit');
+    var answers = [];
+    var allAnswered = true;
+
+    var questions = document.querySelectorAll('#hhl-quiz-form .hhl-quiz-question');
+    questions.forEach(function (qEl) {
+      var qId = qEl.getAttribute('data-q-id');
+      var checked = qEl.querySelector('input[type="radio"]:checked');
+      if (checked) {
+        answers.push({ id: qId, value: checked.value });
+      } else {
+        allAnswered = false;
+      }
+    });
+
+    if (!allAnswered) {
+      showFeedback('hhl-quiz-feedback', 'Please answer all questions before submitting.', 'warning');
+      return;
+    }
+
+    var quizRef = quizSection
+      ? quizSection.getAttribute('data-quiz-ref') || 'quiz-1'
+      : 'quiz-1';
+
+    if (btn) btn.disabled = true;
+
+    fetch(API_BASE + '/tasks/quiz/submit', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        module_slug: moduleSlug,
+        quiz_ref: quizRef,
+        answers: answers,
+      }),
+    })
+      .then(function (resp) {
+        if (resp.status === 401) { showAuthPrompt(); return null; }
+        if (!resp.ok) {
+          showFeedback('hhl-quiz-feedback', 'Something went wrong. Your progress may not have been saved. Please try again.', 'fail');
+          if (btn) btn.disabled = false;
+          return null;
+        }
+        return resp.json();
+      })
+      .then(function (result) {
+        if (!result) return;
+        var score = result.score !== undefined ? result.score + '%' : '';
+        if (result.pass) {
+          showQuizPassed(score);
+          if (result.module_complete) showModuleComplete(result.cert_id || null);
+        } else {
+          showQuizFailed(score, result.attempts);
+          if (btn) btn.disabled = false;
+        }
+      })
+      .catch(function () {
+        showFeedback('hhl-quiz-feedback', 'Could not reach the server. Please check your connection.', 'fail');
+        if (btn) btn.disabled = false;
+      });
+  }
+
+  // ----------------------------------------------------------------
+  // Lab attestation
+  // ----------------------------------------------------------------
+
+  function handleLabAttest() {
+    var btn = document.getElementById('hhl-lab-attest-btn');
+    if (btn) btn.disabled = true;
+
+    fetch(API_BASE + '/tasks/lab/attest', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        module_slug: moduleSlug,
+        task_slug: 'lab-main',
+      }),
+    })
+      .then(function (resp) {
+        if (resp.status === 401) { showAuthPrompt(); return null; }
+        if (!resp.ok) {
+          showFeedback('hhl-lab-feedback', 'Something went wrong. Your progress may not have been saved. Please try again.', 'fail');
+          if (btn) btn.disabled = false;
+          return null;
+        }
+        return resp.json();
+      })
+      .then(function (result) {
+        if (!result) return;
+        showLabCompleted();
+        if (result.module_complete) showModuleComplete(result.cert_id || null);
+      })
+      .catch(function () {
+        showFeedback('hhl-lab-feedback', 'Could not reach the server. Please check your connection.', 'fail');
+        if (btn) btn.disabled = false;
+      });
+  }
+
+  // ----------------------------------------------------------------
+  // UI state helpers
+  // ----------------------------------------------------------------
+
+  function showQuizPassed(score) {
+    var form = document.getElementById('hhl-quiz-form');
+    var btn = document.getElementById('hhl-quiz-submit');
+    var feedback = document.getElementById('hhl-quiz-feedback');
+    if (form) form.style.display = 'none';
+    if (btn) btn.style.display = 'none';
+    if (feedback) {
+      feedback.style.display = '';
+      feedback.innerHTML =
+        '<div class="hhl-task-badge hhl-task-badge--pass">Quiz Passed \u2713' +
+        (score ? ' \u2014 Score: ' + score : '') +
+        '</div>';
+    }
+  }
+
+  function showQuizFailed(score, attempts) {
+    var btn = document.getElementById('hhl-quiz-submit');
+    var feedback = document.getElementById('hhl-quiz-feedback');
+    if (btn) btn.style.display = 'none';
+    if (feedback) {
+      feedback.style.display = '';
+      var att = attempts ? ' (Attempt ' + attempts + ')' : '';
+      feedback.innerHTML =
+        '<div class="hhl-task-badge hhl-task-badge--fail">Score: ' +
+        (score || '0%') + att +
+        ' \u2014 Need 75% to pass.</div>' +
+        '<button type="button" id="hhl-quiz-retake" class="hhl-retake-btn">Retake Quiz</button>';
+      var retakeBtn = document.getElementById('hhl-quiz-retake');
+      if (retakeBtn) {
+        retakeBtn.addEventListener('click', function () {
+          resetQuizForm();
+          if (btn) { btn.style.display = ''; btn.disabled = false; }
+          feedback.style.display = 'none';
+        });
+      }
+    }
+  }
+
+  function resetQuizForm() {
+    var form = document.getElementById('hhl-quiz-form');
+    if (form) {
+      form.style.display = '';
+      form.querySelectorAll('input[type="radio"]').forEach(function (r) {
+        r.checked = false;
+      });
+    }
+  }
+
+  function showLabCompleted() {
+    var btn = document.getElementById('hhl-lab-attest-btn');
+    var feedback = document.getElementById('hhl-lab-feedback');
+    if (btn) btn.style.display = 'none';
+    if (feedback) {
+      feedback.style.display = '';
+      feedback.innerHTML = '<div class="hhl-task-badge hhl-task-badge--pass">Lab Completed \u2713</div>';
+    }
+  }
+
+  function showModuleComplete(certId) {
+    if (document.getElementById('hhl-module-complete-banner')) return;
+    var banner = document.createElement('div');
+    banner.id = 'hhl-module-complete-banner';
+    banner.className = 'hhl-module-complete';
+    banner.setAttribute('role', 'status');
+    var certLink = '';
+    if (certId) {
+      certLink = ' \u2014 <a href="/learn/certificate?id=' +
+        encodeURIComponent(certId) +
+        '" class="hhl-cert-link" target="_blank" rel="noopener noreferrer">' +
+        '\uD83C\uDF93 View Certificate</a>';
+    }
+    banner.innerHTML = '<strong>Module Complete \u2713</strong> \u2014 All tasks finished.' + certLink;
+    var detail = document.querySelector('.module-detail');
+    if (detail) detail.insertBefore(banner, detail.firstChild);
+  }
+
+  function showAuthPrompt() {
+    var redirectUrl = encodeURIComponent(window.location.href);
+    showGlobalError(
+      'Please sign in to save your progress. <a href="' +
+        LOGIN_URL + '?redirect_url=' + redirectUrl +
+        '">Sign in</a>'
+    );
+  }
+
+  function showFeedback(elId, msg, type) {
+    var el = document.getElementById(elId);
+    if (el) {
+      el.style.display = '';
+      el.innerHTML = '<div class="hhl-task-badge hhl-task-badge--' + (type || 'warning') + '">' + msg + '</div>';
+    }
+  }
+
+  function showGlobalError(msg) {
+    var existing = document.getElementById('hhl-completion-error');
+    if (existing) { existing.innerHTML = msg; return; }
+    var el = document.createElement('div');
+    el.id = 'hhl-completion-error';
+    el.className = 'hhl-error-banner';
+    el.innerHTML = msg;
+    var detail = document.querySelector('.module-detail');
+    if (detail) detail.insertBefore(el, detail.firstChild);
+  }
+
+}());

--- a/clean-x-hedgehog-templates/learn/module-page.html
+++ b/clean-x-hedgehog-templates/learn/module-page.html
@@ -665,6 +665,121 @@
       line-height: 1.4;
     }
   }
+
+  /* ============================================================
+     Production Completion Framework — Quiz + Lab UI (Issue #434/#435)
+     ============================================================ */
+  .hhl-task-section {
+    margin: 32px 0;
+    padding: 24px;
+    background: #F9FAFB;
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+  }
+  .hhl-task-title {
+    margin: 0 0 16px 0;
+    font-size: 1.375rem;
+    color: #1a4e8a;
+  }
+  .hhl-quiz-question {
+    margin-bottom: 24px;
+  }
+  .hhl-quiz-stem {
+    margin: 0 0 8px 0;
+    line-height: 1.6;
+    color: #111827;
+  }
+  .hhl-quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-left: 8px;
+  }
+  .hhl-quiz-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    cursor: pointer;
+    padding: 10px 14px;
+    border: 1px solid #E5E7EB;
+    border-radius: 6px;
+    background: #fff;
+    transition: background 0.15s, border-color 0.15s;
+    font-size: 1rem;
+    font-weight: normal;
+  }
+  .hhl-quiz-option:hover {
+    background: #EFF6FF;
+    border-color: #1a4e8a;
+  }
+  .hhl-quiz-option input[type="radio"] {
+    flex-shrink: 0;
+    margin-top: 3px;
+    cursor: pointer;
+  }
+  .hhl-task-badge {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-weight: 600;
+    font-size: 0.9375rem;
+  }
+  .hhl-task-badge--pass {
+    background: #D1FAE5;
+    color: #065F46;
+    border: 1px solid #A7F3D0;
+  }
+  .hhl-task-badge--fail {
+    background: #FEE2E2;
+    color: #991B1B;
+    border: 1px solid #FECACA;
+  }
+  .hhl-task-badge--warning {
+    background: #FEF3C7;
+    color: #92400E;
+    border: 1px solid #FDE68A;
+  }
+  .hhl-retake-btn {
+    display: inline-block;
+    margin-top: 12px;
+    padding: 8px 18px;
+    background: #F3F4F6;
+    color: #1a4e8a;
+    border: 1px solid #E5E7EB;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    font-size: 0.9375rem;
+  }
+  .hhl-retake-btn:hover {
+    background: #EFF6FF;
+    border-color: #1a4e8a;
+  }
+  .hhl-module-complete {
+    margin: 16px 0 24px 0;
+    padding: 14px 20px;
+    background: #D1FAE5;
+    border: 1px solid #A7F3D0;
+    border-radius: 8px;
+    color: #065F46;
+    font-size: 1rem;
+    font-weight: 600;
+  }
+  .hhl-error-banner {
+    margin: 16px 0;
+    padding: 12px 16px;
+    background: #FEE2E2;
+    border: 1px solid #FECACA;
+    border-radius: 8px;
+    color: #991B1B;
+    font-size: 0.9375rem;
+  }
+  .hhl-error-banner a {
+    color: #991B1B;
+    font-weight: 600;
+    text-decoration: underline;
+  }
 </style>
 
 <main id="main-content">
@@ -741,6 +856,7 @@
             <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/course-navigation.js') }}"></script>
             <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/progress.js') }}"></script>
             <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/pageview.js') }}"></script>
+            <script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/production-completion.js') }}"></script>
           </header>
 
           {% set module_media = [] %}
@@ -985,6 +1101,67 @@
               <p><em>Module content coming soon.</em></p>
             {% endif %}
           </div>
+
+          {# ============================================================
+             Production Completion Framework — Quiz + Lab UI (Issue #434/#435)
+             Hidden context div passes module_slug to production-completion.js.
+             Quiz and lab sections are rendered here (after full content),
+             conditional on HubDB fields quiz_schema_json and completion_tasks_json.
+             production-completion.js handles submission, result display, and state
+             restoration via GET /tasks/status. Correct answers are never written to HTML.
+             ============================================================ #}
+
+          {# Hidden context div: passes module_slug to production-completion.js #}
+          <div id="hhl-module-context"
+               data-module-slug="{{ dynamic_page_hubdb_row.hs_path }}"
+               style="display:none"></div>
+
+          {# Quiz Section — quiz_schema_json is populated iff the module has a quiz.
+             HubL outputs only stems + options; correct_answer field is never written to HTML. #}
+          {% if dynamic_page_hubdb_row.quiz_schema_json %}
+            {% set quiz_schema = dynamic_page_hubdb_row.quiz_schema_json|fromjson %}
+            {% if quiz_schema and quiz_schema.questions %}
+              <section id="hhl-quiz-section" class="hhl-task-section"
+                       aria-label="Module Assessment"
+                       data-quiz-ref="{{ quiz_schema.quiz_id|default('quiz-1') }}">
+                <h2 class="hhl-task-title">Module Assessment</h2>
+                <div id="hhl-quiz-form">
+                  {% for question in quiz_schema.questions %}
+                    <div class="hhl-quiz-question" data-q-id="{{ question.id }}">
+                      <p class="hhl-quiz-stem"><strong>{{ loop.index }}. {{ question.stem }}</strong></p>
+                      <div class="hhl-quiz-options" role="radiogroup" aria-label="{{ question.stem }}">
+                        {% for option in question.options %}
+                          <label class="hhl-quiz-option" for="q-{{ question.id }}-{{ option.id }}">
+                            <input type="radio" id="q-{{ question.id }}-{{ option.id }}"
+                                   name="{{ question.id }}" value="{{ option.id }}">
+                            <span>{{ option.text }}</span>
+                          </label>
+                        {% endfor %}
+                      </div>
+                    </div>
+                  {% endfor %}
+                </div>
+                <div id="hhl-quiz-feedback" style="display:none" aria-live="polite"></div>
+                <button type="button" id="hhl-quiz-submit" class="pathways-cta-button" style="margin-top:16px;">
+                  Submit Quiz
+                </button>
+              </section>
+            {% endif %}
+          {% endif %}
+
+          {# Lab Attestation Section #}
+          {% if dynamic_page_hubdb_row.completion_tasks_json and 'lab_attestation' in dynamic_page_hubdb_row.completion_tasks_json %}
+            <section id="hhl-lab-section" class="hhl-task-section"
+                     aria-label="Hands-On Lab Attestation">
+              <h2 class="hhl-task-title">Hands-On Lab</h2>
+              <p>Complete the hands-on lab activities above, then click below to mark the lab as complete.</p>
+              <div id="hhl-lab-feedback" style="display:none" aria-live="polite"></div>
+              <button type="button" id="hhl-lab-attest-btn" class="pathways-cta-button" style="margin-top:8px;">
+                Mark Lab Complete
+              </button>
+            </section>
+          {% endif %}
+
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Covers A4 (#434) and A5 (#435) from the Production Completion Framework roadmap.

### A4 — production-completion.js
- New file: `assets/js/production-completion.js`
- Ported from `shadow-completion.js`; API calls target `api.hedgehog.cloud` directly (no `/shadow/` prefix)
- Context element ID: `#hhl-module-context` (production) vs `#hhl-shadow-module-context` (shadow)
- Certificate link URL: `/learn/certificate?id=` (production) vs `/learn-shadow/certificate?id=` (shadow)
- **Already published** to HubSpot: `CLEAN x HEDGEHOG/templates/assets/js/production-completion.js`

### A5 — Production module template (learn/module-page.html)
- Added completion framework CSS (task sections, quiz options, pass/fail badges, module-complete banner)
- Loads `production-completion.js` in `<header>` (deferred)
- Hidden `#hhl-module-context` div with `data-module-slug` for JS bootstrap
- Quiz section: conditional on `quiz_schema_json` — renders question stems + options; **correct answers never written to HTML**
- Lab attestation section: conditional on `'lab_attestation' in completion_tasks_json`
- Legacy `hhl-mark-started` and `hhl-mark-complete` buttons hidden by `production-completion.js` on load

## Dependencies
Requires PR #438 (merged) — production Lambda endpoints must return 401 not 403.

## Test plan
- [ ] CI passes (build failure is pre-existing ESLint — not a blocker)
- [ ] Validate-templates check passes (production-completion.js published to HubSpot before PR)
- [ ] Production module page with quiz_schema_json renders quiz UI for logged-in users
- [ ] Production module page with lab_attestation renders lab button for logged-in users
- [ ] No task modules show "No required tasks" note (legacy buttons hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)