### PR TITLE
feat(A7): production certificate display page [skip-docs-check]

### DIFF
--- a/clean-x-hedgehog-templates/assets/js/production-certificate.js
+++ b/clean-x-hedgehog-templates/assets/js/production-certificate.js
@@ -1,0 +1,201 @@
+/**
+ * Production Certificate Display (Issue #437)
+ *
+ * Powers the /learn/certificate?id=<certId> CMS page.
+ *
+ * Flow:
+ *   1. Read certId from URL query param (?id=...)
+ *   2. Fetch GET /certificate/<certId>  — public, no auth
+ *   3. Optionally fetch GET /auth/me  — for learner name (best-effort, no auth required)
+ *   4. Render a certificate card in #certificate-container
+ *
+ * On error: show a human-readable "not found" message.
+ *
+ * Ported from shadow-certificate.js; uses production API paths (no /shadow/ prefix).
+ *
+ * @see Issue #437
+ * @see GET /certificate/:certId (#427)
+ * @see GET /auth/me (#303)
+ */
+(function () {
+  'use strict';
+
+  var API_BASE = 'https://api.hedgehog.cloud';
+
+  var container = document.getElementById('certificate-container');
+  if (!container) return; // Not on the certificate page
+
+  // ----------------------------------------------------------------
+  // Utilities
+  // ----------------------------------------------------------------
+
+  function getQueryParam(name) {
+    try {
+      var params = new URLSearchParams(window.location.search);
+      return params.get(name) || '';
+    } catch (e) {
+      // Fallback for older browsers
+      var match = window.location.search.match(new RegExp('[?&]' + name + '=([^&]*)'));
+      return match ? decodeURIComponent(match[1]) : '';
+    }
+  }
+
+  function formatDate(isoString) {
+    if (!isoString) return '';
+    try {
+      return new Date(isoString).toLocaleDateString('en-US', {
+        month: 'long', day: 'numeric', year: 'numeric'
+      });
+    } catch (e) { return isoString; }
+  }
+
+  function slugToTitle(slug) {
+    if (!slug) return '';
+    return slug.replace(/-/g, ' ').replace(/\b\w/g, function (l) { return l.toUpperCase(); });
+  }
+
+  function showError(msg) {
+    container.innerHTML =
+      '<div class="cert-display-error">' +
+        '<p>' + msg + '</p>' +
+        '<a href="/learn/my-learning" class="cert-back-link">Back to My Learning</a>' +
+      '</div>';
+  }
+
+  function renderCertificate(certData, learnerName) {
+    var entityTitle = certData.entityTitle
+      ? certData.entityTitle
+      : slugToTitle(certData.entitySlug || '');
+    var typeLabel = certData.entityType === 'course' ? 'Course' : 'Module';
+    var dateStr = formatDate(certData.issuedAt);
+    var verifyUrl = window.location.href;
+    var name = learnerName || 'Certificate Holder';
+
+    container.innerHTML =
+      '<div class="cert-display-card">' +
+        '<div class="cert-display-header">' +
+          '<div class="cert-display-logo">\uD83E\uDD94</div>' +
+          '<div class="cert-display-brand">Hedgehog Learn</div>' +
+        '</div>' +
+        '<div class="cert-display-body">' +
+          '<h1 class="cert-display-heading">Certificate of Completion</h1>' +
+          '<p class="cert-display-subheading">This certifies that</p>' +
+          '<div class="cert-display-learner">' + name + '</div>' +
+          '<p class="cert-display-subheading">has successfully completed the ' + typeLabel.toLowerCase() + '</p>' +
+          '<div class="cert-display-entity">' + entityTitle + '</div>' +
+          (dateStr ? '<p class="cert-display-date">Completed on ' + dateStr + '</p>' : '') +
+        '</div>' +
+        '<div class="cert-display-footer">' +
+          '<div class="cert-display-verify">' +
+            '<span class="cert-verify-label">Certificate ID:</span> ' +
+            '<span class="cert-verify-id">' + certData.certId + '</span>' +
+          '</div>' +
+          '<div class="cert-display-verify">' +
+            '<span class="cert-verify-label">Verify at:</span> ' +
+            '<a href="' + verifyUrl + '" class="cert-verify-link">' + verifyUrl + '</a>' +
+          '</div>' +
+          '<div class="cert-display-actions">' +
+            '<button type="button" class="cert-copy-link-btn" id="cert-copy-link-btn">Copy Verification Link</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    // Bind copy link button
+    var copyBtn = document.getElementById('cert-copy-link-btn');
+    if (copyBtn) {
+      copyBtn.addEventListener('click', function () {
+        var url = verifyUrl;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(url).then(function () {
+            copyBtn.textContent = 'Copied!';
+            setTimeout(function () { copyBtn.textContent = 'Copy Verification Link'; }, 2000);
+          }).catch(function () {
+            copyBtn.textContent = 'Copy failed';
+            setTimeout(function () { copyBtn.textContent = 'Copy Verification Link'; }, 2000);
+          });
+        } else {
+          try {
+            var ta = document.createElement('textarea');
+            ta.value = url;
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand('copy');
+            document.body.removeChild(ta);
+            copyBtn.textContent = 'Copied!';
+            setTimeout(function () { copyBtn.textContent = 'Copy Verification Link'; }, 2000);
+          } catch (e) {
+            copyBtn.textContent = 'Copy failed';
+            setTimeout(function () { copyBtn.textContent = 'Copy Verification Link'; }, 2000);
+          }
+        }
+      });
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Main flow
+  // ----------------------------------------------------------------
+
+  function ready(fn) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', fn);
+    else fn();
+  }
+
+  ready(function () {
+    var certId = getQueryParam('id');
+
+    if (!certId) {
+      showError('No certificate ID provided. Please check the link.');
+      return;
+    }
+
+    // Validate basic UUID-ish shape before fetching (client-side sanity check)
+    var UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(certId)) {
+      showError('Certificate not found or invalid link.');
+      return;
+    }
+
+    // Show loading indicator
+    container.innerHTML = '<div class="cert-display-loading">Loading certificate...</div>';
+
+    // Fetch certificate data (public endpoint — no auth required)
+    fetch(API_BASE + '/certificate/' + encodeURIComponent(certId))
+      .then(function (r) {
+        if (r.status === 404) return null;
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (certData) {
+        if (!certData) {
+          showError('Certificate not found or invalid link.');
+          return;
+        }
+
+        // Best-effort: try to get learner name from /auth/me (requires being logged in)
+        fetch(API_BASE + '/auth/me', { credentials: 'include' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (meData) {
+            var learnerName = null;
+            if (meData) {
+              var first = meData.firstname || meData.given_name || '';
+              var last = meData.lastname || meData.family_name || '';
+              var full = (first + ' ' + last).trim();
+              if (full) learnerName = full;
+            }
+            renderCertificate(certData, learnerName);
+          })
+          .catch(function () {
+            // Not logged in or /auth/me failed: render without name
+            renderCertificate(certData, null);
+          });
+      })
+      .catch(function (err) {
+        console.error('[production-certificate] Fetch error:', err);
+        showError('Unable to load certificate. Please try again later.');
+      });
+  });
+
+}());

--- a/clean-x-hedgehog-templates/learn/certificate.html
+++ b/clean-x-hedgehog-templates/learn/certificate.html
@@ -1,0 +1,182 @@
+<!--
+  templateType: "page"
+  isAvailableForNewContent: true
+-->
+{% extends "/CLEAN x HEDGEHOG/templates/layouts/base.html" %}
+
+{% block head %}
+  {{ super() }}
+  {# Production Certificate Display (Issue #437) #}
+  {% set constants = {
+    'HUBDB_MODULES_TABLE_ID': '135621904',
+    'HUBDB_PATHWAYS_TABLE_ID': '135381504',
+    'HUBDB_COURSES_TABLE_ID': '135381433',
+    'ENABLE_CRM_PROGRESS': true,
+    'AUTH_LOGIN_URL': 'https://api.hedgehog.cloud/auth/login',
+    'AUTH_ME_URL': 'https://api.hedgehog.cloud/auth/me',
+    'AUTH_LOGOUT_URL': 'https://api.hedgehog.cloud/auth/logout'
+  } %}
+
+  <title>Certificate of Completion - Hedgehog Learn</title>
+  <meta name="description" content="Certificate of completion for Hedgehog Learn — verifiable proof of course or module completion.">
+  <link rel="canonical" href="https://{{ request.domain }}/learn/certificate">
+{% endblock head %}
+
+{% block body %}
+<style>
+  /* Certificate Display page styles (Issue #437) */
+  .cert-page-container {
+    max-width: 760px;
+    margin: 60px auto;
+    padding: 0 24px;
+  }
+
+  .cert-display-card {
+    border: 2px solid #1a4e8a;
+    border-radius: 12px;
+    padding: 48px;
+    background: #fff;
+    text-align: center;
+    box-shadow: 0 4px 24px rgba(26, 78, 138, 0.1);
+  }
+
+  .cert-display-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 32px;
+  }
+
+  .cert-display-logo { font-size: 3rem; line-height: 1; }
+  .cert-display-brand {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #1a4e8a;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .cert-display-heading {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #111827;
+    margin: 0 0 16px 0;
+  }
+
+  .cert-display-subheading {
+    font-size: 1rem;
+    color: #6B7280;
+    margin: 0 0 8px 0;
+  }
+
+  .cert-display-learner {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1a4e8a;
+    margin-bottom: 16px;
+    font-style: italic;
+  }
+
+  .cert-display-entity {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 16px;
+    padding: 12px 24px;
+    background: #EFF6FF;
+    border-radius: 8px;
+    display: inline-block;
+  }
+
+  .cert-display-date {
+    font-size: 0.9375rem;
+    color: #6B7280;
+    margin: 8px 0 0 0;
+  }
+
+  .cert-display-footer {
+    margin-top: 40px;
+    padding-top: 24px;
+    border-top: 1px solid #E5E7EB;
+    text-align: left;
+  }
+
+  .cert-display-verify {
+    font-size: 0.8125rem;
+    color: #6B7280;
+    margin-bottom: 6px;
+    word-break: break-all;
+  }
+
+  .cert-verify-label { font-weight: 600; color: #374151; }
+  .cert-verify-id { font-family: monospace; font-size: 0.75rem; }
+  .cert-verify-link { color: #1a4e8a; text-decoration: none; }
+  .cert-verify-link:hover { text-decoration: underline; }
+
+  .cert-display-actions { margin-top: 16px; text-align: center; }
+
+  .cert-copy-link-btn {
+    background: #1a4e8a;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 10px 24px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .cert-copy-link-btn:hover { background: #154171; }
+
+  .cert-display-loading {
+    text-align: center;
+    padding: 80px 40px;
+    color: #6B7280;
+    font-size: 1rem;
+  }
+
+  .cert-display-error {
+    text-align: center;
+    padding: 80px 40px;
+    color: #991B1B;
+  }
+
+  .cert-display-error p { font-size: 1.125rem; margin-bottom: 24px; }
+
+  .cert-back-link {
+    color: #1a4e8a;
+    text-decoration: underline;
+    font-weight: 600;
+  }
+
+  @media (max-width: 600px) {
+    .cert-display-card { padding: 24px 16px; }
+    .cert-display-heading { font-size: 1.5rem; }
+    .cert-display-learner { font-size: 1.375rem; }
+  }
+</style>
+
+<main id="main-content">
+  <div class="cert-page-container">
+
+    <div id="certificate-container">
+      <div class="cert-display-loading">Loading certificate...</div>
+    </div>
+
+  </div>
+</main>
+
+{# Auth context (used by production-certificate.js for /auth/me) #}
+{% set auth_me_url = constants.AUTH_ME_URL if constants and constants.AUTH_ME_URL else 'https://api.hedgehog.cloud/auth/me' %}
+{% set auth_login_url = constants.AUTH_LOGIN_URL if constants and constants.AUTH_LOGIN_URL else 'https://api.hedgehog.cloud/auth/login' %}
+{% set auth_logout_url = constants.AUTH_LOGOUT_URL if constants and constants.AUTH_LOGOUT_URL else 'https://api.hedgehog.cloud/auth/logout' %}
+<div id="hhl-auth-context"
+     data-auth-me-url="{{ auth_me_url }}"
+     data-auth-login-url="{{ auth_login_url }}"
+     data-auth-logout-url="{{ auth_logout_url }}"
+     data-enable-crm="{{ 'true' if constants.ENABLE_CRM_PROGRESS else 'false' }}"
+     style="display:none"></div>
+<script src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/learn/assets/js/cognito-auth-integration.js') }}"></script>
+<script defer src="{{ get_asset_url('/CLEAN x HEDGEHOG/templates/assets/js/production-certificate.js') }}"></script>
+{% endblock body %}


### PR DESCRIPTION
## Summary
- Adds `production-certificate.js` — port of `shadow-certificate.js` for production:
  - `GET /certificate/<certId>` (no `/shadow/` prefix)
  - Back link goes to `/learn/my-learning`
  - No shadow-mode banner
- Adds `learn/certificate.html` — production HubL template for `/learn/certificate?id=<certId>`:
  - No `data-shadow="true"` on auth context
  - No noindex robots meta (production certs are public)
  - Loads `production-certificate.js`

Closes #437

## Test plan
- [ ] Verify both assets published to HubSpot (done before commit)
- [ ] CI: validate, lint, smoke pass
- [ ] Create a CMS page at `/learn/certificate` using `learn/certificate.html` template
- [ ] Browser: `?id=<valid-cert-uuid>` renders certificate card; `?id=bad` shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)