### PR TITLE
fix(security): dual-guard Cognito test bypass paths (Issue #461)

### DIFF
--- a/src/api/lambda/cognito-auth.ts
+++ b/src/api/lambda/cognito-auth.ts
@@ -58,8 +58,27 @@ if (!process.env.JWT_SECRET) {
 }
 const STATE_SECRET = process.env.JWT_SECRET;
 
-// Test bypass for mock auth codes
-const ENABLE_TEST_BYPASS = process.env.ENABLE_TEST_BYPASS === 'true';
+/**
+ * Defense-in-depth dual guard for all test bypass code paths in this module
+ * (Issue #461).
+ *
+ * Test bypass behavior is only permitted when BOTH:
+ *   - process.env.APP_STAGE === 'shadow'
+ *   - process.env.ENABLE_TEST_BYPASS === 'true'
+ *
+ * Any other stage — including 'production', 'prod', 'staging', 'dev', or
+ * unset — must reject every bypass mechanism. This guard is evaluated per
+ * request (no module-level caching of the flag) so a misconfigured prod
+ * deployment cannot opt itself into test behavior with a single env var.
+ *
+ * Mirrors the reference pattern in src/api/lambda/admin-test-reset.ts.
+ */
+export function isTestBypassEnabled(): boolean {
+  return (
+    process.env.APP_STAGE === 'shadow' &&
+    process.env.ENABLE_TEST_BYPASS === 'true'
+  );
+}
 
 // DynamoDB client
 const dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region: COGNITO_REGION }));
@@ -501,8 +520,9 @@ export async function handleCallback(event: any): Promise<APIGatewayProxyResultV
       };
     }
 
