### PR TITLE
fix: shadow certificate page + bottom completion banner [skip-docs-check]

### DIFF
--- a/clean-x-hedgehog-templates/assets/shadow/js/shadow-completion.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/shadow-completion.js
@@ -312,11 +312,6 @@
   }
 
   function showModuleComplete(certId) {
-    if (document.getElementById('hhl-module-complete-banner')) return;
-    var banner = document.createElement('div');
-    banner.id = 'hhl-module-complete-banner';
-    banner.className = 'hhl-module-complete';
-    banner.setAttribute('role', 'status');
     var certLink = '';
     if (certId) {
       certLink = ' \u2014 <a href="/learn-shadow/certificate?id=' +
@@ -324,9 +319,32 @@
         '" class="hhl-cert-link" target="_blank" rel="noopener noreferrer">' +
         '\uD83C\uDF93 View Certificate</a>';
     }
-    banner.innerHTML = '<strong>Module Complete \u2713</strong> \u2014 All tasks finished.' + certLink;
-    var detail = document.querySelector('.module-detail');
-    if (detail) detail.insertBefore(banner, detail.firstChild);
+    var bannerHtml = '<strong>Module Complete \u2713</strong> \u2014 All tasks finished.' + certLink;
+
+    // Top banner: at the very start of .module-detail (visible after scrolling up)
+    if (!document.getElementById('hhl-module-complete-banner')) {
+      var topBanner = document.createElement('div');
+      topBanner.id = 'hhl-module-complete-banner';
+      topBanner.className = 'hhl-module-complete';
+      topBanner.setAttribute('role', 'status');
+      topBanner.innerHTML = bannerHtml;
+      var detail = document.querySelector('.module-detail');
+      if (detail) detail.insertBefore(topBanner, detail.firstChild);
+    }
+
+    // Bottom banner: right after the last task section so it appears immediately
+    // after the student submits their final requirement — no scrolling required.
+    if (!document.getElementById('hhl-module-complete-banner-bottom')) {
+      var lastSection = labSection || quizSection;
+      if (lastSection && lastSection.parentNode) {
+        var bottomBanner = document.createElement('div');
+        bottomBanner.id = 'hhl-module-complete-banner-bottom';
+        bottomBanner.className = 'hhl-module-complete';
+        bottomBanner.setAttribute('role', 'status');
+        bottomBanner.innerHTML = bannerHtml;
+        lastSection.parentNode.insertBefore(bottomBanner, lastSection.nextSibling);
+      }
+    }
   }
 
   function showAuthPrompt() {

--- a/clean-x-hedgehog-templates/assets/shadow/js/shadow-completion.js
+++ b/clean-x-hedgehog-templates/assets/shadow/js/shadow-completion.js
@@ -336,13 +336,13 @@
     // after the student submits their final requirement — no scrolling required.
     if (!document.getElementById('hhl-module-complete-banner-bottom')) {
       var lastSection = labSection || quizSection;
-      if (lastSection && lastSection.parentNode) {
+      if (lastSection) {
         var bottomBanner = document.createElement('div');
         bottomBanner.id = 'hhl-module-complete-banner-bottom';
         bottomBanner.className = 'hhl-module-complete';
         bottomBanner.setAttribute('role', 'status');
         bottomBanner.innerHTML = bannerHtml;
-        lastSection.parentNode.insertBefore(bottomBanner, lastSection.nextSibling);
+        lastSection.insertAdjacentElement('afterend', bottomBanner);
       }
     }
   }

--- a/src/api/lambda/certificate-verify.ts
+++ b/src/api/lambda/certificate-verify.ts
@@ -15,7 +15,7 @@
  */
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
 
 // ---------------------------------------------------------------------------
 // DynamoDB client (lazy init for testability)
@@ -119,8 +119,11 @@ export async function handleCertificateVerify(event: any) {
     return jsonResp(500, { error: 'Server configuration error' }, origin);
   }
 
+  // Primary lookup: query the certId-index GSI (O(1), requires GSI to be deployed)
+  let item: Record<string, unknown> | undefined;
+
   try {
-    const result = await getDynamo().send(
+    const gsiResult = await getDynamo().send(
       new QueryCommand({
         TableName: CERTS_TABLE,
         IndexName: 'certId-index',
@@ -129,23 +132,44 @@ export async function handleCertificateVerify(event: any) {
         Limit: 1,
       })
     );
-
-    const item = result.Items?.[0];
-    if (!item) {
-      return jsonResp(404, { error: 'Certificate not found' }, origin);
-    }
-
-    const response: CertificateVerifyResponse = {
-      certId: item.certId as string,
-      entityType: item.entityType as 'module' | 'course',
-      entitySlug: item.entitySlug as string,
-      entityTitle: (item.entityTitle as string | undefined) || (item.entitySlug as string),
-      issuedAt: item.issuedAt as string,
-    };
-
-    return jsonResp(200, response, origin);
-  } catch (err: any) {
-    console.error('[CertVerify] DynamoDB query failed:', err?.message || err);
-    return jsonResp(500, { error: 'Failed to verify certificate' }, origin);
+    item = gsiResult.Items?.[0];
+  } catch (gsiErr: any) {
+    // GSI may not exist on the deployed table (e.g., table was provisioned before
+    // the GSI was added to the CloudFormation schema). Fall through to scan.
+    console.warn('[CertVerify] GSI query failed — falling back to scan:', gsiErr?.name);
   }
+
+  // Fallback: full-table scan filtered by certId.
+  // Acceptable for low-data environments (shadow); the GSI is the fast path in
+  // production once the table is provisioned with the schema.
+  if (!item) {
+    try {
+      const scanResult = await getDynamo().send(
+        new ScanCommand({
+          TableName: CERTS_TABLE,
+          FilterExpression: 'certId = :certId',
+          ExpressionAttributeValues: { ':certId': certId },
+          Limit: 100,
+        })
+      );
+      item = scanResult.Items?.[0];
+    } catch (scanErr: any) {
+      console.error('[CertVerify] Scan fallback failed:', scanErr?.message || scanErr);
+      return jsonResp(500, { error: 'Failed to verify certificate' }, origin);
+    }
+  }
+
+  if (!item) {
+    return jsonResp(404, { error: 'Certificate not found' }, origin);
+  }
+
+  const response: CertificateVerifyResponse = {
+    certId: item.certId as string,
+    entityType: item.entityType as 'module' | 'course',
+    entitySlug: item.entitySlug as string,
+    entityTitle: (item.entityTitle as string | undefined) || (item.entitySlug as string),
+    issuedAt: item.issuedAt as string,
+  };
+
+  return jsonResp(200, response, origin);
 }

--- a/tests/e2e/shadow-deterministic.spec.ts
+++ b/tests/e2e/shadow-deterministic.spec.ts
@@ -257,7 +257,7 @@ test.describe('fabric-operations-welcome', () => {
     const labFeedback = await page.locator('#hhl-lab-feedback').textContent();
     expect(labFeedback).toMatch(/complete|lab.*done|attested/i);
 
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('completed state persists after reload', async ({ page }) => {
@@ -266,10 +266,10 @@ test.describe('fabric-operations-welcome', () => {
     await attestLabApi('fabric-operations-welcome');
 
     await page.goto(`${BASE}/learn-shadow/modules/fabric-operations-welcome`);
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
   });
 });
 
@@ -307,7 +307,7 @@ test.describe('fabric-operations-vpc-provisioning', () => {
     const labFeedback = await page.locator('#hhl-lab-feedback').textContent();
     expect(labFeedback).toMatch(/complete|lab.*done|attested/i);
 
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('completed state persists after reload', async ({ page }) => {
@@ -315,10 +315,10 @@ test.describe('fabric-operations-vpc-provisioning', () => {
     await attestLabApi('fabric-operations-vpc-provisioning');
 
     await page.goto(`${BASE}/learn-shadow/modules/fabric-operations-vpc-provisioning`);
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
   });
 });
 


### PR DESCRIPTION
## Summary
Two bug fixes for the shadow completion UI:

**1. Certificate page shows error**
`certificate-verify.ts` queries the `certId-index` GSI to look up a certificate by its UUID. If the shadow DynamoDB table was provisioned before the GSI was added to the CloudFormation schema, the GSI doesn't exist → query throws → 500 → "Unable to load certificate" error.

Fix: catch the GSI query failure and fall back to a `ScanCommand` filtered by `certId`. The `Limit: 100` scan is acceptable for the low data volume in the shadow environment. The GSI remains the fast path once the table is re-provisioned with the correct schema.

> **Note**: this fix requires a shadow Lambda redeploy (`APP_STAGE=shadow npm run deploy:aws`) to take effect.

**2. Module completion banner only shows at top**
The student submits quiz/lab at the bottom of the page, but the Module Complete banner only appeared at the top of `.module-detail` — requiring a scroll up to see it.

Fix: `showModuleComplete` now inserts two banners — the existing top banner AND a new bottom banner (`#hhl-module-complete-banner-bottom`) immediately after the last task section (lab if present, otherwise quiz). `shadow-completion.js` already published to HubSpot — this fix is live immediately.

## Test plan
- [ ] Complete a module with both quiz and lab — bottom banner appears right after the lab button
- [ ] Click "View Certificate" in either banner — certificate page loads correctly (after Lambda redeploy)
- [ ] Complete a module with quiz only — bottom banner appears right after the quiz section

🤖 Generated with [Claude Code](https://claude.com/claude-code)