### PR TITLE
Stabilize Phase 5B deterministic suite: 38/38 green vs live (Issue #465)

### DIFF
--- a/clean-x-hedgehog-templates/assets/js/production-pathway-detail.js
+++ b/clean-x-hedgehog-templates/assets/js/production-pathway-detail.js
@@ -39,10 +39,15 @@
     });
   }
 
-  function statusBadge(status) {
+  // `scope` differentiates the pathway-level header badge from per-course-row
+  // badges so callers can target a single node (Issue #465 — removes the
+  // [data-pathway-status-badge] strict-mode collision in the deterministic
+  // suite while keeping the same visual + semantic styling).
+  function statusBadge(status, scope) {
     var label = status === 'complete' ? 'Completed' : status === 'in_progress' ? 'In Progress' : 'Not Started';
     var cls = status === 'complete' ? 'status-completed' : status === 'in_progress' ? 'status-in-progress' : 'status-not-started';
-    return '<span class="enrollment-status-badge ' + cls + '" data-pathway-status-badge>' + label + '</span>';
+    var attr = scope === 'course' ? 'data-pathway-course-status-badge' : 'data-pathway-status-badge';
+    return '<span class="enrollment-status-badge ' + cls + '" ' + attr + '>' + label + '</span>';
   }
 
   function renderCourseRow(c) {
@@ -50,7 +55,7 @@
     return '<a data-pathway-course-row data-course-slug="' + escapeHtml(c.course_slug) + '" class="pathway-course-row" href="' + link + '">' +
       '<div class="pathway-course-title">' + escapeHtml(c.course_title) + '</div>' +
       '<div class="pathway-course-meta">' +
-        statusBadge(c.course_status) +
+        statusBadge(c.course_status, 'course') +
         '<span class="pathway-course-progress">' + c.modules_completed + ' of ' + c.modules_total + ' modules</span>' +
       '</div>' +
       '</a>';

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -193,6 +193,17 @@ CI gates:
 
 ## Release Notes
 
+### 2026-05-14: Phase 5B Deterministic Suite Stabilization + Pathway Badge Marker Disambiguation (Issue #465 / PR #466)
+
+Stabilizes the four `production-learner-record-deterministic` failures observed during the #464 post-publish run. Three were test-side (a `MutationObserver`-vs-`DOMContentLoaded` race on the ownership marker, a 400 path that navigated to a CMS-404 slug so the renderer never ran, and a strict-mode `toBeVisible()` missing `.first()` on the answer-review fixture). The fourth was a small renderer-side DOM contract change.
+
+DOM contract change in `production-pathway-detail.js`:
+- Header pathway-level badge keeps `data-pathway-status-badge` (single occurrence, the pathway's own status).
+- Per-course-row badges now emit `data-pathway-course-status-badge` (one per course row).
+- Visual rendering is unchanged (same CSS classes and labels); only the data attribute differs. This matches how `production-course-detail.js` already keeps `data-course-status-badge` to a single header occurrence and removes the strict-mode collision that previously resolved the locator to 5 nodes.
+
+The deterministic spec intercepts production JS via `interceptProductionJs`, so the suite is green against live `hedgehog.cloud` (38/38) without re-publishing the renderer. A small follow-up rollout can publish the updated `production-pathway-detail.js` to PUBLISHED if/when desired; that change has no other consumers (verified with `grep -rn 'data-pathway-status-badge\|data-pathway-course-status-badge'`).
+
 ### 2026-05-13: Phase 5B `/learn` Parity with Approved Shadow Learner-Progress Center (Issue #459 / PR #463)
 
 Brings production `/learn` up to the approved shadow learner-progress center (#452). All client renderers now consume the bare production server-authoritative endpoints (`/pathway/status`, `/course/status`, `/module/progress`, `/certificates`) — no client-side rollup recomputation, no `/tasks/status/batch` call on dashboard load.

--- a/tests/e2e/production-learner-record-deterministic.spec.ts
+++ b/tests/e2e/production-learner-record-deterministic.spec.ts
@@ -737,17 +737,22 @@ test.describe('Production My Learning dashboard — single-ownership boundary', 
   });
 
   test('removing the ownership marker disables the new renderer (legacy renderer regains exclusive ownership)', async ({ page }) => {
-    // Strip the marker at document_start so the new renderer's Guard 2
-    // (data-enrollment-renderer precondition) trips early and short-circuits
-    // before any /pathway/status or /enrollments/list fetch is issued.
-    await page.addInitScript(() => {
-      const obs = new MutationObserver(() => {
-        const el = document.getElementById('hhl-auth-context');
-        if (el && el.getAttribute('data-enrollment-renderer')) {
-          el.removeAttribute('data-enrollment-renderer');
-        }
+    // Strip the marker from the document HTML before any script runs. Using a
+    // MutationObserver-via-addInitScript races the renderer's DOMContentLoaded
+    // read of the attribute; mutating the response body is deterministic — the
+    // renderer never sees the marker because the HTML never carries it.
+    await page.route(/hedgehog\.cloud\/learn\/my-learning/, async (route) => {
+      const resp = await route.fetch();
+      const original = await resp.text();
+      const stripped = original.replace(
+        /(id=["']hhl-auth-context["'][^>]*?)\s+data-enrollment-renderer=(["'])[^"']*\2/i,
+        '$1'
+      );
+      await route.fulfill({
+        response: resp,
+        body: stripped,
+        headers: { ...resp.headers(), 'content-length': String(Buffer.byteLength(stripped, 'utf-8')) },
       });
-      obs.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
     });
 
     const pathwayCalls: string[] = [];
@@ -812,7 +817,11 @@ test.describe('Production pathway detail page', () => {
     await mockPathwayStatus(page, 200, PATHWAY_MIXED);
     await page.goto(`${BASE}/learn/pathways/${PATHWAY_SLUG}`);
     await expect(page.locator('[data-pathway-title]')).toContainText('Network Like a Hyperscaler');
+    // Header pathway-level badge is now uniquely marked; per-course-row badges
+    // moved to [data-pathway-course-status-badge] in the renderer to remove the
+    // strict-mode collision (Issue #465).
     await expect(page.locator('[data-pathway-status-badge]')).toContainText(/in.?progress/i);
+    await expect(page.locator('[data-pathway-course-status-badge]')).toHaveCount(4);
     await expect(page.locator('[data-pathway-course-row]')).toHaveCount(4);
     await expect(page.locator('[data-pathway-course-row]').first()).toContainText(/2 of 4/);
   });
@@ -916,8 +925,14 @@ test.describe('Production course detail page', () => {
   });
 
   test('not found (400): "Course not found" error block', async ({ page }) => {
+    // Navigate to a valid course slug so the production template renders
+    // #course-detail-context + #course-progress-detail-root. The 400 path
+    // models "API responds course-not-found even on a valid CMS URL" — which
+    // is exactly the renderer branch we want to exercise (Issue #465: prior
+    // navigation to a nonexistent slug 404'd at the CMS level and the
+    // renderer never ran).
     await mockCourseStatus(page, 400, { error: 'course not found' });
-    await page.goto(`${BASE}/learn/courses/nonexistent-slug`);
+    await page.goto(`${BASE}/learn/courses/${COURSE_SLUG}`);
     await expect(page.locator('[data-course-error]')).toContainText(/not found/i);
   });
 });
@@ -978,7 +993,10 @@ test.describe('Production module learner-record page', () => {
     await mockModuleProgress(page, 200, MODULE_PROGRESS_WITH_ATTEMPTS);
     await page.goto(`${BASE}/learn/module-progress?module=${MODULE_SLUG}`);
     await page.locator('[data-module-attempt-row] details summary').first().click();
-    await expect(page.locator('[data-module-answer-review-row]')).toBeVisible();
+    // Two attempts in the fixture → two answer-review rows in DOM (only the
+    // opened drawer is visible). Scope the visibility check to the first row
+    // to match the next two assertions' explicit `.first()` (Issue #465).
+    await expect(page.locator('[data-module-answer-review-row]').first()).toBeVisible();
     await expect(page.locator('[data-module-answer-review-row]').first()).toContainText('kubectl get pods');
     await expect(page.locator('[data-module-answer-review-row][data-is-correct]').first()).toHaveAttribute(
       'data-is-correct',


### PR DESCRIPTION
Closes #465.

## Summary

Stabilizes the 4 deterministic-suite failures surfaced during the #464 post-publish run (`verification-output/issue-464/logs/layer1-deterministic.log`). Re-running `production-learner-record-deterministic` against live `hedgehog.cloud` now reports **38/38 green** (1.8 min, 1 worker).

3 test-side fixes + 1 small renderer DOM-attribute rename. No live rollout work (deliberately — #465 scope).

## Root causes (one per failure)

| Case | Failing assertion | Cause | Fix |
| --- | --- | --- | --- |
| A | `removing the ownership marker disables the new renderer` (line 739) | `MutationObserver` async callback raced the renderer's `DOMContentLoaded` read — renderer won on live CDN-served JS and issued one `/pathway/status` call before the marker was stripped | **test only**: replace the observer with `page.route` on `/learn/my-learning`, strip `data-enrollment-renderer` from the HTML response body, fulfill. Deterministic — the renderer never sees the marker. |
| B | `loaded (in_progress): … per-course rollup rows` (line 811) | `production-pathway-detail.js` reused `statusBadge()` for both the header pathway-level badge **and** every course row → 5 `[data-pathway-status-badge]` nodes → strict-mode violation | **renderer**: add a `scope` arg so per-course-row badges emit `data-pathway-course-status-badge` (header keeps original attr). Matches how `production-course-detail.js` already keeps `data-course-status-badge` to a single header occurrence. **test**: add the corresponding `[data-pathway-course-status-badge].toHaveCount(4)` assertion. |
| C | `not found (400): "Course not found" error block` (line 918) | Test navigated to `/learn/courses/nonexistent-slug`, but HubSpot's HubDB-bound CMS itself returns a 404 (`curl https://hedgehog.cloud/learn/courses/nonexistent-slug` → HTTP 404 + site 404 template). Production course detail template never rendered `#course-detail-context`/`#course-progress-detail-root` and the renderer short-circuited at line 30/36 — the mocked 400 was never read | **test only**: navigate to the valid `COURSE_SLUG`. The mocked 400 then exercises the renderer's `body.error === 'course not found'` branch (`production-course-detail.js:131`) which **is** correct. |
| D | `expand quiz attempt: answer-review drawer …` (line 977) | `MODULE_PROGRESS_WITH_ATTEMPTS` fixture has 2 attempts × 1 review-row each → 2 `[data-module-answer-review-row]` nodes → strict-mode violation on `toBeVisible()`. The next two assertions in the same test already used `.first()`. | **test only**: add `.first()` to the visibility check. |

## Diff-visible TDD sequence

| # | SHA | Subject |
| --- | --- | --- |
| 1 | `c4e23f6` | `test(prod-parity): stabilize 3 deterministic failures with test-only fixes (Issue #465)` — A/C/D pass; B still red intentionally |
| 2 | `4560637` | `fix(pathway-detail): scope status badge so per-course rows don't collide with header (Issue #465)` — B passes |

Run logs:

- Run 1 (after commit 1, targeted 4 tests): **3 passed / 1 failed** — A, C, D green; B red as expected.
- Run 2 (after commit 2, targeted 4 tests): **4 passed**.
- Run 3 (full suite, 38 tests, against live `hedgehog.cloud`): **38 passed / 1.8 min**.

Artifacts: `verification-output/issue-465/verification.md` + `verification-output/issue-465/logs/run{1,2,3}-*.log` (gitignored per the same pattern as #458/#459/#464).

## Live rollout impact

The renderer change is a DOM-attribute rename only:
- Visual rendering identical (same CSS class, same text).
- Cross-checked consumers: `grep -rn 'data-pathway-status-badge\\|data-pathway-course-status-badge' clean-x-hedgehog-templates/ tests/ src/ scripts/` returns only the renderer (2 lines) and the deterministic spec (2 lines).
- The deterministic spec intercepts production JS with local repo source via `interceptProductionJs`, so green-against-live does not depend on rolling the renderer change to live.

Per #465's stated boundary, rollout to live HubSpot is **not** done here. If desired, a small follow-up issue can publish `production-pathway-detail.js` to PUBLISHED so the live DOM matches the new attribute name; it has no other dependencies.

## Out of scope

- Layer 2 live (still blocked by #461, no PR linked there).
- Any `/learn` template / page provisioning work (was #464's scope, complete).
- Other unrelated failing suites.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean.
- [x] Targeted re-run of the 4 affected tests confirms TDD: 3 → 4 → 4 green across the two commits.
- [x] Full `production-learner-record-deterministic` project against live `hedgehog.cloud`: **38 passed**.
- [ ] Lead review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)