-    // Test bypass for mock codes
-    if (ENABLE_TEST_BYPASS && code.startsWith('MOCK_')) {
+    // Test bypass for mock codes — gated by the dual guard
+    // (APP_STAGE=shadow AND ENABLE_TEST_BYPASS=true). See isTestBypassEnabled().
+    if (isTestBypassEnabled() && code.startsWith('MOCK_')) {
       console.warn('[TEST] Using mock auth bypass for code:', code);
 
       const stateData = decodeState(state);
@@ -1009,11 +1029,13 @@ async function updateUserHubspotContactId(userId: string, hubspotContactId: stri
  * Throws if the token is missing or invalid.
  * Used by shadow-only endpoints (Issue #407+).
  *
- * When ENABLE_TEST_BYPASS=true and the token is the fixed bypass sentinel value,
+ * When the dual guard is satisfied (APP_STAGE=shadow AND
+ * ENABLE_TEST_BYPASS=true) and the token is the fixed bypass sentinel value,
  * JWT verification is skipped and a stable test identity is returned. This
- * allows automated shadow E2E tests to exercise real DynamoDB operations without
- * needing a live Cognito browser session. The bypass is already gated by the
- * shadow-only ENABLE_TEST_BYPASS flag at every calling endpoint.
+ * allows automated shadow E2E tests to exercise real DynamoDB operations
+ * without needing a live Cognito browser session. The dual guard is enforced
+ * here directly via isTestBypassEnabled(); the same predicate gates every
+ * other bypass path in this module (Issue #461).
  */
 export async function verifyCookieAuth(event: any): Promise<{ userId: string; email: string; decoded: any }> {
   const rawCookies = event.cookies && event.cookies.length
@@ -1026,8 +1048,8 @@ export async function verifyCookieAuth(event: any): Promise<{ userId: string; em
   }
 
   // Test bypass: skip JWT verification for the fixed bypass sentinel.
-  // Only active when ENABLE_TEST_BYPASS=true (shadow stage only).
-  if (ENABLE_TEST_BYPASS && accessToken === 'shadow_e2e_test_token') {
+  // Dual-guarded — only active when APP_STAGE=shadow AND ENABLE_TEST_BYPASS=true.
+  if (isTestBypassEnabled() && accessToken === 'shadow_e2e_test_token') {
     const decoded = { sub: 'shadow-e2e-test-user', email: 'shadow-e2e@test.internal', token_use: 'access' };
     return { userId: 'shadow-e2e-test-user', email: 'shadow-e2e@test.internal', decoded };
   }

--- a/tests/unit/cognito-auth-bypass.test.ts
+++ b/tests/unit/cognito-auth-bypass.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for the P0 dual-guard hardening of Cognito test bypass paths.
+ *
+ * Issue: #461 — bypass logic must require BOTH
+ *   - APP_STAGE === 'shadow'
+ *   - ENABLE_TEST_BYPASS === 'true'
+ *
+ * Covers the two entry points in src/api/lambda/cognito-auth.ts:
+ *   1. handleCallback() — mock auth code (MOCK_*) → mock cookies
+ *   2. verifyCookieAuth() — sentinel access token (shadow_e2e_test_token)
+ *
+ * Required cases (from issue body):
+ *   - callback bypass accepted on shadow + enabled
+ *   - callback bypass rejected on production + enabled
+ *   - cookie bypass accepted on shadow + enabled
+ *   - cookie bypass rejected on production + enabled
+ *   - cookie bypass rejected when bypass disabled (even on shadow)
+ */
+
+// IMPORTANT: cognito-auth.ts reads several env vars at module load and throws
+// if JWT_SECRET is unset. These assignments must execute before the SUT is
+// imported. With ts-jest + tsconfig module=CommonJS, top-level statements
+// run in source order, so setting env here works.
+process.env.JWT_SECRET = 'test-jwt-secret-for-unit-tests';
+process.env.COGNITO_DOMAIN = 'test.example.com';
+process.env.COGNITO_CLIENT_ID = 'test-client-id';
+process.env.COGNITO_REDIRECT_URI = 'https://api.test.example.com/auth/callback';
+process.env.COGNITO_ISSUER = 'https://cognito-idp.us-west-2.amazonaws.com/test-pool';
+process.env.COGNITO_USER_POOL_ID = 'us-west-2_testpool';
+process.env.DYNAMODB_USERS_TABLE = 'test-users-table';
+process.env.SITE_BASE_URL = 'https://test.example.com';
+
+import jwt from 'jsonwebtoken';
+import {
+  handleCallback,
+  verifyCookieAuth,
+  isTestBypassEnabled,
+} from '../../src/api/lambda/cognito-auth';
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+const STATE_SECRET = 'test-jwt-secret-for-unit-tests';
+
+function signState(overrides: Record<string, unknown> = {}): string {
+  return jwt.sign(
+    {
+      redirect_url: '/learn',
+      code_verifier: 'test-code-verifier-abcdefghij',
+      nonce: 'test-nonce',
+      timestamp: Date.now(),
+      ...overrides,
+    },
+    STATE_SECRET,
+    { expiresIn: '10m' }
+  );
+}
+
+function cookieEvent(token: string) {
+  return { headers: { cookie: `hhl_access_token=${token}` } };
+}
+
+// Snapshot only the env vars the helper reads so each test starts clean.
+let originalAppStage: string | undefined;
+let originalEnableBypass: string | undefined;
+
+beforeEach(() => {
+  originalAppStage = process.env.APP_STAGE;
+  originalEnableBypass = process.env.ENABLE_TEST_BYPASS;
+});
+
+afterEach(() => {
+  if (originalAppStage === undefined) delete process.env.APP_STAGE;
+  else process.env.APP_STAGE = originalAppStage;
+  if (originalEnableBypass === undefined) delete process.env.ENABLE_TEST_BYPASS;
+  else process.env.ENABLE_TEST_BYPASS = originalEnableBypass;
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// isTestBypassEnabled() — direct truth-table
+// ---------------------------------------------------------------------------
+
+describe('isTestBypassEnabled() — dual-guard predicate', () => {
+  it('returns true only when APP_STAGE=shadow AND ENABLE_TEST_BYPASS=true', () => {
+    process.env.APP_STAGE = 'shadow';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+    expect(isTestBypassEnabled()).toBe(true);
+  });
+
+  it('returns false when APP_STAGE is production even if bypass enabled', () => {
+    process.env.APP_STAGE = 'production';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+    expect(isTestBypassEnabled()).toBe(false);
+  });
+
+  it('returns false when APP_STAGE is unset even if bypass enabled', () => {
+    delete process.env.APP_STAGE;
+    process.env.ENABLE_TEST_BYPASS = 'true';
+    expect(isTestBypassEnabled()).toBe(false);
+  });
+
+  it('returns false when bypass disabled even on shadow', () => {
+    process.env.APP_STAGE = 'shadow';
+    process.env.ENABLE_TEST_BYPASS = 'false';
+    expect(isTestBypassEnabled()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCallback — MOCK_ code bypass
+// ---------------------------------------------------------------------------
+
+describe('handleCallback() — MOCK_ code bypass', () => {
+  it('accepts MOCK_ code when APP_STAGE=shadow and ENABLE_TEST_BYPASS=true', async () => {
+    process.env.APP_STAGE = 'shadow';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+
+    const state = signState();
+    const res: any = await handleCallback({
+      queryStringParameters: { code: 'MOCK_unit_test', state },
+      headers: {},
+    });
+
+    expect(res.statusCode).toBe(302);
+    const cookies: string[] = res.cookies || [];
+    expect(
+      cookies.some((c) => c.includes('hhl_access_token=mock_access_token_for_testing'))
+    ).toBe(true);
+  });
+
+  it('rejects MOCK_ code in production even when ENABLE_TEST_BYPASS=true', async () => {
+    process.env.APP_STAGE = 'production';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+
+    // Stub fetch so the non-bypass token-exchange path fails deterministically
+    // instead of hitting the network. We assert behavior, not reachability.
+    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('blocked in unit test'));
+
+    const state = signState();
+    const res: any = await handleCallback({
+      queryStringParameters: { code: 'MOCK_unit_test', state },
+      headers: {},
+    });
+
+    // The bypass must NOT have set the mock cookies.
+    const cookies: string[] = res.cookies || [];
+    expect(cookies.some((c) => c.includes('mock_access_token_for_testing'))).toBe(false);
+    // Code path fell through to normal exchange and errored out → 500
+    expect(res.statusCode).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyCookieAuth — sentinel token bypass
+// ---------------------------------------------------------------------------
+
+describe('verifyCookieAuth() — sentinel token bypass', () => {
+  it('accepts shadow_e2e_test_token when APP_STAGE=shadow and ENABLE_TEST_BYPASS=true', async () => {
+    process.env.APP_STAGE = 'shadow';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+
+    const result = await verifyCookieAuth(cookieEvent('shadow_e2e_test_token'));
+
+    expect(result.userId).toBe('shadow-e2e-test-user');
+    expect(result.email).toBe('shadow-e2e@test.internal');
+    expect(result.decoded).toMatchObject({
+      sub: 'shadow-e2e-test-user',
+      token_use: 'access',
+    });
+  });
+
+  it('rejects sentinel token in production even when ENABLE_TEST_BYPASS=true', async () => {
+    process.env.APP_STAGE = 'production';
+    process.env.ENABLE_TEST_BYPASS = 'true';
+
+    // Defense-in-depth: stub fetch so JWKS resolution can't accidentally
+    // succeed in some unrelated way. (The sentinel is not a valid JWT so
+    // jwt.decode returns null and verifyJWT throws before fetch is called.)
+    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('JWKS blocked in unit test'));
+
+    await expect(
+      verifyCookieAuth(cookieEvent('shadow_e2e_test_token'))
+    ).rejects.toThrow();
+  });
+
+  it('rejects sentinel token when ENABLE_TEST_BYPASS=false, even on shadow', async () => {
+    process.env.APP_STAGE = 'shadow';
+    process.env.ENABLE_TEST_BYPASS = 'false';
+
+    jest.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('JWKS blocked in unit test'));
+
+    await expect(
+      verifyCookieAuth(cookieEvent('shadow_e2e_test_token'))
+    ).rejects.toThrow();
+  });
+});

--- a/verification-output/issue-461/implementation-summary.md
+++ b/verification-output/issue-461/implementation-summary.md
@@ -1,0 +1,110 @@
+# Issue #461 — Implementation Summary
+
+**Issue:** P0 Security: harden Cognito test bypass to require shadow stage
+**Branch:** `issue-461-cognito-bypass-dual-guard`
+**Base:** `origin/main` @ `cc9b093`
+
+## Problem recap
+Both test-bypass entry points in `src/api/lambda/cognito-auth.ts` were gated
+on `ENABLE_TEST_BYPASS` alone. A misconfigured production deployment that
+leaked `ENABLE_TEST_BYPASS=true` therefore accepted:
+- mock callback codes (`MOCK_*`) and issued mock cookies, and
+- the fixed sentinel access token `shadow_e2e_test_token` as a valid identity.
+
+This contradicted the local reference pattern in
+`src/api/lambda/admin-test-reset.ts:200-203`, which already enforces a dual
+guard (`APP_STAGE === 'shadow'` AND `ENABLE_TEST_BYPASS === 'true'`).
+
+## Change
+Introduced a single exported predicate in `cognito-auth.ts`:
+
+```ts
+export function isTestBypassEnabled(): boolean {
+  return (
+    process.env.APP_STAGE === 'shadow' &&
+    process.env.ENABLE_TEST_BYPASS === 'true'
+  );
+}
+```
+
+- Evaluated **per request** — no module-level caching of the flag, so a
+  misconfigured prod deployment cannot opt in via a single env var.
+- Mirrors the `admin-test-reset.ts` dual guard so the project has one
+  consistent invariant for "shadow test behavior".
+
+Both bypass call sites switched to the helper:
+
+| Site | Before | After |
+| --- | --- | --- |
+| Callback (mock codes) | `if (ENABLE_TEST_BYPASS && code.startsWith('MOCK_'))` | `if (isTestBypassEnabled() && code.startsWith('MOCK_'))` |
+| `verifyCookieAuth` (sentinel) | `if (ENABLE_TEST_BYPASS && accessToken === 'shadow_e2e_test_token')` | `if (isTestBypassEnabled() && accessToken === 'shadow_e2e_test_token')` |
+
+The deprecated module-scope constant `const ENABLE_TEST_BYPASS = ...` was
+removed (the new helper supersedes it). Comments around both call sites and
+on `verifyCookieAuth` were updated to describe the **enforced** dual guard,
+not the prior intended behavior.
+
+## Files touched
+- `src/api/lambda/cognito-auth.ts` — helper added, both sites updated, comments aligned.
+- `tests/unit/cognito-auth-bypass.test.ts` — new unit coverage (9 cases).
+
+No other production source files modified. No rollout, frontend, or unrelated
+auth refactors bundled in.
+
+## Tests added (9 total)
+All cases prescribed by the issue body, plus a direct truth-table on the
+predicate:
+
+**`isTestBypassEnabled()` truth table (4)**
+1. true only when `APP_STAGE=shadow` and `ENABLE_TEST_BYPASS=true`
+2. false when `APP_STAGE=production` even if bypass enabled
+3. false when `APP_STAGE` unset even if bypass enabled
+4. false when bypass disabled even on shadow
+
+**`handleCallback()` — MOCK_ code bypass (2)**
+5. accepts MOCK_ code on shadow + enabled → 302 with `mock_access_token_for_testing` cookie
+6. rejects MOCK_ code in production + enabled → no mock cookie set; falls through to token-exchange path (stubbed `fetch` → 500)
+
+**`verifyCookieAuth()` — sentinel token bypass (3)**
+7. accepts `shadow_e2e_test_token` on shadow + enabled → returns the stable test identity
+8. rejects sentinel token in production + enabled → throws
+9. rejects sentinel token on shadow when `ENABLE_TEST_BYPASS=false` → throws
+
+## Env caching in tests
+Because the new helper reads `process.env` at call time, the test does **not**
+require `jest.resetModules` / dynamic imports for the dual-guard logic itself.
+The test mutates only `APP_STAGE` and `ENABLE_TEST_BYPASS` per case (snapshot
+in `beforeEach`, restore in `afterEach`).
+
+Module-load-time env vars (`JWT_SECRET`, `COGNITO_*`, `DYNAMODB_USERS_TABLE`,
+`SITE_BASE_URL`) are assigned at the top of the test file **before** the SUT
+is imported. With `tsconfig` `module=CommonJS`, top-level statements run in
+source order so this is sufficient.
+
+## Verification commands
+
+```bash
+# Targeted unit test
+npm run test:unit -- tests/unit/cognito-auth-bypass.test.ts
+#   Test Suites: 1 passed, 1 total
+#   Tests:       9 passed, 9 total
+
+# Full unit suite (1 unrelated preexisting failure in certificate-issuance)
+npm run test:unit
+
+# Lambda type-check (clean)
+npx tsc -p tsconfig.lambda.json --noEmit
+```
+
+The preexisting failure in `tests/unit/certificate-issuance.test.ts`
+(`handleCertificateVerify › returns 404 when certId is not found in DynamoDB`)
+was confirmed on `origin/main` via `git stash`; it is out of scope for #461.
+
+## Scope discipline
+Per the lead's re-entry note:
+- Did not touch rollout, frontend, or unrelated auth code.
+- Did not introduce new abstractions beyond the single predicate.
+- Solved with focused unit coverage; no E2E changes needed.
+- No broader refactor of `cognito-auth.ts` env reads — the helper reads
+  `process.env` at call time, which made the existing module-scope `import`
+  side effects irrelevant to the test seam.

--- a/verification-output/issue-461/unit-test-output.txt
+++ b/verification-output/issue-461/unit-test-output.txt
@@ -1,0 +1,10 @@
+      600 |       body: JSON.stringify({ error: 'Authentication failed' }),
+
+      at handleCallback (src/api/lambda/cognito-auth.ts:597:13)
+      at Object.<anonymous> (tests/unit/cognito-auth-bypass.test.ts:142:22)
+
+Test Suites: 1 passed, 1 total
+Tests:       9 passed, 9 total
+Snapshots:   0 total
+Time:        2.935 s, estimated 3 s
+Ran all test suites matching tests/unit/cognito-auth-bypass.test.ts.


### PR DESCRIPTION
## Summary
- Code hardening for the P0 finding in #461: both test-bypass entry points in `src/api/lambda/cognito-auth.ts` now require **both** `APP_STAGE === 'shadow'` AND `ENABLE_TEST_BYPASS === 'true'`, via a single per-call predicate `isTestBypassEnabled()`. Mirrors the existing dual-guard pattern in `src/api/lambda/admin-test-reset.ts:200-203`.
- A misconfigured prod with only `ENABLE_TEST_BYPASS=true` can no longer accept `MOCK_*` callback codes or the fixed sentinel access token.
- New unit coverage in `tests/unit/cognito-auth-bypass.test.ts` (9 cases) — covers the 5 scenarios required by the issue plus a direct truth-table on the predicate.

## Scope
- **In scope:** the dual-guard hardening in `cognito-auth.ts` and its unit tests.
- **Out of scope (deliberately):** rollout / deployment, frontend, and any unrelated auth refactor. Per the lead's re-entry note and review note, this PR is code hardening only.

## Issue + review trail
- Issue: https://github.com/afewell-hh/hh-learn/issues/461
- Lead re-entry note: https://github.com/afewell-hh/hh-learn/issues/461#issuecomment-4458341628
- Pre-implementation plan: https://github.com/afewell-hh/hh-learn/issues/461#issuecomment-4568464479
- Implementation + verification: https://github.com/afewell-hh/hh-learn/issues/461#issuecomment-4568506870
- Lead branch approval: https://github.com/afewell-hh/hh-learn/issues/461#issuecomment-4578541011
- Compare: https://github.com/afewell-hh/hh-learn/compare/main...issue-461-cognito-bypass-dual-guard

## Change shape
```ts
export function isTestBypassEnabled(): boolean {
  return (
    process.env.APP_STAGE === 'shadow' &&
    process.env.ENABLE_TEST_BYPASS === 'true'
  );
}
```
- `handleCallback()` — `if (isTestBypassEnabled() && code.startsWith('MOCK_'))`
- `verifyCookieAuth()` — `if (isTestBypassEnabled() && accessToken === 'shadow_e2e_test_token')`
- The deprecated module-scope `const ENABLE_TEST_BYPASS = ...` was removed.
- Comments around both call sites and on `verifyCookieAuth` updated to describe enforced behavior.
- Evaluated per request — no module-level caching of the flag.

## Test results
```
$ npm run test:unit -- tests/unit/cognito-auth-bypass.test.ts
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total

$ npx tsc -p tsconfig.lambda.json --noEmit
(clean)
```

Full unit suite: 108/109 pass. The single failure — `tests/unit/certificate-issuance.test.ts › handleCertificateVerify › returns 404 when certId is not found in DynamoDB` — is baseline noise that reproduces on `origin/main` (confirmed via `git stash`) and is out of scope for this PR.

## Artifacts
Committed under `verification-output/issue-461/`:
- `implementation-summary.md`
- `unit-test-output.txt`

## Test plan
- [x] `npm run test:unit -- tests/unit/cognito-auth-bypass.test.ts` → 9/9 passing
- [x] `npx tsc -p tsconfig.lambda.json --noEmit` → clean
- [x] Full unit suite — only the preexisting `certificate-issuance` failure remains; not caused by this PR
- [ ] Reviewer to confirm dual-guard invariant at both call sites
- [ ] Reviewer to confirm `isTestBypassEnabled()` reads env per-call (no module-scope cache reintroduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)