### PR TITLE
test(smoke): comprehensive bottom-banner assertions + CDN content verification

### DIFF
--- a/tests/e2e/shadow-deterministic.spec.ts
+++ b/tests/e2e/shadow-deterministic.spec.ts
@@ -257,7 +257,13 @@ test.describe('fabric-operations-welcome', () => {
     const labFeedback = await page.locator('#hhl-lab-feedback').textContent();
     expect(labFeedback).toMatch(/complete|lab.*done|attested/i);
 
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 10000 });
+    // Top banner (at page top)
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 10000 });
+    // Bottom banner (directly after the last task section — no scrolling required)
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 10000 });
+    // Bottom banner must be a sibling immediately after #hhl-lab-section
+    const bannerAfterLab = page.locator('#hhl-lab-section + #hhl-module-complete-banner-bottom');
+    await expect(bannerAfterLab).toBeAttached({ timeout: 5000 });
   });
 
   test('completed state persists after reload', async ({ page }) => {
@@ -266,10 +272,12 @@ test.describe('fabric-operations-welcome', () => {
     await attestLabApi('fabric-operations-welcome');
 
     await page.goto(`${BASE}/learn-shadow/modules/fabric-operations-welcome`);
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 15000 });
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 15000 });
   });
 });
 
@@ -307,7 +315,12 @@ test.describe('fabric-operations-vpc-provisioning', () => {
     const labFeedback = await page.locator('#hhl-lab-feedback').textContent();
     expect(labFeedback).toMatch(/complete|lab.*done|attested/i);
 
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 10000 });
+    // Top banner at page start
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 10000 });
+    // Bottom banner after lab section (lab-only module: no quiz above it)
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 10000 });
+    const bannerAfterLab = page.locator('#hhl-lab-section + #hhl-module-complete-banner-bottom');
+    await expect(bannerAfterLab).toBeAttached({ timeout: 5000 });
   });
 
   test('completed state persists after reload', async ({ page }) => {
@@ -315,10 +328,12 @@ test.describe('fabric-operations-vpc-provisioning', () => {
     await attestLabApi('fabric-operations-vpc-provisioning');
 
     await page.goto(`${BASE}/learn-shadow/modules/fabric-operations-vpc-provisioning`);
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 15000 });
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 15000 });
   });
 });
 

--- a/tests/e2e/shadow-live.spec.ts
+++ b/tests/e2e/shadow-live.spec.ts
@@ -168,6 +168,30 @@ test.describe('CDN Asset Verification', () => {
     expect(body, 'CDN shadow-completion.js must always hide legacy buttons').not.toContain('if (quizSection || labSection)');
   });
 
+  test('shadow-completion.js CDN copy contains bottom module-complete banner fix', async ({ page }) => {
+    // Capture the actual CDN URL from a real page load — this proves what code
+    // the browser actually receives, independent of JS interception in other suites.
+    const completionUrls: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('shadow-completion')) completionUrls.push(req.url());
+    });
+
+    await page.goto(`${BASE}/learn-shadow/modules/fabric-operations-welcome`);
+    await page.waitForTimeout(5000);
+
+    const cdnUrl = completionUrls[0];
+    expect(cdnUrl, 'shadow-completion.js must be requested from CDN').toBeTruthy();
+
+    const resp = await page.request.get(cdnUrl);
+    expect(resp.status()).toBe(200);
+    const body = await resp.text();
+
+    // Bottom banner must be present — if this fails it means the CDN is serving
+    // a stale version and the template + JS must be re-published to HubSpot.
+    expect(body, 'CDN shadow-completion.js must create bottom module-complete banner').toContain('hhl-module-complete-banner-bottom');
+    expect(body, 'CDN shadow-completion.js must use insertAdjacentElement for bottom banner').toContain('insertAdjacentElement');
+  });
+
   test('shadow-my-learning.js CDN copy contains details[open] fix', async ({ page }) => {
     // Capture the actual CDN URL by listening to requests on a live page load.
     const myLearningUrls: string[] = [];
@@ -316,12 +340,21 @@ test.describe('fabric-operations-welcome [LIVE — zero mocks]', () => {
     await expect(labBtn).toBeVisible({ timeout: 10000 });
     await labBtn.click();
 
-    // Module complete banner appears when both tasks done
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 15000 });
+    // Top banner appears at start of .module-detail
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 15000 });
+
+    // Bottom banner appears directly after the last task section — no scrolling required.
+    // This is the key UX requirement: the student sees completion feedback at the point
+    // of submission, not just at the top of the page.
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 10000 });
+
+    // Bottom banner must be immediately after #hhl-lab-section in the DOM
+    const bannerAfterLab = page.locator('#hhl-lab-section + #hhl-module-complete-banner-bottom');
+    await expect(bannerAfterLab).toBeAttached({ timeout: 5000 });
 
     await page.screenshot({
       path: path.join(SCREENSHOTS_DIR, '05-welcome-module-complete.png'),
-      fullPage: false,
+      fullPage: true,
     });
   });
 });
@@ -355,7 +388,10 @@ test.describe('fabric-operations-vpc-provisioning [LIVE — zero mocks]', () => 
     const labFeedback = await page.locator('#hhl-lab-feedback').textContent();
     expect(labFeedback).toMatch(/complete|lab.*done|attested/i);
 
-    await expect(page.locator('#hhl-module-complete, .hhl-module-complete')).toBeVisible({ timeout: 10000 });
+    // Top banner (at page top)
+    await expect(page.locator('#hhl-module-complete-banner')).toBeVisible({ timeout: 10000 });
+    // Bottom banner (directly after #hhl-lab-section — no scrolling required)
+    await expect(page.locator('#hhl-module-complete-banner-bottom')).toBeVisible({ timeout: 10000 });
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds specific `#hhl-module-complete-banner-bottom` assertions to `shadow-deterministic` (CI) — previously tests only checked for `.hhl-module-complete` (any banner), which let the bottom banner go undetected
- Adds CDN content verification to `shadow-live` that fetches the ACTUAL CDN URL of `shadow-completion.js` and asserts it contains `hhl-module-complete-banner-bottom` and `insertAdjacentElement` — proves the deployed JS matches the repo source, independent of JS interception
- Fixes strict-mode violations in `shadow-live` completion tests (ID-based selectors now)
- Uses CSS sibling selector `#hhl-lab-section + #hhl-module-complete-banner-bottom` to verify DOM position (not just existence)
- Updates reload persistence tests to check both top and bottom banners

## Why this matters

The smoke test previously intercepted `shadow-completion.js` with the local repo file and checked for any `.hhl-module-complete` element — which passed because the top banner was present. The bottom banner was never specifically asserted, and there was no test verifying the CDN copy matched the repo source.

## Test plan
- [ ] `shadow-deterministic` CI check passes
- [ ] Manually run `shadow-live` against production site to verify CDN serves correct JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)