### PR TITLE
feat(api): restore bare learner-progress read routes for production parity (Issue #473)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -190,6 +190,18 @@ functions:
       - httpApi:
           path: /tasks/status/batch
           method: GET
+      # Server-authoritative learner-progress read endpoints (Issue #451 backend; restored for Layer 2 parity in #433/#473)
+      # Static bare paths — registered like /tasks/status: the /shadow base-path mapping strips the prefix,
+      # so both api.hedgehog.cloud/<route> (production) and api.hedgehog.cloud/shadow/<route> (shadow) reach the same HttpApi route.
+      - httpApi:
+          path: /course/status
+          method: GET
+      - httpApi:
+          path: /pathway/status
+          method: GET
+      - httpApi:
+          path: /module/progress
+          method: GET
       - httpApi:
           path: /admin/test/reset
           method: POST

--- a/src/api/lambda/completion.ts
+++ b/src/api/lambda/completion.ts
@@ -34,12 +34,17 @@ interface CourseProgressState {
 interface CourseMetadata {
   slug: string;
   modules: string[];
+  // Additive for Issue #451 — shadow aggregator reads title via this cache.
+  // CRM aggregators (calculateCourseCompletion/calculatePathwayCompletion) do not consume this field.
+  title?: string;
   // Future: optional: boolean[] for optional modules
 }
 
 interface PathwayMetadata {
   slug: string;
   courses: string[];
+  // Additive for Issue #451 — shadow aggregator reads title via this cache.
+  title?: string;
   // Future: optional: boolean[] for optional courses
 }
 
@@ -102,7 +107,8 @@ export function loadMetadataCache(): void {
           if (course.slug && Array.isArray(course.modules)) {
             METADATA_CACHE.courses.set(course.slug, {
               slug: course.slug,
-              modules: course.modules
+              modules: course.modules,
+              ...(typeof course.title === 'string' ? { title: course.title } : {})
             });
           }
         } catch (err) {
@@ -124,7 +130,8 @@ export function loadMetadataCache(): void {
           if (pathway.slug && Array.isArray(pathway.courses)) {
             METADATA_CACHE.pathways.set(pathway.slug, {
               slug: pathway.slug,
-              courses: pathway.courses
+              courses: pathway.courses,
+              ...(typeof pathway.title === 'string' ? { title: pathway.title } : {})
             });
           }
         } catch (err) {
@@ -156,6 +163,22 @@ export function getCourseMetadata(courseSlug: string): CourseMetadata | undefine
  */
 export function getPathwayMetadata(pathwaySlug: string): PathwayMetadata | undefined {
   return METADATA_CACHE.pathways.get(pathwaySlug);
+}
+
+/**
+ * Iterate all cached courses. Additive accessor for Issue #451;
+ * used by the shadow module-progress handler for breadcrumb resolution.
+ * Callers receive an alphabetically-sorted slug list for deterministic first-match.
+ */
+export function listAllCourseSlugs(): string[] {
+  return Array.from(METADATA_CACHE.courses.keys()).sort();
+}
+
+/**
+ * Iterate all cached pathways. Additive accessor for Issue #451.
+ */
+export function listAllPathwaySlugs(): string[] {
+  return Array.from(METADATA_CACHE.pathways.keys()).sort();
 }
 
 // ============================================================================

--- a/src/api/lambda/index.ts
+++ b/src/api/lambda/index.ts
@@ -39,6 +39,10 @@ import { handleTasksStatusBatch } from './tasks-status-batch.js';
 import { handleAdminTestReset } from './admin-test-reset.js';
 import { handleCertificateVerify } from './certificate-verify.js';
 import { handleCertificatesList } from './certificates-list.js';
+// Server-authoritative learner-progress read endpoints (Issue #451 backend, restored for production parity in #473)
+import { handleShadowCourseStatus } from './shadow-course-status.js';
+import { handleShadowPathwayStatus } from './shadow-pathway-status.js';
+import { handleShadowModuleProgress } from './shadow-module-progress.js';
 
 // Allowed origins for CORS
 const ALLOWED_ORIGINS = [
@@ -203,6 +207,13 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
     if (path.endsWith('/tasks/lab/attest') && method === 'POST') return await handleLabAttest(event);
     if (path.endsWith('/tasks/status/batch') && method === 'GET') return await handleTasksStatusBatch(event);
     if (path.endsWith('/tasks/status') && method === 'GET') return await handleTasksStatus(event);
+    // Server-authoritative learner-progress read endpoints (Issue #451 backend; restored for Layer 2 parity in #473)
+    //   Shadow: api.hedgehog.cloud/shadow/{course/status,pathway/status,module/progress} (base-path mapping leaves /shadow/ in rawPath)
+    //   Production: api.hedgehog.cloud/{course/status,pathway/status,module/progress} (direct route, no prefix)
+    //   Auth + stage gating reuse the same verifyCookieAuth path as /tasks/status — #461 hardening is inherited.
+    if (path.endsWith('/course/status') && method === 'GET') return await handleShadowCourseStatus(event);
+    if (path.endsWith('/pathway/status') && method === 'GET') return await handleShadowPathwayStatus(event);
+    if (path.endsWith('/module/progress') && method === 'GET') return await handleShadowModuleProgress(event);
     if (path.endsWith('/admin/test/reset') && method === 'POST') return await handleAdminTestReset(event);
     // Certificate verification endpoint:
     //   Shadow: api.hedgehog.cloud/shadow/certificate/:certId — base-path mapping leaves full path with /shadow/

--- a/src/api/lambda/shadow-aggregation.ts
+++ b/src/api/lambda/shadow-aggregation.ts
@@ -1,0 +1,439 @@
+/**
+ * Shadow-specific aggregation helper for the learner progress center
+ * (Issue #451, Phase 5A). Architecture-mandated single source of truth
+ * for denominator semantics on the shadow read and shadow write-cert paths.
+ *
+ * This module operates natively on shadow DynamoDB entity-completion records
+ * and encodes the task-bearing-denominator policy:
+ *   - A module is "task-bearing" iff its completion_tasks_json contains at
+ *     least one required quiz or lab_attestation task.
+ *   - Modules with no required task-bearing tasks are displayed with
+ *     module_status='no_tasks' and are excluded from course denominators.
+ *
+ * It MUST NOT call calculateCourseCompletion or calculatePathwayCompletion
+ * from ./completion — those are CRM-progress aggregators reading the
+ * hhl_progress_state contact property with different input shape and
+ * different denominator policy. The only allowed reuse from ./completion
+ * is the pure metadata cache loaders (loadMetadataCache, getCourseMetadata,
+ * getPathwayMetadata) which read content/*.json definitions.
+ *
+ * @see Issue #446, #448 (architecture), #449 (spec), #450 (test plan)
+ */
+
+import { DynamoDBDocumentClient, BatchGetCommand } from '@aws-sdk/lib-dynamodb';
+
+import { getHubSpotClient } from '../../shared/hubspot.js';
+import {
+  getCourseMetadata,
+  getPathwayMetadata,
+  loadMetadataCache,
+} from './completion.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ShadowModuleStatus = 'not_started' | 'in_progress' | 'complete' | 'no_tasks';
+export type ShadowCourseStatus = 'not_started' | 'in_progress' | 'complete';
+export type ShadowPathwayStatus = 'not_started' | 'in_progress' | 'complete';
+
+export interface ShadowModuleEntry {
+  module_slug: string;
+  module_title: string;
+  module_status: ShadowModuleStatus;
+  has_required_tasks: boolean;
+  tasks: Record<string, { status: string; score?: number; attempts?: number }>;
+}
+
+export interface ShadowCourseStatusResult {
+  course_slug: string;
+  course_title: string;
+  course_status: ShadowCourseStatus;
+  modules_completed: number;
+  modules_total: number;
+  modules: ShadowModuleEntry[];
+  course_cert_id: string | null;
+}
+
+export interface ShadowPathwayCourseEntry {
+  course_slug: string;
+  course_title: string;
+  course_status: ShadowCourseStatus;
+  modules_completed: number;
+  modules_total: number;
+  course_cert_id: string | null;
+}
+
+export interface ShadowPathwayStatusResult {
+  pathway_slug: string;
+  pathway_title: string;
+  pathway_status: ShadowPathwayStatus;
+  courses_completed: number;
+  courses_total: number;
+  courses: ShadowPathwayCourseEntry[];
+  pathway_cert_id: string | null;
+}
+
+export interface CompletionTaskDeclaration {
+  task_slug: string;
+  task_type: string;
+  required?: boolean;
+}
+
+interface ModuleRecord {
+  status?: string;
+  task_statuses?: Record<string, { status: string; score?: number; attempts?: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Title resolution — reuses the metadata cache extension in completion.ts
+// (additive title field on CourseMetadata / PathwayMetadata for Issue #451).
+// No duplicate filesystem loader.
+// ---------------------------------------------------------------------------
+
+export function getCourseTitle(courseSlug: string): string {
+  return getCourseMetadata(courseSlug)?.title ?? courseSlug;
+}
+
+export function getPathwayTitle(pathwaySlug: string): string {
+  return getPathwayMetadata(pathwaySlug)?.title ?? pathwaySlug;
+}
+
+// Ensure metadata cache is primed at module load (mirrors completion.ts pattern).
+loadMetadataCache();
+
+// ---------------------------------------------------------------------------
+// classifyModule — pure. Single source of truth for denominator semantics.
+// ---------------------------------------------------------------------------
+
+export function classifyModule(
+  moduleRecord: ModuleRecord | undefined,
+  completionTasks: CompletionTaskDeclaration[]
+): { module_status: ShadowModuleStatus; has_required_tasks: boolean } {
+  const hasRequiredTaskBearing = completionTasks.some(
+    (t) =>
+      (t.task_type === 'quiz' || t.task_type === 'lab_attestation') && t.required !== false
+  );
+
+  if (!hasRequiredTaskBearing) {
+    return { module_status: 'no_tasks', has_required_tasks: false };
+  }
+
+  if (!moduleRecord) {
+    return { module_status: 'not_started', has_required_tasks: true };
+  }
+
+  const raw = moduleRecord.status;
+  if (raw === 'in_progress' || raw === 'complete' || raw === 'not_started') {
+    return { module_status: raw, has_required_tasks: true };
+  }
+  return { module_status: 'not_started', has_required_tasks: true };
+}
+
+// ---------------------------------------------------------------------------
+// HubDB helper — fetch all module rows once; caller cross-references by path.
+// ---------------------------------------------------------------------------
+
+async function loadAllModuleRows(): Promise<any[]> {
+  const tableId = process.env.HUBDB_MODULES_TABLE_ID;
+  if (!tableId) {
+    throw new Error('Server configuration error');
+  }
+  const hubspot = getHubSpotClient();
+  const response = await (hubspot as any).cms.hubdb.rowsApi.getTableRows(
+    tableId,
+    undefined,
+    undefined,
+    undefined
+  );
+  return response?.results || [];
+}
+
+function parseCompletionTasks(row: any): CompletionTaskDeclaration[] {
+  const json = row?.values?.completion_tasks_json;
+  if (!json) return [];
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function moduleTitleFromRow(row: any, slug: string): string {
+  return (row?.name || row?.values?.hs_name || row?.values?.name || slug) as string;
+}
+
+function findModuleRow(rows: any[], slug: string): any | undefined {
+  const target = slug.toLowerCase();
+  return rows.find((r) => (r?.path || '').toLowerCase() === target);
+}
+
+// ---------------------------------------------------------------------------
+// BatchGet helpers — chunk at 100 items per AWS API limit.
+// ---------------------------------------------------------------------------
+
+const BATCH_GET_CHUNK = 100;
+
+async function batchGetModuleCompletions(
+  dynamo: DynamoDBDocumentClient,
+  tableName: string,
+  userId: string,
+  moduleSlugs: string[]
+): Promise<Map<string, ModuleRecord>> {
+  const out = new Map<string, ModuleRecord>();
+  if (moduleSlugs.length === 0) return out;
+
+  for (let i = 0; i < moduleSlugs.length; i += BATCH_GET_CHUNK) {
+    const chunk = moduleSlugs.slice(i, i + BATCH_GET_CHUNK);
+    const keys = chunk.map((s) => ({
+      PK: `USER#${userId}`,
+      SK: `COMPLETION#MODULE#${s}`,
+    }));
+    const res = await dynamo.send(
+      new BatchGetCommand({
+        RequestItems: { [tableName]: { Keys: keys } },
+      })
+    );
+    const items = res.Responses?.[tableName] || [];
+    for (const item of items) {
+      const sk = (item.SK as string) || '';
+      const slug = sk.replace('COMPLETION#MODULE#', '');
+      if (slug) out.set(slug, item as ModuleRecord);
+    }
+  }
+  return out;
+}
+
+async function batchGetCerts(
+  dynamo: DynamoDBDocumentClient,
+  tableName: string,
+  userId: string,
+  keys: Array<{ entityType: 'module' | 'course' | 'pathway'; entitySlug: string }>
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (keys.length === 0) return out;
+
+  for (let i = 0; i < keys.length; i += BATCH_GET_CHUNK) {
+    const chunk = keys.slice(i, i + BATCH_GET_CHUNK);
+    const ddbKeys = chunk.map((k) => ({
+      PK: `USER#${userId}`,
+      SK: `CERT#${k.entityType}#${k.entitySlug}`,
+    }));
+    try {
+      const res = await dynamo.send(
+        new BatchGetCommand({
+          RequestItems: { [tableName]: { Keys: ddbKeys } },
+        })
+      );
+      const items = res.Responses?.[tableName] || [];
+      for (const item of items) {
+        const sk = (item.SK as string) || '';
+        const parts = sk.split('#'); // CERT#<type>#<slug>
+        if (parts.length >= 3 && item.certId) {
+          out.set(`${parts[1]}#${parts.slice(2).join('#')}`, item.certId as string);
+        }
+      }
+    } catch (err: any) {
+      // Best-effort cert lookup: never fail the caller.
+      console.warn('[ShadowAggregation] cert BatchGet failed:', err?.message || err);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// computeShadowCourseStatus
+// ---------------------------------------------------------------------------
+
+export async function computeShadowCourseStatus(params: {
+  dynamo: DynamoDBDocumentClient;
+  userId: string;
+  courseSlug: string;
+}): Promise<ShadowCourseStatusResult | null> {
+  const { dynamo, userId, courseSlug } = params;
+
+  const courseMeta = getCourseMetadata(courseSlug);
+  if (!courseMeta) return null;
+
+  const ENTITY_COMPLETIONS_TABLE = process.env.ENTITY_COMPLETIONS_TABLE;
+  if (!ENTITY_COMPLETIONS_TABLE) {
+    throw new Error('Server configuration error');
+  }
+
+  const moduleSlugs = courseMeta.modules;
+  const moduleRows = await loadAllModuleRows();
+  const completions = await batchGetModuleCompletions(
+    dynamo,
+    ENTITY_COMPLETIONS_TABLE,
+    userId,
+    moduleSlugs
+  );
+
+  // Certificate lookups: course-level + per-module
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  let certs = new Map<string, string>();
+  if (CERTS_TABLE) {
+    const certKeys: Array<{ entityType: 'module' | 'course'; entitySlug: string }> = [
+      { entityType: 'course', entitySlug: courseSlug },
+    ];
+    certs = await batchGetCerts(dynamo, CERTS_TABLE, userId, certKeys);
+  }
+
+  const entries: ShadowModuleEntry[] = moduleSlugs.map((slug) => {
+    const row = findModuleRow(moduleRows, slug);
+    const completionTasks = row ? parseCompletionTasks(row) : [];
+    const record = completions.get(slug);
+    const { module_status, has_required_tasks } = classifyModule(record, completionTasks);
+
+    const tasks: Record<string, { status: string; score?: number; attempts?: number }> = {};
+    if (record?.task_statuses) {
+      for (const [k, v] of Object.entries(record.task_statuses)) {
+        tasks[k] = { status: v.status };
+        if (v.score !== undefined) tasks[k].score = Number(v.score);
+        if (v.attempts !== undefined) tasks[k].attempts = Number(v.attempts);
+      }
+    }
+
+    return {
+      module_slug: slug,
+      module_title: row ? moduleTitleFromRow(row, slug) : slug,
+      module_status,
+      has_required_tasks,
+      tasks,
+    };
+  });
+
+  const taskBearing = entries.filter((e) => e.has_required_tasks);
+  const modules_total = taskBearing.length;
+  const modules_completed = taskBearing.filter((e) => e.module_status === 'complete').length;
+
+  let course_status: ShadowCourseStatus;
+  if (modules_total > 0 && modules_completed === modules_total) {
+    course_status = 'complete';
+  } else {
+    const anyRecord = taskBearing.some((e) => e.module_status !== 'not_started');
+    course_status = anyRecord ? 'in_progress' : 'not_started';
+  }
+
+  return {
+    course_slug: courseSlug,
+    course_title: getCourseTitle(courseSlug),
+    course_status,
+    modules_completed,
+    modules_total,
+    modules: entries,
+    course_cert_id: certs.get(`course#${courseSlug}`) ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// computeShadowPathwayStatus
+// ---------------------------------------------------------------------------
+
+export async function computeShadowPathwayStatus(params: {
+  dynamo: DynamoDBDocumentClient;
+  userId: string;
+  pathwaySlug: string;
+}): Promise<ShadowPathwayStatusResult | null> {
+  const { dynamo, userId, pathwaySlug } = params;
+
+  const pathwayMeta = getPathwayMetadata(pathwaySlug);
+  if (!pathwayMeta) return null;
+
+  const ENTITY_COMPLETIONS_TABLE = process.env.ENTITY_COMPLETIONS_TABLE;
+  if (!ENTITY_COMPLETIONS_TABLE) {
+    throw new Error('Server configuration error');
+  }
+
+  const courseSlugs = pathwayMeta.courses;
+
+  // Collect all module slugs across all courses — one BatchGet covers them.
+  const allModuleSlugs: string[] = [];
+  const courseToModules = new Map<string, string[]>();
+  for (const cs of courseSlugs) {
+    const cm = getCourseMetadata(cs);
+    const modules = cm ? cm.modules : [];
+    courseToModules.set(cs, modules);
+    for (const m of modules) if (!allModuleSlugs.includes(m)) allModuleSlugs.push(m);
+  }
+
+  const moduleRows = await loadAllModuleRows();
+  const completions = await batchGetModuleCompletions(
+    dynamo,
+    ENTITY_COMPLETIONS_TABLE,
+    userId,
+    allModuleSlugs
+  );
+
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  let certs = new Map<string, string>();
+  if (CERTS_TABLE) {
+    const certKeys: Array<{ entityType: 'course' | 'pathway'; entitySlug: string }> = [
+      { entityType: 'pathway', entitySlug: pathwaySlug },
+      ...courseSlugs.map((s) => ({ entityType: 'course' as const, entitySlug: s })),
+    ];
+    certs = await batchGetCerts(dynamo, CERTS_TABLE, userId, certKeys);
+  }
+
+  const courseEntries: ShadowPathwayCourseEntry[] = courseSlugs.map((cs) => {
+    const modules = courseToModules.get(cs) || [];
+
+    const taskBearingCount = modules.reduce((acc, slug) => {
+      const row = findModuleRow(moduleRows, slug);
+      const tasks = row ? parseCompletionTasks(row) : [];
+      const c = classifyModule(completions.get(slug), tasks);
+      return c.has_required_tasks ? acc + 1 : acc;
+    }, 0);
+
+    const completedCount = modules.reduce((acc, slug) => {
+      const row = findModuleRow(moduleRows, slug);
+      const tasks = row ? parseCompletionTasks(row) : [];
+      const c = classifyModule(completions.get(slug), tasks);
+      return c.has_required_tasks && c.module_status === 'complete' ? acc + 1 : acc;
+    }, 0);
+
+    let course_status: ShadowCourseStatus;
+    if (taskBearingCount > 0 && completedCount === taskBearingCount) {
+      course_status = 'complete';
+    } else {
+      const anyRecord = modules.some((slug) => {
+        const row = findModuleRow(moduleRows, slug);
+        const tasks = row ? parseCompletionTasks(row) : [];
+        const c = classifyModule(completions.get(slug), tasks);
+        return c.has_required_tasks && c.module_status !== 'not_started';
+      });
+      course_status = anyRecord ? 'in_progress' : 'not_started';
+    }
+
+    return {
+      course_slug: cs,
+      course_title: getCourseTitle(cs),
+      course_status,
+      modules_completed: completedCount,
+      modules_total: taskBearingCount,
+      course_cert_id: certs.get(`course#${cs}`) ?? null,
+    };
+  });
+
+  const courses_total = courseEntries.length;
+  const courses_completed = courseEntries.filter((c) => c.course_status === 'complete').length;
+
+  let pathway_status: ShadowPathwayStatus;
+  if (courses_total > 0 && courses_completed === courses_total) {
+    pathway_status = 'complete';
+  } else {
+    const anyProgress = courseEntries.some((c) => c.course_status !== 'not_started');
+    pathway_status = anyProgress ? 'in_progress' : 'not_started';
+  }
+
+  return {
+    pathway_slug: pathwaySlug,
+    pathway_title: getPathwayTitle(pathwaySlug),
+    pathway_status,
+    courses_completed,
+    courses_total,
+    courses: courseEntries,
+    pathway_cert_id: certs.get(`pathway#${pathwaySlug}`) ?? null,
+  };
+}

--- a/src/api/lambda/shadow-course-status.ts
+++ b/src/api/lambda/shadow-course-status.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /shadow/course/status (handler-visible path: /course/status)
+ *
+ * Shadow-only read endpoint: returns course-level progress with per-module
+ * breakdown using shadow aggregation semantics. Consumed by the shadow
+ * course detail page and by My Learning for course cards.
+ *
+ * Shadow guard: 403 when APP_STAGE is neither 'shadow' nor 'production'.
+ * Auth: httpOnly cookie (hhl_access_token) verified against Cognito JWKS.
+ * Read-only: no DynamoDB writes.
+ *
+ * @see Issue #451 (Phase 5A), Spec #449 §2.1, Test plan #450 §2.2.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+import { verifyCookieAuth } from './cognito-auth.js';
+import { computeShadowCourseStatus } from './shadow-aggregation.js';
+
+let _dynamoClient: DynamoDBDocumentClient | undefined;
+function getDynamo(): DynamoDBDocumentClient {
+  if (!_dynamoClient) {
+    const region = process.env.COGNITO_REGION || process.env.AWS_REGION || 'us-west-2';
+    _dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+  }
+  return _dynamoClient;
+}
+
+const ALLOWED_ORIGINS = ['https://hedgehog.cloud', 'https://www.hedgehog.cloud'];
+const HUBSPOT_CDN_PATTERN = /^https:\/\/.*\.hubspotusercontent(?:-na1|00|20|30|40)\.net$/;
+
+function getAllowedOrigin(origin: string | undefined): string {
+  if (!origin) return 'https://hedgehog.cloud';
+  if (ALLOWED_ORIGINS.includes(origin) || HUBSPOT_CDN_PATTERN.test(origin)) return origin;
+  return 'https://hedgehog.cloud';
+}
+
+function jsonResp(status: number, body: unknown, origin?: string) {
+  return {
+    statusCode: status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': getAllowedOrigin(origin),
+      'Access-Control-Allow-Credentials': 'true',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+export async function handleShadowCourseStatus(event: any) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+
+  const stage = process.env.APP_STAGE;
+  if (stage !== 'shadow' && stage !== 'production') {
+    return jsonResp(403, { error: 'Not available in this environment' }, origin);
+  }
+
+  let userId: string;
+  try {
+    const auth = await verifyCookieAuth(event);
+    userId = auth.userId;
+  } catch {
+    return jsonResp(401, { error: 'Unauthorized' }, origin);
+  }
+
+  const course_slug = (event.queryStringParameters?.course_slug || '').trim();
+  if (!course_slug) {
+    return jsonResp(400, { error: 'course_slug query parameter is required' }, origin);
+  }
+
+  if (!process.env.ENTITY_COMPLETIONS_TABLE) {
+    return jsonResp(500, { error: 'Server configuration error' }, origin);
+  }
+
+  try {
+    const result = await computeShadowCourseStatus({
+      dynamo: getDynamo(),
+      userId,
+      courseSlug: course_slug,
+    });
+    if (!result) {
+      return jsonResp(400, { error: 'course not found' }, origin);
+    }
+    return jsonResp(200, result, origin);
+  } catch (err: any) {
+    if (err?.message === 'Server configuration error') {
+      return jsonResp(500, { error: 'Server configuration error' }, origin);
+    }
+    console.error('[ShadowCourseStatus] error:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to read course status' }, origin);
+  }
+}

--- a/src/api/lambda/shadow-module-progress.ts
+++ b/src/api/lambda/shadow-module-progress.ts
@@ -1,0 +1,460 @@
+/**
+ * GET /shadow/module/progress (handler-visible path: /module/progress)
+ *
+ * Shadow-only read endpoint: returns the learner-record view for a module —
+ * overall module status, per-task state with best_score/attempt_count, and
+ * attempt history with per-quiz-attempt answer review.
+ *
+ * Shadow guard: 403 when APP_STAGE is neither 'shadow' nor 'production'.
+ * Auth: httpOnly cookie (hhl_access_token) verified against Cognito JWKS.
+ *
+ * Sensitive-handling rules (spec §2.4):
+ *   - Correct answers are NEVER serialized.
+ *   - learner_identity snapshots from attempt records are NEVER serialized.
+ *   - Schema drift (deleted question ids) → {is_correct:null, question_text:null, schema_drift:true}.
+ *   - Lab attestation attempts carry no answer_review.
+ *   - Ownership-scoped: Query PK is always USER#<cookieUserId>; query-param
+ *     overrides are ignored.
+ *
+ * @see Issue #451 (Phase 5A), Spec #449 §2.3, §2.4, Test plan #450 §2.4, §2.5.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+
+import { getHubSpotClient } from '../../shared/hubspot.js';
+import { verifyCookieAuth } from './cognito-auth.js';
+import {
+  classifyModule,
+  type CompletionTaskDeclaration,
+} from './shadow-aggregation.js';
+import {
+  getCourseMetadata,
+  getPathwayMetadata,
+  listAllCourseSlugs,
+  listAllPathwaySlugs,
+  loadMetadataCache,
+} from './completion.js';
+
+// Ensure metadata is loaded for breadcrumb resolution.
+loadMetadataCache();
+
+// ---------------------------------------------------------------------------
+// Lazy DynamoDB client
+// ---------------------------------------------------------------------------
+
+let _dynamoClient: DynamoDBDocumentClient | undefined;
+function getDynamo(): DynamoDBDocumentClient {
+  if (!_dynamoClient) {
+    const region = process.env.COGNITO_REGION || process.env.AWS_REGION || 'us-west-2';
+    _dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+  }
+  return _dynamoClient;
+}
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
+
+const ALLOWED_ORIGINS = ['https://hedgehog.cloud', 'https://www.hedgehog.cloud'];
+const HUBSPOT_CDN_PATTERN = /^https:\/\/.*\.hubspotusercontent(?:-na1|00|20|30|40)\.net$/;
+
+function getAllowedOrigin(origin: string | undefined): string {
+  if (!origin) return 'https://hedgehog.cloud';
+  if (ALLOWED_ORIGINS.includes(origin) || HUBSPOT_CDN_PATTERN.test(origin)) return origin;
+  return 'https://hedgehog.cloud';
+}
+
+function jsonResp(status: number, body: unknown, origin?: string) {
+  return {
+    statusCode: status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': getAllowedOrigin(origin),
+      'Access-Control-Allow-Credentials': 'true',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Breadcrumb resolution — uses the metadata cache from completion.ts
+// (titles are available via the additive title field on CourseMetadata /
+// PathwayMetadata, loaded during loadMetadataCache).
+// ---------------------------------------------------------------------------
+
+function resolveBreadcrumbs(moduleSlug: string): {
+  parent_course_slug: string | null;
+  parent_course_title: string | null;
+  parent_pathway_slug: string | null;
+  parent_pathway_title: string | null;
+} {
+  let parent_course_slug: string | null = null;
+  let parent_course_title: string | null = null;
+  for (const cs of listAllCourseSlugs()) {
+    const cm = getCourseMetadata(cs);
+    if (cm && cm.modules.includes(moduleSlug)) {
+      parent_course_slug = cs;
+      parent_course_title = cm.title ?? cs;
+      break;
+    }
+  }
+
+  let parent_pathway_slug: string | null = null;
+  let parent_pathway_title: string | null = null;
+  if (parent_course_slug) {
+    for (const ps of listAllPathwaySlugs()) {
+      const pm = getPathwayMetadata(ps);
+      if (pm && pm.courses.includes(parent_course_slug)) {
+        parent_pathway_slug = ps;
+        parent_pathway_title = pm.title ?? ps;
+        break;
+      }
+    }
+  }
+
+  return {
+    parent_course_slug,
+    parent_course_title,
+    parent_pathway_slug,
+    parent_pathway_title,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface QuizQuestion {
+  id: string;
+  question?: string;
+  text?: string;
+  label?: string;
+  correct_answer?: string;
+  answer_options?: Array<{ id: string; text?: string; label?: string }>;
+}
+
+interface QuizSchema {
+  quiz_id?: string;
+  passing_score?: number;
+  questions: QuizQuestion[];
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleShadowModuleProgress(event: any) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+
+  const stage = process.env.APP_STAGE;
+  if (stage !== 'shadow' && stage !== 'production') {
+    return jsonResp(403, { error: 'Not available in this environment' }, origin);
+  }
+
+  let userId: string;
+  try {
+    const auth = await verifyCookieAuth(event);
+    userId = auth.userId;
+  } catch {
+    return jsonResp(401, { error: 'Unauthorized' }, origin);
+  }
+
+  const module_slug = (event.queryStringParameters?.module_slug || '').trim();
+  if (!module_slug) {
+    return jsonResp(400, { error: 'module_slug query parameter is required' }, origin);
+  }
+
+  // include_attempts (default true)
+  const includeAttemptsRaw = event.queryStringParameters?.include_attempts;
+  const include_attempts = includeAttemptsRaw !== 'false';
+
+  // attempts_limit (default 20, 1..50)
+  let attempts_limit = 20;
+  if (event.queryStringParameters?.attempts_limit !== undefined) {
+    const parsed = Number(event.queryStringParameters.attempts_limit);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > 50) {
+      return jsonResp(400, { error: 'attempts_limit must be between 1 and 50' }, origin);
+    }
+    attempts_limit = parsed;
+  }
+
+  const TASK_RECORDS_TABLE = process.env.TASK_RECORDS_TABLE;
+  const TASK_ATTEMPTS_TABLE = process.env.TASK_ATTEMPTS_TABLE;
+  const ENTITY_COMPLETIONS_TABLE = process.env.ENTITY_COMPLETIONS_TABLE;
+  const CERTS_TABLE = process.env.CERTIFICATES_TABLE;
+  const MODULES_TABLE_ID = process.env.HUBDB_MODULES_TABLE_ID;
+  if (!TASK_RECORDS_TABLE || !TASK_ATTEMPTS_TABLE || !ENTITY_COMPLETIONS_TABLE || !MODULES_TABLE_ID) {
+    return jsonResp(500, { error: 'Server configuration error' }, origin);
+  }
+
+  const dynamo = getDynamo();
+
+  // --- Step 1: load HubDB module row (for completion tasks + quiz schema + title) ---
+  let completionTasks: CompletionTaskDeclaration[] = [];
+  let quizSchema: QuizSchema | null = null;
+  let moduleTitle = module_slug;
+  try {
+    const hubspot = getHubSpotClient();
+    const rowsResponse = await (hubspot as any).cms.hubdb.rowsApi.getTableRows(
+      MODULES_TABLE_ID,
+      undefined,
+      undefined,
+      undefined
+    );
+    const rows: any[] = rowsResponse?.results || [];
+    const moduleRow = rows.find(
+      (r: any) => (r.path || '').toLowerCase() === module_slug.toLowerCase()
+    );
+    if (!moduleRow) {
+      return jsonResp(400, { error: 'module not found' }, origin);
+    }
+    moduleTitle = (moduleRow.name || moduleRow.values?.hs_name || moduleRow.values?.name || module_slug) as string;
+    if (moduleRow.values?.completion_tasks_json) {
+      try {
+        const parsed = JSON.parse(moduleRow.values.completion_tasks_json);
+        if (Array.isArray(parsed)) completionTasks = parsed;
+      } catch {
+        /* ignore */
+      }
+    }
+    if (moduleRow.values?.quiz_schema_json) {
+      try {
+        quizSchema = JSON.parse(moduleRow.values.quiz_schema_json);
+      } catch {
+        quizSchema = null;
+      }
+    }
+  } catch (err: any) {
+    console.error('[ShadowModuleProgress] HubDB fetch error:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to read module configuration' }, origin);
+  }
+
+  // --- Step 2: entity-completion record (overall module_status) ---
+  let moduleRecord: { status?: string; task_statuses?: Record<string, any> } | undefined;
+  try {
+    const res = await dynamo.send(
+      new GetCommand({
+        TableName: ENTITY_COMPLETIONS_TABLE,
+        Key: { PK: `USER#${userId}`, SK: `COMPLETION#MODULE#${module_slug}` },
+      })
+    );
+    if (res.Item) moduleRecord = res.Item as any;
+  } catch (err: any) {
+    console.error('[ShadowModuleProgress] entity-completion read failed:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to read module progress' }, origin);
+  }
+
+  const { module_status, has_required_tasks } = classifyModule(moduleRecord, completionTasks);
+
+  // --- Step 3: task-records for this module (per-task best_score/attempts) ---
+  interface TaskRecordEntry {
+    task_slug: string;
+    task_type?: string;
+    status?: string;
+    best_score?: number;
+    attempt_count?: number;
+    last_attempt_at?: string;
+  }
+  const taskRecordsMap = new Map<string, TaskRecordEntry>();
+  try {
+    const res = await dynamo.send(
+      new QueryCommand({
+        TableName: TASK_RECORDS_TABLE,
+        KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+        ExpressionAttributeValues: {
+          ':pk': `USER#${userId}`,
+          ':skPrefix': `TASK#MODULE#${module_slug}#`,
+        },
+      })
+    );
+    for (const item of res.Items || []) {
+      const sk = (item.SK as string) || '';
+      const parts = sk.split('#');
+      const taskSlug = parts[parts.length - 1];
+      if (!taskSlug) continue;
+      taskRecordsMap.set(taskSlug, {
+        task_slug: taskSlug,
+        task_type: item.task_type as string | undefined,
+        status: item.status as string | undefined,
+        best_score: item.best_score !== undefined ? Number(item.best_score) : undefined,
+        attempt_count: item.attempt_count !== undefined ? Number(item.attempt_count) : undefined,
+        last_attempt_at: item.last_attempt_at as string | undefined,
+      });
+    }
+  } catch (err: any) {
+    console.error('[ShadowModuleProgress] task-records query failed:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to read task records' }, origin);
+  }
+
+  // Build tasks[] array in declaration order. Knowledge-checks with records are included; others may have no record.
+  const tasks = completionTasks.map((decl) => {
+    const record = taskRecordsMap.get(decl.task_slug);
+    const entry: any = {
+      task_slug: decl.task_slug,
+      task_type: decl.task_type,
+      task_title: (decl as any).label || (decl as any).task_title || decl.task_slug,
+      required: decl.required !== false,
+      status: record?.status ?? 'not_started',
+    };
+    if (record?.best_score !== undefined) entry.best_score = record.best_score;
+    if (record?.attempt_count !== undefined) entry.attempt_count = record.attempt_count;
+    if (record?.last_attempt_at) entry.last_attempt_at = record.last_attempt_at;
+    if (decl.task_type === 'quiz' && quizSchema?.passing_score !== undefined) {
+      entry.passing_score = quizSchema.passing_score;
+    }
+    return entry;
+  });
+
+  // --- Step 4: attempts[] (optional) ---
+  let attempts: any[] | undefined;
+  if (include_attempts) {
+    try {
+      const res = await dynamo.send(
+        new QueryCommand({
+          TableName: TASK_ATTEMPTS_TABLE,
+          KeyConditionExpression: 'PK = :pk AND begins_with(SK, :skPrefix)',
+          ExpressionAttributeValues: {
+            ':pk': `USER#${userId}`,
+            ':skPrefix': `ATTEMPT#MODULE#${module_slug}#`,
+          },
+          ScanIndexForward: false,
+          Limit: attempts_limit,
+        })
+      );
+      attempts = (res.Items || []).map((item: any) => buildAttemptEntry(item, quizSchema));
+    } catch (err: any) {
+      console.error('[ShadowModuleProgress] task-attempts query failed:', err?.message || err);
+      return jsonResp(500, { error: 'Failed to read attempt history' }, origin);
+    }
+  }
+
+  // --- Step 5: module_cert_id (best-effort) ---
+  let module_cert_id: string | null = null;
+  if (CERTS_TABLE) {
+    try {
+      const res = await dynamo.send(
+        new GetCommand({
+          TableName: CERTS_TABLE,
+          Key: { PK: `USER#${userId}`, SK: `CERT#module#${module_slug}` },
+          ProjectionExpression: 'certId',
+        })
+      );
+      if (res.Item?.certId) module_cert_id = res.Item.certId as string;
+    } catch (err: any) {
+      console.warn('[ShadowModuleProgress] cert lookup failed:', err?.message || err);
+    }
+  }
+
+  const breadcrumbs = resolveBreadcrumbs(module_slug);
+
+  const responseBody: any = {
+    module_slug,
+    module_title: moduleTitle,
+    module_status,
+    has_required_tasks,
+    tasks,
+    module_cert_id,
+    breadcrumbs,
+  };
+  if (include_attempts) responseBody.attempts = attempts;
+
+  return jsonResp(200, responseBody, origin);
+}
+
+// ---------------------------------------------------------------------------
+// Attempt entry builder (pure)
+//
+// Sensitive-handling rules enforced here:
+//   - learner_identity, answers (raw quiz submitted pairs), correct_answer
+//     are ALL excluded from the output.
+//   - Quiz attempts produce answer_review[] using the CURRENT quiz schema.
+//   - Lab attestations produce no answer_review.
+// ---------------------------------------------------------------------------
+
+function buildAttemptEntry(item: any, quizSchema: QuizSchema | null): any {
+  const sk = (item.SK as string) || '';
+  const taskType = item.task_type as string | undefined;
+  let outcome: string;
+  if (taskType === 'quiz') outcome = item.pass ? 'passed' : 'failed';
+  else if (taskType === 'lab_attestation') outcome = 'attested';
+  else outcome = 'recorded';
+
+  // Extract task_slug from SK: ATTEMPT#MODULE#<module>#<task>#<timestamp>
+  const parts = sk.split('#');
+  const task_slug = parts.length >= 5 ? parts[3] : '';
+
+  const entry: any = {
+    attempt_id: sk,
+    task_slug,
+    task_type: taskType,
+    attempted_at: item.attempted_at || item.attested_at,
+    outcome,
+  };
+
+  if (taskType === 'quiz') {
+    if (item.score !== undefined) entry.score = Number(item.score);
+    entry.answer_review = buildAnswerReview(item.answers, quizSchema);
+  }
+  // Lab attestations: no answer_review by contract.
+
+  return entry;
+}
+
+interface AnswerReviewEntry {
+  question_id: string;
+  question_text: string | null;
+  submitted_answer_id: string | null;
+  submitted_answer_text: string | null;
+  is_correct: boolean | null;
+  schema_drift: boolean;
+}
+
+function questionText(q: QuizQuestion | undefined): string | null {
+  if (!q) return null;
+  return q.question ?? q.text ?? q.label ?? null;
+}
+
+function optionText(q: QuizQuestion | undefined, answerId: string | undefined): string | null {
+  if (!q || !answerId) return answerId ?? null;
+  const opt = (q.answer_options || []).find((o) => o.id === answerId);
+  return opt?.text ?? opt?.label ?? answerId;
+}
+
+function buildAnswerReview(
+  submittedAnswers: Array<{ id: string; value: string }> | undefined,
+  quizSchema: QuizSchema | null
+): AnswerReviewEntry[] {
+  const answers = Array.isArray(submittedAnswers) ? submittedAnswers : [];
+  return answers.map((ans): AnswerReviewEntry => {
+    const q = quizSchema?.questions.find((x) => x.id === ans.id);
+    if (!q) {
+      // Schema drift: question no longer exists in the current schema.
+      // Preserve the learner's submitted answer identifier/value — NEVER
+      // substitute the question id.
+      return {
+        question_id: ans.id,
+        question_text: null,
+        submitted_answer_id: ans.value ?? null,
+        submitted_answer_text: ans.value ?? null,
+        is_correct: null,
+        schema_drift: true,
+      };
+    }
+    const is_correct = q.correct_answer !== undefined
+      ? ans.value === q.correct_answer
+      : null;
+    return {
+      question_id: ans.id,
+      question_text: questionText(q),
+      submitted_answer_id: ans.value ?? null,
+      submitted_answer_text: optionText(q, ans.value) ?? ans.value ?? null,
+      is_correct,
+      schema_drift: false,
+    };
+  });
+}

--- a/src/api/lambda/shadow-pathway-status.ts
+++ b/src/api/lambda/shadow-pathway-status.ts
@@ -1,0 +1,93 @@
+/**
+ * GET /shadow/pathway/status (handler-visible path: /pathway/status)
+ *
+ * Shadow-only read endpoint: returns pathway-level progress with per-course
+ * rollup using shadow aggregation semantics. Consumed by the shadow pathway
+ * detail page and by My Learning for pathway cards.
+ *
+ * Shadow guard: 403 when APP_STAGE is neither 'shadow' nor 'production'.
+ * Auth: httpOnly cookie (hhl_access_token) verified against Cognito JWKS.
+ * Read-only: no DynamoDB writes.
+ *
+ * @see Issue #451 (Phase 5A), Spec #449 §2.2, Test plan #450 §2.3.
+ */
+
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+import { verifyCookieAuth } from './cognito-auth.js';
+import { computeShadowPathwayStatus } from './shadow-aggregation.js';
+
+let _dynamoClient: DynamoDBDocumentClient | undefined;
+function getDynamo(): DynamoDBDocumentClient {
+  if (!_dynamoClient) {
+    const region = process.env.COGNITO_REGION || process.env.AWS_REGION || 'us-west-2';
+    _dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+  }
+  return _dynamoClient;
+}
+
+const ALLOWED_ORIGINS = ['https://hedgehog.cloud', 'https://www.hedgehog.cloud'];
+const HUBSPOT_CDN_PATTERN = /^https:\/\/.*\.hubspotusercontent(?:-na1|00|20|30|40)\.net$/;
+
+function getAllowedOrigin(origin: string | undefined): string {
+  if (!origin) return 'https://hedgehog.cloud';
+  if (ALLOWED_ORIGINS.includes(origin) || HUBSPOT_CDN_PATTERN.test(origin)) return origin;
+  return 'https://hedgehog.cloud';
+}
+
+function jsonResp(status: number, body: unknown, origin?: string) {
+  return {
+    statusCode: status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': getAllowedOrigin(origin),
+      'Access-Control-Allow-Credentials': 'true',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+export async function handleShadowPathwayStatus(event: any) {
+  const origin = event.headers?.origin || event.headers?.Origin;
+
+  const stage = process.env.APP_STAGE;
+  if (stage !== 'shadow' && stage !== 'production') {
+    return jsonResp(403, { error: 'Not available in this environment' }, origin);
+  }
+
+  let userId: string;
+  try {
+    const auth = await verifyCookieAuth(event);
+    userId = auth.userId;
+  } catch {
+    return jsonResp(401, { error: 'Unauthorized' }, origin);
+  }
+
+  const pathway_slug = (event.queryStringParameters?.pathway_slug || '').trim();
+  if (!pathway_slug) {
+    return jsonResp(400, { error: 'pathway_slug query parameter is required' }, origin);
+  }
+
+  if (!process.env.ENTITY_COMPLETIONS_TABLE) {
+    return jsonResp(500, { error: 'Server configuration error' }, origin);
+  }
+
+  try {
+    const result = await computeShadowPathwayStatus({
+      dynamo: getDynamo(),
+      userId,
+      pathwaySlug: pathway_slug,
+    });
+    if (!result) {
+      return jsonResp(400, { error: 'pathway not found' }, origin);
+    }
+    return jsonResp(200, result, origin);
+  } catch (err: any) {
+    if (err?.message === 'Server configuration error') {
+      return jsonResp(500, { error: 'Server configuration error' }, origin);
+    }
+    console.error('[ShadowPathwayStatus] error:', err?.message || err);
+    return jsonResp(500, { error: 'Failed to read pathway status' }, origin);
+  }
+}

--- a/tests/unit/shadow-aggregation-parity.test.ts
+++ b/tests/unit/shadow-aggregation-parity.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Parity regression — architecture-mandated by Phase 2 and Phase 3 §7.3.
+ * Issue #451, Phase 5A. Test plan §2.8.
+ *
+ * Exercises the BACKEND RESPONSE SHAPE as consumed by the dashboard and
+ * course-detail surfaces — not helper internals.
+ *
+ * The My Learning dashboard is specified to fetch GET /shadow/pathway/status
+ * for each enrolled pathway and render the per-course rollups.
+ * The course detail page is specified to fetch GET /shadow/course/status
+ * for the visible course.
+ * Against the same DynamoDB state, both surfaces must agree on
+ *   - modules_completed
+ *   - modules_total
+ *   - course_status
+ * for the same course.
+ *
+ * This test simulates a dashboard fetch-and-render pipeline:
+ *   1. Seed a shared DynamoDB state for one learner (half of foundations
+ *      complete, other pathway courses untouched).
+ *   2. Invoke handleShadowPathwayStatus to produce the JSON payload the
+ *      dashboard would consume; parse its response body.
+ *   3. Invoke handleShadowCourseStatus for the same course; parse its body.
+ *   4. Locate the matching per-course entry in the pathway response.
+ *   5. Assert that the three fields match exactly.
+ *
+ * If the dashboard's rollup ever drifts from the course-detail surface,
+ * this test fails — at the wire-contract level, not the helper-call level.
+ */
+
+import { handleShadowCourseStatus } from '../../src/api/lambda/shadow-course-status';
+import { handleShadowPathwayStatus } from '../../src/api/lambda/shadow-pathway-status';
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+jest.mock('../../src/api/lambda/cognito-auth', () => ({
+  verifyCookieAuth: jest.fn(),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  BatchGetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'BatchGetCommand' })),
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { verifyCookieAuth } from '../../src/api/lambda/cognito-auth';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+const mockVerifyCookieAuth = verifyCookieAuth as jest.MockedFunction<typeof verifyCookieAuth>;
+
+const AUTH_RESULT = { userId: 'parity-user', email: 'parity@example.com', decoded: {} as any };
+const COURSE_SLUG = 'network-like-hyperscaler-foundations';
+const PATHWAY_SLUG = 'network-like-hyperscaler';
+
+const ENTITY_COMPLETIONS_TABLE = 'entity-completions-shadow';
+const CERTS_TABLE = 'certificates-shadow';
+
+const ALL_MODULES = [
+  // foundations (2 complete, 2 not-started per shared state)
+  'fabric-operations-welcome',
+  'fabric-operations-how-it-works',
+  'fabric-operations-mastering-interfaces',
+  'fabric-operations-foundations-recap',
+  // provisioning
+  'fabric-operations-vpc-provisioning',
+  'fabric-operations-vpc-attachments',
+  'fabric-operations-connectivity-validation',
+  'fabric-operations-decommission-cleanup',
+  // observability
+  'fabric-operations-telemetry-overview',
+  'fabric-operations-dashboard-interpretation',
+  'fabric-operations-events-status',
+  'fabric-operations-pre-support-diagnostics',
+  // troubleshooting
+  'fabric-operations-troubleshooting-framework',
+  'fabric-operations-diagnosis-lab',
+  'fabric-operations-rollback-recovery',
+  'fabric-operations-post-incident-review',
+];
+
+// Shared state: exactly two foundations modules complete; no other shadow state.
+const COMPLETED_SKS = new Set([
+  'COMPLETION#MODULE#fabric-operations-welcome',
+  'COMPLETION#MODULE#fabric-operations-how-it-works',
+]);
+
+function buildHubspotMock() {
+  const modulesRows = ALL_MODULES.map((slug) => ({
+    path: slug,
+    name: slug,
+    values: {
+      hs_name: slug,
+      completion_tasks_json: JSON.stringify([
+        { task_slug: 'quiz-1', task_type: 'quiz', required: true },
+      ]),
+    },
+  }));
+  return {
+    cms: {
+      hubdb: {
+        rowsApi: {
+          getTableRows: jest.fn().mockResolvedValue({ results: modulesRows }),
+        },
+      },
+    },
+  } as any;
+}
+
+function buildDynamoImpl() {
+  return (cmd: any) => {
+    const tag = cmd?._tag;
+    const input = cmd?.input;
+    if (tag === 'BatchGetCommand') {
+      const req = input.RequestItems || {};
+      const resp: any = { Responses: {} };
+      for (const [table, spec] of Object.entries(req)) {
+        const keys = (spec as any).Keys as Array<{ PK: string; SK: string }>;
+        if (table === ENTITY_COMPLETIONS_TABLE) {
+          resp.Responses[table] = keys
+            .filter((k) => COMPLETED_SKS.has(k.SK))
+            .map((k) => ({ PK: k.PK, SK: k.SK, status: 'complete', task_statuses: {} }));
+        } else if (table === CERTS_TABLE) {
+          // No certs yet
+          resp.Responses[table] = [];
+        } else {
+          resp.Responses[table] = [];
+        }
+      }
+      return Promise.resolve(resp);
+    }
+    return Promise.resolve({});
+  };
+}
+
+function makeEvent(qs: Record<string, string>) {
+  return { headers: { origin: 'https://hedgehog.cloud' }, cookies: [], queryStringParameters: qs };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.APP_STAGE = 'shadow';
+  process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+  process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  process.env.HUBDB_MODULES_TABLE_ID = 'modules-table';
+  mockVerifyCookieAuth.mockResolvedValue(AUTH_RESULT);
+  mockGetHubSpotClient.mockImplementation(() => buildHubspotMock());
+  mockDynamoSend.mockImplementation(buildDynamoImpl());
+});
+
+afterEach(() => {
+  delete process.env.APP_STAGE;
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+});
+
+describe('parity regression — dashboard surface agrees with course-detail surface', () => {
+  it('pathway-status rollup for foundations matches course-status response (wire-contract level)', async () => {
+    // Dashboard simulation: fetch pathway-status for the enrolled pathway.
+    const pathwayResp = await handleShadowPathwayStatus(makeEvent({ pathway_slug: PATHWAY_SLUG }));
+    expect(pathwayResp.statusCode).toBe(200);
+    const pathwayBody = JSON.parse(pathwayResp.body);
+
+    // Course-detail simulation: fetch course-status for the visible course.
+    const courseResp = await handleShadowCourseStatus(makeEvent({ course_slug: COURSE_SLUG }));
+    expect(courseResp.statusCode).toBe(200);
+    const courseBody = JSON.parse(courseResp.body);
+
+    // Locate the same course in the pathway response.
+    const pathwayCourseEntry = pathwayBody.courses.find(
+      (c: any) => c.course_slug === COURSE_SLUG
+    );
+    expect(pathwayCourseEntry).toBeDefined();
+
+    // Parity — the three fields the dashboard renders from the pathway response
+    // must equal the fields the course-detail surface renders directly.
+    expect(pathwayCourseEntry.modules_completed).toBe(courseBody.modules_completed);
+    expect(pathwayCourseEntry.modules_total).toBe(courseBody.modules_total);
+    expect(pathwayCourseEntry.course_status).toBe(courseBody.course_status);
+
+    // And the absolute values match the seeded shared state (2 of 4 complete).
+    expect(courseBody.modules_completed).toBe(2);
+    expect(courseBody.modules_total).toBe(4);
+    expect(courseBody.course_status).toBe('in_progress');
+  });
+
+  it('empty state: all courses parity-aligned at zero', async () => {
+    // Override Dynamo to return no completions at all.
+    mockDynamoSend.mockImplementation((cmd: any) => {
+      if (cmd?._tag === 'BatchGetCommand') {
+        const req = cmd.input.RequestItems || {};
+        const resp: any = { Responses: {} };
+        for (const table of Object.keys(req)) {
+          resp.Responses[table] = [];
+        }
+        return Promise.resolve(resp);
+      }
+      return Promise.resolve({});
+    });
+
+    const pathwayResp = await handleShadowPathwayStatus(makeEvent({ pathway_slug: PATHWAY_SLUG }));
+    const courseResp = await handleShadowCourseStatus(makeEvent({ course_slug: COURSE_SLUG }));
+    const pathwayBody = JSON.parse(pathwayResp.body);
+    const courseBody = JSON.parse(courseResp.body);
+
+    const pathwayCourseEntry = pathwayBody.courses.find((c: any) => c.course_slug === COURSE_SLUG);
+    expect(pathwayCourseEntry.modules_completed).toBe(courseBody.modules_completed);
+    expect(pathwayCourseEntry.modules_total).toBe(courseBody.modules_total);
+    expect(pathwayCourseEntry.course_status).toBe(courseBody.course_status);
+    expect(pathwayCourseEntry.modules_completed).toBe(0);
+    expect(pathwayCourseEntry.course_status).toBe('not_started');
+  });
+
+  it('all complete state: parity holds at full completion', async () => {
+    mockDynamoSend.mockImplementation((cmd: any) => {
+      if (cmd?._tag === 'BatchGetCommand') {
+        const req = cmd.input.RequestItems || {};
+        const resp: any = { Responses: {} };
+        for (const [table, spec] of Object.entries(req)) {
+          const keys = (spec as any).Keys as Array<{ PK: string; SK: string }>;
+          if (table === ENTITY_COMPLETIONS_TABLE) {
+            resp.Responses[table] = keys.map((k) => ({
+              PK: k.PK,
+              SK: k.SK,
+              status: 'complete',
+              task_statuses: {},
+            }));
+          } else {
+            resp.Responses[table] = [];
+          }
+        }
+        return Promise.resolve(resp);
+      }
+      return Promise.resolve({});
+    });
+
+    const pathwayResp = await handleShadowPathwayStatus(makeEvent({ pathway_slug: PATHWAY_SLUG }));
+    const courseResp = await handleShadowCourseStatus(makeEvent({ course_slug: COURSE_SLUG }));
+    const pathwayBody = JSON.parse(pathwayResp.body);
+    const courseBody = JSON.parse(courseResp.body);
+
+    const pathwayCourseEntry = pathwayBody.courses.find((c: any) => c.course_slug === COURSE_SLUG);
+    expect(pathwayCourseEntry.modules_completed).toBe(courseBody.modules_completed);
+    expect(pathwayCourseEntry.modules_total).toBe(courseBody.modules_total);
+    expect(pathwayCourseEntry.course_status).toBe(courseBody.course_status);
+    expect(courseBody.course_status).toBe('complete');
+    expect(pathwayBody.pathway_status).toBe('complete');
+  });
+});

--- a/tests/unit/shadow-aggregation.test.ts
+++ b/tests/unit/shadow-aggregation.test.ts
@@ -1,0 +1,446 @@
+/**
+ * Unit tests for the shadow aggregation helper (Issue #451, Phase 5A).
+ *
+ * Targets src/api/lambda/shadow-aggregation.ts:
+ *   - classifyModule (pure)
+ *   - computeShadowCourseStatus
+ *   - computeShadowPathwayStatus
+ *
+ * The helper operates natively on shadow DynamoDB records and encodes the
+ * task-bearing-denominator policy per Phase 3 spec §2, §3.4 and Phase 4 plan §2.1.
+ * It MUST NOT reuse calculateCourseCompletion/calculatePathwayCompletion from
+ * completion.ts — that file is a CRM-progress aggregator with a different
+ * input shape and different denominator policy.
+ */
+
+import {
+  classifyModule,
+  computeShadowCourseStatus,
+  computeShadowPathwayStatus,
+} from '../../src/api/lambda/shadow-aggregation';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  BatchGetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'BatchGetCommand' })),
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+  QueryCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'QueryCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'test-user-sub-123';
+const COURSE_SLUG = 'network-like-hyperscaler-foundations';
+const PATHWAY_SLUG = 'network-like-hyperscaler';
+
+const ENTITY_COMPLETIONS_TABLE = 'hedgehog-learn-entity-completions-shadow';
+const CERTS_TABLE = 'hedgehog-learn-certificates-shadow';
+
+function makeDynamo(): DynamoDBDocumentClient {
+  return DynamoDBDocumentClient.from({} as any);
+}
+
+// A HubSpot client mock that returns a given modules-table payload
+function hubspotWithModules(modulesRows: any[]) {
+  return {
+    cms: {
+      hubdb: {
+        rowsApi: {
+          getTableRows: jest.fn().mockResolvedValue({ results: modulesRows }),
+        },
+      },
+    },
+  };
+}
+
+const REQUIRED_QUIZ = { task_slug: 'quiz-1', task_type: 'quiz', required: true };
+const REQUIRED_LAB = { task_slug: 'lab-main', task_type: 'lab_attestation', required: true };
+const KNOWLEDGE_CHECK = { task_slug: 'kc-1', task_type: 'knowledge_check', required: false };
+const OPT_OUT_QUIZ = { task_slug: 'quiz-optional', task_type: 'quiz', required: false };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+  process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  process.env.HUBDB_MODULES_TABLE_ID = 'test-modules-table';
+  process.env.HUBDB_COURSES_TABLE_ID = 'test-courses-table';
+  process.env.HUBDB_PATHWAYS_TABLE_ID = 'test-pathways-table';
+});
+
+afterEach(() => {
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+  delete process.env.HUBDB_COURSES_TABLE_ID;
+  delete process.env.HUBDB_PATHWAYS_TABLE_ID;
+});
+
+// ---------------------------------------------------------------------------
+// classifyModule — pure function (Phase 4 §2.1.1–2.1.8)
+// ---------------------------------------------------------------------------
+
+describe('classifyModule', () => {
+  it('returns no_tasks / has_required_tasks=false when completionTasks is empty', () => {
+    const result = classifyModule(undefined, []);
+    expect(result.module_status).toBe('no_tasks');
+    expect(result.has_required_tasks).toBe(false);
+  });
+
+  it('returns no_tasks when only knowledge_check tasks are declared', () => {
+    const result = classifyModule(undefined, [KNOWLEDGE_CHECK]);
+    expect(result.module_status).toBe('no_tasks');
+    expect(result.has_required_tasks).toBe(false);
+  });
+
+  it('returns no_tasks when only required:false quiz is declared', () => {
+    const result = classifyModule(undefined, [OPT_OUT_QUIZ]);
+    expect(result.module_status).toBe('no_tasks');
+    expect(result.has_required_tasks).toBe(false);
+  });
+
+  it('returns not_started when module has required task but no record', () => {
+    const result = classifyModule(undefined, [REQUIRED_QUIZ]);
+    expect(result.module_status).toBe('not_started');
+    expect(result.has_required_tasks).toBe(true);
+  });
+
+  it('returns in_progress when record status is in_progress', () => {
+    const result = classifyModule({ status: 'in_progress' }, [REQUIRED_QUIZ]);
+    expect(result.module_status).toBe('in_progress');
+    expect(result.has_required_tasks).toBe(true);
+  });
+
+  it('returns complete when record status is complete', () => {
+    const result = classifyModule({ status: 'complete' }, [REQUIRED_QUIZ, REQUIRED_LAB]);
+    expect(result.module_status).toBe('complete');
+    expect(result.has_required_tasks).toBe(true);
+  });
+
+  it('treats mixed quiz+knowledge_check as task-bearing (quiz is required)', () => {
+    const result = classifyModule({ status: 'complete' }, [REQUIRED_QUIZ, KNOWLEDGE_CHECK]);
+    expect(result.has_required_tasks).toBe(true);
+    expect(result.module_status).toBe('complete');
+  });
+
+  it('safely defaults unknown record status to not_started', () => {
+    const result = classifyModule({ status: 'weird' as any }, [REQUIRED_QUIZ]);
+    expect(result.module_status).toBe('not_started');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeShadowCourseStatus (Phase 4 §2.1.9–2.1.17)
+// ---------------------------------------------------------------------------
+
+describe('computeShadowCourseStatus', () => {
+  function modulesRowFor(slug: string, completionTasks: any[], title?: string) {
+    return {
+      path: slug,
+      name: title ?? slug,
+      values: {
+        hs_name: title ?? slug,
+        completion_tasks_json: JSON.stringify(completionTasks),
+      },
+    };
+  }
+
+  function setupHubSpotForCourse(rows: any[]) {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(rows) as any);
+  }
+
+  it('returns not_started with zero counts when no DynamoDB records exist', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+    ]);
+    mockDynamoSend.mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.course_status).toBe('not_started');
+    expect(result!.modules_completed).toBe(0);
+    expect(result!.modules_total).toBe(4);
+    expect(result!.modules).toHaveLength(4);
+  });
+
+  it('returns in_progress with partial completion', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+    ]);
+    mockDynamoSend.mockResolvedValueOnce({
+      Responses: {
+        [ENTITY_COMPLETIONS_TABLE]: [
+          { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-welcome', status: 'complete', task_statuses: {} },
+          { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-how-it-works', status: 'in_progress', task_statuses: {} },
+        ],
+      },
+    });
+    // No cert lookup
+    mockDynamoSend.mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result!.course_status).toBe('in_progress');
+    expect(result!.modules_completed).toBe(1);
+    expect(result!.modules_total).toBe(4);
+  });
+
+  it('returns complete when all task-bearing modules are complete', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+    ]);
+    const completeRecords = [
+      'fabric-operations-welcome',
+      'fabric-operations-how-it-works',
+      'fabric-operations-mastering-interfaces',
+      'fabric-operations-foundations-recap',
+    ].map((s) => ({
+      PK: `USER#${USER_ID}`,
+      SK: `COMPLETION#MODULE#${s}`,
+      status: 'complete',
+      task_statuses: {},
+    }));
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: completeRecords } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result!.course_status).toBe('complete');
+    expect(result!.modules_completed).toBe(4);
+    expect(result!.modules_total).toBe(4);
+  });
+
+  it('excludes no-task module from denominator while still returning it in modules[]', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', []), // no tasks
+    ]);
+    mockDynamoSend
+      .mockResolvedValueOnce({
+        Responses: {
+          [ENTITY_COMPLETIONS_TABLE]: [
+            { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-welcome', status: 'complete', task_statuses: {} },
+            { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-how-it-works', status: 'complete', task_statuses: {} },
+            { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-mastering-interfaces', status: 'complete', task_statuses: {} },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result!.modules_total).toBe(3);
+    expect(result!.modules_completed).toBe(3);
+    expect(result!.course_status).toBe('complete');
+    expect(result!.modules).toHaveLength(4);
+    const recap = result!.modules.find((m) => m.module_slug === 'fabric-operations-foundations-recap')!;
+    expect(recap.module_status).toBe('no_tasks');
+    expect(recap.has_required_tasks).toBe(false);
+  });
+
+  it('populates course_cert_id when cert exists', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+    ]);
+    const completeRecords = [
+      'fabric-operations-welcome',
+      'fabric-operations-how-it-works',
+      'fabric-operations-mastering-interfaces',
+      'fabric-operations-foundations-recap',
+    ].map((s) => ({
+      PK: `USER#${USER_ID}`,
+      SK: `COMPLETION#MODULE#${s}`,
+      status: 'complete',
+      task_statuses: {},
+    }));
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: completeRecords } })
+      .mockResolvedValueOnce({
+        Responses: {
+          [CERTS_TABLE]: [
+            { PK: `USER#${USER_ID}`, SK: `CERT#course#${COURSE_SLUG}`, certId: 'abc-course-cert' },
+          ],
+        },
+      });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result!.course_cert_id).toBe('abc-course-cert');
+  });
+
+  it('returns null when course slug is not in metadata cache', async () => {
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: 'nonexistent-course',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('preserves module ordering from course metadata', async () => {
+    setupHubSpotForCourse([
+      modulesRowFor('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRowFor('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+    ]);
+    // Return DynamoDB records in reversed order — aggregator must still return metadata order
+    mockDynamoSend
+      .mockResolvedValueOnce({
+        Responses: {
+          [ENTITY_COMPLETIONS_TABLE]: [
+            { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-foundations-recap', status: 'complete', task_statuses: {} },
+            { PK: `USER#${USER_ID}`, SK: 'COMPLETION#MODULE#fabric-operations-welcome', status: 'complete', task_statuses: {} },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowCourseStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      courseSlug: COURSE_SLUG,
+    });
+
+    expect(result!.modules.map((m) => m.module_slug)).toEqual([
+      'fabric-operations-welcome',
+      'fabric-operations-how-it-works',
+      'fabric-operations-mastering-interfaces',
+      'fabric-operations-foundations-recap',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeShadowPathwayStatus (Phase 4 §2.1.18–2.1.23)
+// ---------------------------------------------------------------------------
+
+describe('computeShadowPathwayStatus', () => {
+  function setupHubSpotForPathway(moduleRows: any[]) {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(moduleRows) as any);
+  }
+
+  // Build a module row for every module in all four real courses (required quiz each).
+  const allModuleSlugs = [
+    // foundations
+    'fabric-operations-welcome',
+    'fabric-operations-how-it-works',
+    'fabric-operations-mastering-interfaces',
+    'fabric-operations-foundations-recap',
+    // the other three courses' modules are discovered from metadata
+  ];
+
+  function buildModulesRows(withReqQuiz: string[]): any[] {
+    return withReqQuiz.map((slug) => ({
+      path: slug,
+      name: slug,
+      values: {
+        hs_name: slug,
+        completion_tasks_json: JSON.stringify([REQUIRED_QUIZ]),
+      },
+    }));
+  }
+
+  it('returns not_started when no records exist for any course', async () => {
+    // All modules task-bearing, no records
+    setupHubSpotForPathway(buildModulesRows(allModuleSlugs));
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowPathwayStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      pathwaySlug: PATHWAY_SLUG,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.pathway_status).toBe('not_started');
+    expect(result!.courses_completed).toBe(0);
+    expect(result!.courses_total).toBe(4); // network-like-hyperscaler has 4 courses
+  });
+
+  it('returns null when pathway slug is not in metadata cache', async () => {
+    const result = await computeShadowPathwayStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      pathwaySlug: 'nonexistent-pathway',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('per-course entries exclude modules[] key (payload bounded)', async () => {
+    setupHubSpotForPathway(buildModulesRows(allModuleSlugs));
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await computeShadowPathwayStatus({
+      dynamo: makeDynamo(),
+      userId: USER_ID,
+      pathwaySlug: PATHWAY_SLUG,
+    });
+
+    for (const course of result!.courses) {
+      expect((course as any).modules).toBeUndefined();
+    }
+  });
+});

--- a/tests/unit/shadow-course-status.test.ts
+++ b/tests/unit/shadow-course-status.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for GET /shadow/course/status handler (handler-visible path /course/status).
+ * Issue #451, Phase 5A. Spec §2.1, §1.4. Test plan §2.2.
+ */
+
+import { handleShadowCourseStatus } from '../../src/api/lambda/shadow-course-status';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+jest.mock('../../src/api/lambda/cognito-auth', () => ({
+  verifyCookieAuth: jest.fn(),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  BatchGetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'BatchGetCommand' })),
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { verifyCookieAuth } from '../../src/api/lambda/cognito-auth';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+const mockVerifyCookieAuth = verifyCookieAuth as jest.MockedFunction<typeof verifyCookieAuth>;
+
+const AUTH_RESULT = { userId: 'test-user-id', email: 'test@example.com', decoded: {} as any };
+
+const REQUIRED_QUIZ = { task_slug: 'quiz-1', task_type: 'quiz', required: true };
+
+function hubspotWithModules(rows: any[]) {
+  return {
+    cms: {
+      hubdb: {
+        rowsApi: {
+          getTableRows: jest.fn().mockResolvedValue({ results: rows }),
+        },
+      },
+    },
+  };
+}
+
+function modulesRow(slug: string, completionTasks: any[]) {
+  return {
+    path: slug,
+    name: slug,
+    values: {
+      hs_name: slug,
+      completion_tasks_json: JSON.stringify(completionTasks),
+    },
+  };
+}
+
+const ENTITY_COMPLETIONS_TABLE = 'hedgehog-learn-entity-completions-shadow';
+const CERTS_TABLE = 'hedgehog-learn-certificates-shadow';
+const COURSE_SLUG = 'network-like-hyperscaler-foundations';
+
+const FOUR_MODULE_ROWS = [
+  modulesRow('fabric-operations-welcome', [REQUIRED_QUIZ]),
+  modulesRow('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+  modulesRow('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+  modulesRow('fabric-operations-foundations-recap', [REQUIRED_QUIZ]),
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.APP_STAGE = 'shadow';
+  process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+  process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  process.env.HUBDB_MODULES_TABLE_ID = 'test-modules-table';
+  mockVerifyCookieAuth.mockResolvedValue(AUTH_RESULT);
+});
+
+afterEach(() => {
+  delete process.env.APP_STAGE;
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+});
+
+function makeEvent(qs: Record<string, string> | null = { course_slug: COURSE_SLUG }, origin = 'https://hedgehog.cloud') {
+  return {
+    headers: { origin },
+    cookies: [],
+    queryStringParameters: qs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error paths (success/empty/partial/unauthorized/error state coverage)
+// ---------------------------------------------------------------------------
+
+describe('handleShadowCourseStatus — error paths', () => {
+  it('returns 403 when APP_STAGE is not shadow or production', async () => {
+    process.env.APP_STAGE = 'dev';
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(403);
+    expect(JSON.parse(result.body).error).toBe('Not available in this environment');
+  });
+
+  it('returns 401 when cookie auth fails', async () => {
+    mockVerifyCookieAuth.mockRejectedValue(new Error('no cookie'));
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(401);
+    expect(JSON.parse(result.body).error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when course_slug query param is missing', async () => {
+    const result = await handleShadowCourseStatus(makeEvent({}));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('course_slug query parameter is required');
+  });
+
+  it('returns 400 when course_slug is not found in metadata cache', async () => {
+    const result = await handleShadowCourseStatus(makeEvent({ course_slug: 'nonexistent-course' }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('course not found');
+  });
+
+  it('returns 500 when DynamoDB BatchGet throws', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(FOUR_MODULE_ROWS) as any);
+    mockDynamoSend.mockRejectedValueOnce(new Error('dynamo down'));
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body).error).toBe('Failed to read course status');
+  });
+
+  it('returns 500 when required env var is missing', async () => {
+    delete process.env.ENTITY_COMPLETIONS_TABLE;
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body).error).toBe('Server configuration error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success paths
+// ---------------------------------------------------------------------------
+
+describe('handleShadowCourseStatus — success paths', () => {
+  it('happy path: returns in_progress with per-module breakdown', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(FOUR_MODULE_ROWS) as any);
+    mockDynamoSend
+      .mockResolvedValueOnce({
+        Responses: {
+          [ENTITY_COMPLETIONS_TABLE]: [
+            { PK: `USER#${AUTH_RESULT.userId}`, SK: 'COMPLETION#MODULE#fabric-operations-welcome', status: 'complete', task_statuses: {} },
+            { PK: `USER#${AUTH_RESULT.userId}`, SK: 'COMPLETION#MODULE#fabric-operations-how-it-works', status: 'in_progress', task_statuses: {} },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.course_slug).toBe(COURSE_SLUG);
+    expect(body.course_status).toBe('in_progress');
+    expect(body.modules_completed).toBe(1);
+    expect(body.modules_total).toBe(4);
+    expect(body.modules).toHaveLength(4);
+    expect(body.course_cert_id).toBeNull();
+  });
+
+  it('empty state: all modules not_started', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(FOUR_MODULE_ROWS) as any);
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.course_status).toBe('not_started');
+    expect(body.modules_completed).toBe(0);
+    for (const m of body.modules) {
+      expect(m.module_status).toBe('not_started');
+    }
+  });
+
+  it('no-task module is present in modules[] but excluded from denominator', async () => {
+    const rowsWithNoTaskRecap = [
+      modulesRow('fabric-operations-welcome', [REQUIRED_QUIZ]),
+      modulesRow('fabric-operations-how-it-works', [REQUIRED_QUIZ]),
+      modulesRow('fabric-operations-mastering-interfaces', [REQUIRED_QUIZ]),
+      modulesRow('fabric-operations-foundations-recap', []), // no tasks
+    ];
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(rowsWithNoTaskRecap) as any);
+    mockDynamoSend
+      .mockResolvedValueOnce({
+        Responses: {
+          [ENTITY_COMPLETIONS_TABLE]: [
+            { PK: `USER#${AUTH_RESULT.userId}`, SK: 'COMPLETION#MODULE#fabric-operations-welcome', status: 'complete', task_statuses: {} },
+            { PK: `USER#${AUTH_RESULT.userId}`, SK: 'COMPLETION#MODULE#fabric-operations-how-it-works', status: 'complete', task_statuses: {} },
+            { PK: `USER#${AUTH_RESULT.userId}`, SK: 'COMPLETION#MODULE#fabric-operations-mastering-interfaces', status: 'complete', task_statuses: {} },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body.modules_total).toBe(3);
+    expect(body.modules_completed).toBe(3);
+    expect(body.course_status).toBe('complete');
+    const recap = body.modules.find((m: any) => m.module_slug === 'fabric-operations-foundations-recap');
+    expect(recap.module_status).toBe('no_tasks');
+    expect(recap.has_required_tasks).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract shape
+// ---------------------------------------------------------------------------
+
+describe('handleShadowCourseStatus — contract shape', () => {
+  it('response has all required top-level keys', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(FOUR_MODULE_ROWS) as any);
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body).toHaveProperty('course_slug');
+    expect(body).toHaveProperty('course_title');
+    expect(body).toHaveProperty('course_status');
+    expect(body).toHaveProperty('modules_completed');
+    expect(body).toHaveProperty('modules_total');
+    expect(body).toHaveProperty('modules');
+    expect(body).toHaveProperty('course_cert_id');
+    expect(['not_started', 'in_progress', 'complete']).toContain(body.course_status);
+  });
+
+  it('every module entry has required keys and valid status enum', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules(FOUR_MODULE_ROWS) as any);
+    mockDynamoSend
+      .mockResolvedValueOnce({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [] } })
+      .mockResolvedValueOnce({ Responses: { [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowCourseStatus(makeEvent());
+    const body = JSON.parse(result.body);
+    for (const m of body.modules) {
+      expect(m).toHaveProperty('module_slug');
+      expect(m).toHaveProperty('module_title');
+      expect(m).toHaveProperty('module_status');
+      expect(m).toHaveProperty('has_required_tasks');
+      expect(m).toHaveProperty('tasks');
+      expect(['not_started', 'in_progress', 'complete', 'no_tasks']).toContain(m.module_status);
+    }
+  });
+});

--- a/tests/unit/shadow-module-progress.answer-review.test.ts
+++ b/tests/unit/shadow-module-progress.answer-review.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Sensitive-handling tests for GET /shadow/module/progress answer-review.
+ * Issue #451, Phase 5A. Spec §2.4, §7.6. Test plan §2.5.
+ *
+ * Non-negotiables this file enforces:
+ *   - Correct answers are NEVER serialized in the response.
+ *   - learner_identity is NEVER serialized in the response.
+ *   - Schema drift degrades gracefully (deleted questions → schema_drift: true).
+ *   - Lab attestation attempts never carry answer_review.
+ *   - Ownership scoping: Query always uses PK=USER#<cookieUserId>.
+ */
+
+import { handleShadowModuleProgress } from '../../src/api/lambda/shadow-module-progress';
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+jest.mock('../../src/api/lambda/cognito-auth', () => ({
+  verifyCookieAuth: jest.fn(),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+// QueryCommand acts as a constructor (the handler uses `new QueryCommand(...)`),
+// and the captured `input` is later inspected in the ownership-scoping assertion.
+const queryCommandInputs: any[] = [];
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+  QueryCommand: jest.fn().mockImplementation((input: any) => {
+    queryCommandInputs.push(input);
+    return { input, _tag: 'QueryCommand' };
+  }),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { verifyCookieAuth } from '../../src/api/lambda/cognito-auth';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+const mockVerifyCookieAuth = verifyCookieAuth as jest.MockedFunction<typeof verifyCookieAuth>;
+
+const AUTH_RESULT = { userId: 'caller-user-id', email: 'caller@example.com', decoded: {} as any };
+const OTHER_USER_ID = 'other-user-id';
+
+const MODULE_SLUG = 'fabric-operations-welcome';
+const REQUIRED_QUIZ = { task_slug: 'quiz-1', task_type: 'quiz', required: true };
+const REQUIRED_LAB = { task_slug: 'lab-main', task_type: 'lab_attestation', required: true };
+
+const CURRENT_SCHEMA = {
+  quiz_id: 'welcome-quiz',
+  passing_score: 75,
+  questions: [
+    { id: 'q1', question: 'Which command lists fabric switches?', correct_answer: 'kubectl get switch' },
+    { id: 'q2', question: 'What is the fabric controller?', correct_answer: 'agent' },
+  ],
+};
+
+// The known-correct-answer strings that MUST NEVER appear in serialized responses.
+const KNOWN_CORRECT_ANSWERS = ['kubectl get switch', 'agent'];
+
+function moduleRow(slug: string, completionTasks: any[], quizSchema?: any) {
+  return {
+    path: slug,
+    name: slug,
+    values: {
+      hs_name: slug,
+      completion_tasks_json: JSON.stringify(completionTasks),
+      ...(quizSchema ? { quiz_schema_json: JSON.stringify(quizSchema) } : {}),
+    },
+  };
+}
+
+function hubspotWithModules(rows: any[]) {
+  return {
+    cms: { hubdb: { rowsApi: { getTableRows: jest.fn().mockResolvedValue({ results: rows }) } } },
+  };
+}
+
+function makeEvent(qs: any = { module_slug: MODULE_SLUG }) {
+  return { headers: { origin: 'https://hedgehog.cloud' }, cookies: [], queryStringParameters: qs };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  queryCommandInputs.length = 0;
+  process.env.APP_STAGE = 'shadow';
+  process.env.TASK_RECORDS_TABLE = 'task-records';
+  process.env.TASK_ATTEMPTS_TABLE = 'task-attempts';
+  process.env.ENTITY_COMPLETIONS_TABLE = 'entity-completions';
+  process.env.CERTIFICATES_TABLE = 'certificates';
+  process.env.HUBDB_MODULES_TABLE_ID = 'modules-table';
+  mockVerifyCookieAuth.mockResolvedValue(AUTH_RESULT);
+});
+
+afterEach(() => {
+  delete process.env.APP_STAGE;
+  delete process.env.TASK_RECORDS_TABLE;
+  delete process.env.TASK_ATTEMPTS_TABLE;
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+});
+
+describe('answer-review — schema resolution', () => {
+  it('full schema: correct answer submitted → is_correct=true', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ], CURRENT_SCHEMA)]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-12T00:00:00.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-12T00:00:00.000Z',
+            score: 100,
+            pass: true,
+            answers: [
+              { id: 'q1', value: 'kubectl get switch' },
+              { id: 'q2', value: 'agent' },
+            ],
+            learner_identity: { userId: AUTH_RESULT.userId, email: AUTH_RESULT.email },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body.attempts[0].answer_review).toHaveLength(2);
+    expect(body.attempts[0].answer_review[0].is_correct).toBe(true);
+    expect(body.attempts[0].answer_review[0].schema_drift).toBe(false);
+    expect(body.attempts[0].answer_review[0].question_text).toBe('Which command lists fabric switches?');
+  });
+
+  it('incorrect answer → is_correct=false', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ], CURRENT_SCHEMA)]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-12T00:00:00.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-12T00:00:00.000Z',
+            score: 0,
+            pass: false,
+            answers: [{ id: 'q1', value: 'kubectl get pods' }],
+            learner_identity: { userId: AUTH_RESULT.userId, email: AUTH_RESULT.email },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body.attempts[0].answer_review[0].is_correct).toBe(false);
+    expect(body.attempts[0].answer_review[0].submitted_answer_text).toBe('kubectl get pods');
+  });
+
+  it('schema drift: deleted question → exact drifted payload preserves submitted answer (NOT question id)', async () => {
+    const DRIFTED_SCHEMA = {
+      quiz_id: 'welcome-quiz',
+      passing_score: 75,
+      questions: [{ id: 'q1', question: 'Which command lists fabric switches?', correct_answer: 'kubectl get switch' }],
+      // q2 removed
+    };
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ], DRIFTED_SCHEMA)]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-12T00:00:00.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-12T00:00:00.000Z',
+            score: 50,
+            pass: false,
+            answers: [
+              { id: 'q1', value: 'kubectl get switch' },
+              { id: 'q2', value: 'old-submitted-option' }, // question q2 no longer exists
+            ],
+            learner_identity: { userId: AUTH_RESULT.userId, email: AUTH_RESULT.email },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    const review = body.attempts[0].answer_review;
+
+    // Assert the exact drifted payload shape — including the specific bug
+    // fix for submitted_answer_id: it MUST carry the learner's submitted
+    // option identifier, NEVER the question id.
+    const drifted = review.find((r: any) => r.question_id === 'q2');
+    expect(drifted).toEqual({
+      question_id: 'q2',
+      question_text: null,
+      submitted_answer_id: 'old-submitted-option',  // the submitted value, not 'q2'
+      submitted_answer_text: 'old-submitted-option',
+      is_correct: null,
+      schema_drift: true,
+    });
+    // Defensive regression guard against the exact prior bug:
+    expect(drifted.submitted_answer_id).not.toBe('q2');
+    expect(drifted.submitted_answer_id).not.toBe(drifted.question_id);
+
+    // Non-drifted row still resolves.
+    const resolved = review.find((r: any) => r.question_id === 'q1');
+    expect(resolved.schema_drift).toBe(false);
+    expect(resolved.is_correct).toBe(true);
+    expect(resolved.question_text).toBe('Which command lists fabric switches?');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NEVER-LEAK assertions (architectural safety contract)
+// ---------------------------------------------------------------------------
+
+describe('answer-review — never-leak assertions', () => {
+  function runAndGetBody() {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ], CURRENT_SCHEMA)]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-12T00:00:00.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-12T00:00:00.000Z',
+            score: 50,
+            pass: false,
+            answers: [{ id: 'q1', value: 'kubectl get pods' }], // wrong answer — correct stays in schema
+            learner_identity: { userId: AUTH_RESULT.userId, email: AUTH_RESULT.email, extraPii: 'sensitive-bit' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+    return handleShadowModuleProgress(makeEvent()).then((r: any) => r.body as string);
+  }
+
+  it('correct-answer text NEVER appears in serialized response (string search)', async () => {
+    const body = await runAndGetBody();
+    for (const correct of KNOWN_CORRECT_ANSWERS) {
+      expect(body).not.toContain(correct);
+    }
+  });
+
+  it('the key "correct_answer" NEVER appears in serialized response', async () => {
+    const body = await runAndGetBody();
+    expect(body).not.toMatch(/"correct_answer"/);
+  });
+
+  it('the key "learner_identity" NEVER appears in serialized response', async () => {
+    const body = await runAndGetBody();
+    expect(body).not.toMatch(/"learner_identity"/);
+  });
+
+  it('extraPii value from learner_identity NEVER appears in serialized response', async () => {
+    const body = await runAndGetBody();
+    expect(body).not.toContain('sensitive-bit');
+  });
+
+  it('lab attestation attempts carry NO answer_review key', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_LAB])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#lab-main#2026-04-12T00:00:00.000Z`,
+            task_type: 'lab_attestation',
+            attempted_at: '2026-04-12T00:00:00.000Z',
+            attested_at: '2026-04-12T00:00:00.000Z',
+            learner_identity: { userId: AUTH_RESULT.userId, email: AUTH_RESULT.email },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body.attempts[0].outcome).toBe('attested');
+    expect(body.attempts[0].answer_review).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ownership scoping (no cross-learner leak)
+// ---------------------------------------------------------------------------
+
+describe('answer-review — ownership scoping', () => {
+  it('Query uses PK=USER#<cookieUserId>; no query-param override is possible', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ], CURRENT_SCHEMA)]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    // Attempt a forgery-style query param (userId/learner_id) — it must be ignored.
+    await handleShadowModuleProgress(
+      makeEvent({ module_slug: MODULE_SLUG, user_id: OTHER_USER_ID, learner_id: OTHER_USER_ID })
+    );
+
+    // Every QueryCommand must have its PK bound to the caller's userId
+    expect(queryCommandInputs.length).toBeGreaterThan(0);
+    for (const input of queryCommandInputs) {
+      const pk = input.ExpressionAttributeValues?.[':pk'];
+      expect(pk).toBe(`USER#${AUTH_RESULT.userId}`);
+      expect(pk).not.toBe(`USER#${OTHER_USER_ID}`);
+    }
+  });
+});

--- a/tests/unit/shadow-module-progress.test.ts
+++ b/tests/unit/shadow-module-progress.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Unit tests for GET /shadow/module/progress handler (handler-visible path /module/progress).
+ * Issue #451, Phase 5A. Spec §2.3, §1.4. Test plan §2.4.
+ *
+ * Sensitive-handling tests (answer review) are in shadow-module-progress.answer-review.test.ts
+ * to keep safety assertions findable and not diluted.
+ */
+
+import { handleShadowModuleProgress } from '../../src/api/lambda/shadow-module-progress';
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+jest.mock('../../src/api/lambda/cognito-auth', () => ({
+  verifyCookieAuth: jest.fn(),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+  QueryCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'QueryCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { verifyCookieAuth } from '../../src/api/lambda/cognito-auth';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+const mockVerifyCookieAuth = verifyCookieAuth as jest.MockedFunction<typeof verifyCookieAuth>;
+
+const AUTH_RESULT = { userId: 'test-user-id', email: 'test@example.com', decoded: {} as any };
+
+const MODULE_SLUG = 'fabric-operations-welcome';
+const TASK_RECORDS_TABLE = 'hedgehog-learn-task-records-shadow';
+const TASK_ATTEMPTS_TABLE = 'hedgehog-learn-task-attempts-shadow';
+const ENTITY_COMPLETIONS_TABLE = 'hedgehog-learn-entity-completions-shadow';
+const CERTS_TABLE = 'hedgehog-learn-certificates-shadow';
+
+const REQUIRED_QUIZ = { task_slug: 'quiz-1', task_type: 'quiz', required: true };
+const REQUIRED_LAB = { task_slug: 'lab-main', task_type: 'lab_attestation', required: true };
+
+function moduleRow(slug: string, completionTasks: any[], quizSchema?: any) {
+  return {
+    path: slug,
+    name: slug,
+    values: {
+      hs_name: slug,
+      completion_tasks_json: JSON.stringify(completionTasks),
+      ...(quizSchema ? { quiz_schema_json: JSON.stringify(quizSchema) } : {}),
+    },
+  };
+}
+
+function hubspotWithModules(rows: any[]) {
+  return {
+    cms: {
+      hubdb: {
+        rowsApi: { getTableRows: jest.fn().mockResolvedValue({ results: rows }) },
+      },
+    },
+  };
+}
+
+function makeEvent(qs: any = { module_slug: MODULE_SLUG }) {
+  return { headers: { origin: 'https://hedgehog.cloud' }, cookies: [], queryStringParameters: qs };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.APP_STAGE = 'shadow';
+  process.env.TASK_RECORDS_TABLE = TASK_RECORDS_TABLE;
+  process.env.TASK_ATTEMPTS_TABLE = TASK_ATTEMPTS_TABLE;
+  process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+  process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  process.env.HUBDB_MODULES_TABLE_ID = 'test-modules-table';
+  mockVerifyCookieAuth.mockResolvedValue(AUTH_RESULT);
+});
+
+afterEach(() => {
+  delete process.env.APP_STAGE;
+  delete process.env.TASK_RECORDS_TABLE;
+  delete process.env.TASK_ATTEMPTS_TABLE;
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+});
+
+describe('handleShadowModuleProgress — error paths', () => {
+  it('403 when APP_STAGE is not shadow/production', async () => {
+    process.env.APP_STAGE = 'dev';
+    const result = await handleShadowModuleProgress(makeEvent());
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('401 on auth failure', async () => {
+    mockVerifyCookieAuth.mockRejectedValue(new Error('nope'));
+    const result = await handleShadowModuleProgress(makeEvent());
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('400 when module_slug missing', async () => {
+    const result = await handleShadowModuleProgress(makeEvent({}));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('module_slug query parameter is required');
+  });
+
+  it('400 when module not found in HubDB', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules([]) as any);
+    const result = await handleShadowModuleProgress(makeEvent({ module_slug: 'nonexistent' }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('module not found');
+  });
+
+  it('400 when attempts_limit is 0', async () => {
+    const result = await handleShadowModuleProgress(makeEvent({ module_slug: MODULE_SLUG, attempts_limit: '0' }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('attempts_limit must be between 1 and 50');
+  });
+
+  it('400 when attempts_limit exceeds 50', async () => {
+    const result = await handleShadowModuleProgress(makeEvent({ module_slug: MODULE_SLUG, attempts_limit: '51' }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('attempts_limit must be between 1 and 50');
+  });
+});
+
+describe('handleShadowModuleProgress — success paths', () => {
+  it('no attempts yet: tasks list with not_started, attempts[] empty', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ, REQUIRED_LAB])]) as any
+    );
+    // EntityCompletion get (for module_status), task-records query, task-attempts query, cert get
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })  // entity-completion: none
+      .mockResolvedValueOnce({ Items: [] })         // task-records query: empty
+      .mockResolvedValueOnce({ Items: [] })         // task-attempts query: empty
+      .mockResolvedValueOnce({ Item: undefined });  // cert get: none
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.module_slug).toBe(MODULE_SLUG);
+    expect(body.module_status).toBe('not_started');
+    expect(body.has_required_tasks).toBe(true);
+    expect(body.tasks).toHaveLength(2);
+    expect(body.tasks[0].status).toBe('not_started');
+    expect(body.attempts).toEqual([]);
+    expect(body.module_cert_id).toBeNull();
+  });
+
+  it('with attempts: tasks have best_score/attempt_count, attempts[] DESC by timestamp', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({
+        Item: {
+          PK: `USER#${AUTH_RESULT.userId}`,
+          SK: `COMPLETION#MODULE#${MODULE_SLUG}`,
+          status: 'in_progress',
+          task_statuses: { 'quiz-1': { status: 'failed', score: 60, attempts: 2 } },
+        },
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            PK: `USER#${AUTH_RESULT.userId}`,
+            SK: `TASK#MODULE#${MODULE_SLUG}#quiz-1`,
+            task_type: 'quiz',
+            status: 'failed',
+            best_score: 60,
+            attempt_count: 2,
+            last_attempt_at: '2026-04-12T14:22:09.000Z',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        Items: [
+          {
+            PK: `USER#${AUTH_RESULT.userId}`,
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-12T14:22:09.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-12T14:22:09.000Z',
+            score: 60,
+            pass: false,
+            answers: [{ id: 'q1', value: 'a' }],
+          },
+          {
+            PK: `USER#${AUTH_RESULT.userId}`,
+            SK: `ATTEMPT#MODULE#${MODULE_SLUG}#quiz-1#2026-04-11T10:00:00.000Z`,
+            task_type: 'quiz',
+            attempted_at: '2026-04-11T10:00:00.000Z',
+            score: 40,
+            pass: false,
+            answers: [{ id: 'q1', value: 'c' }],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.module_status).toBe('in_progress');
+    expect(body.tasks[0].best_score).toBe(60);
+    expect(body.tasks[0].attempt_count).toBe(2);
+    expect(body.attempts).toHaveLength(2);
+    // DESC by attempted_at
+    expect(body.attempts[0].attempted_at).toBe('2026-04-12T14:22:09.000Z');
+    expect(body.attempts[1].attempted_at).toBe('2026-04-11T10:00:00.000Z');
+    expect(body.attempts[0].outcome).toBe('failed');
+  });
+
+  it('include_attempts=false omits attempts[]', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined }); // cert
+
+    const result = await handleShadowModuleProgress(
+      makeEvent({ module_slug: MODULE_SLUG, include_attempts: 'false' })
+    );
+    const body = JSON.parse(result.body);
+    expect(body.attempts).toBeUndefined();
+  });
+
+  it('no-required-tasks module surfaces as has_required_tasks=false', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body.has_required_tasks).toBe(false);
+    expect(body.module_status).toBe('no_tasks');
+    expect(body.tasks).toEqual([]);
+  });
+});
+
+describe('handleShadowModuleProgress — contract shape', () => {
+  it('has all required top-level keys including breadcrumbs', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow(MODULE_SLUG, [REQUIRED_QUIZ])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body).toHaveProperty('module_slug');
+    expect(body).toHaveProperty('module_title');
+    expect(body).toHaveProperty('module_status');
+    expect(body).toHaveProperty('has_required_tasks');
+    expect(body).toHaveProperty('tasks');
+    expect(body).toHaveProperty('module_cert_id');
+    expect(body).toHaveProperty('breadcrumbs');
+    expect(body.breadcrumbs).toHaveProperty('parent_course_slug');
+    expect(body.breadcrumbs).toHaveProperty('parent_course_title');
+    expect(body.breadcrumbs).toHaveProperty('parent_pathway_slug');
+    expect(body.breadcrumbs).toHaveProperty('parent_pathway_title');
+  });
+
+  it('breadcrumbs resolve parent course and pathway for module in real content', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow('fabric-operations-welcome', [REQUIRED_QUIZ])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent({ module_slug: 'fabric-operations-welcome' }));
+    const body = JSON.parse(result.body);
+    expect(body.breadcrumbs.parent_course_slug).toBe('network-like-hyperscaler-foundations');
+    expect(body.breadcrumbs.parent_pathway_slug).toBe('network-like-hyperscaler');
+  });
+
+  it('breadcrumbs are null for orphan module not in any course', async () => {
+    mockGetHubSpotClient.mockReturnValue(
+      hubspotWithModules([moduleRow('orphan-module', [REQUIRED_QUIZ])]) as any
+    );
+    mockDynamoSend
+      .mockResolvedValueOnce({ Item: undefined })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Items: [] })
+      .mockResolvedValueOnce({ Item: undefined });
+
+    const result = await handleShadowModuleProgress(makeEvent({ module_slug: 'orphan-module' }));
+    const body = JSON.parse(result.body);
+    expect(body.breadcrumbs.parent_course_slug).toBeNull();
+    expect(body.breadcrumbs.parent_pathway_slug).toBeNull();
+  });
+});

--- a/tests/unit/shadow-pathway-status.test.ts
+++ b/tests/unit/shadow-pathway-status.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for GET /shadow/pathway/status handler (handler-visible path /pathway/status).
+ * Issue #451, Phase 5A. Spec §2.2, §1.4. Test plan §2.3.
+ */
+
+import { handleShadowPathwayStatus } from '../../src/api/lambda/shadow-pathway-status';
+
+jest.mock('../../src/shared/hubspot', () => ({
+  getHubSpotClient: jest.fn(),
+}));
+jest.mock('../../src/api/lambda/cognito-auth', () => ({
+  verifyCookieAuth: jest.fn(),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDynamoSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: jest.fn().mockReturnValue({
+      send: (...args: any[]) => mockDynamoSend(...args),
+    }),
+  },
+  BatchGetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'BatchGetCommand' })),
+  GetCommand: jest.fn().mockImplementation((input: any) => ({ input, _tag: 'GetCommand' })),
+}));
+
+import { getHubSpotClient } from '../../src/shared/hubspot';
+import { verifyCookieAuth } from '../../src/api/lambda/cognito-auth';
+
+const mockGetHubSpotClient = getHubSpotClient as jest.MockedFunction<typeof getHubSpotClient>;
+const mockVerifyCookieAuth = verifyCookieAuth as jest.MockedFunction<typeof verifyCookieAuth>;
+
+const AUTH_RESULT = { userId: 'test-user-id', email: 'test@example.com', decoded: {} as any };
+
+const REQUIRED_QUIZ = { task_slug: 'quiz-1', task_type: 'quiz', required: true };
+const ENTITY_COMPLETIONS_TABLE = 'hedgehog-learn-entity-completions-shadow';
+const CERTS_TABLE = 'hedgehog-learn-certificates-shadow';
+const PATHWAY_SLUG = 'network-like-hyperscaler';
+
+function modulesRow(slug: string) {
+  return {
+    path: slug,
+    name: slug,
+    values: { hs_name: slug, completion_tasks_json: JSON.stringify([REQUIRED_QUIZ]) },
+  };
+}
+
+function hubspotWithModules(rows: any[]) {
+  return {
+    cms: {
+      hubdb: {
+        rowsApi: {
+          getTableRows: jest.fn().mockResolvedValue({ results: rows }),
+        },
+      },
+    },
+  };
+}
+
+// All modules across all 4 courses of network-like-hyperscaler pathway
+const ALL_MODULE_SLUGS = [
+  'fabric-operations-welcome',
+  'fabric-operations-how-it-works',
+  'fabric-operations-mastering-interfaces',
+  'fabric-operations-foundations-recap',
+  // Provisioning, observability, troubleshooting modules inferred from content/courses
+];
+
+function makeEvent(qs: any = { pathway_slug: PATHWAY_SLUG }) {
+  return { headers: { origin: 'https://hedgehog.cloud' }, cookies: [], queryStringParameters: qs };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.APP_STAGE = 'shadow';
+  process.env.ENTITY_COMPLETIONS_TABLE = ENTITY_COMPLETIONS_TABLE;
+  process.env.CERTIFICATES_TABLE = CERTS_TABLE;
+  process.env.HUBDB_MODULES_TABLE_ID = 'test-modules-table';
+  mockVerifyCookieAuth.mockResolvedValue(AUTH_RESULT);
+});
+
+afterEach(() => {
+  delete process.env.APP_STAGE;
+  delete process.env.ENTITY_COMPLETIONS_TABLE;
+  delete process.env.CERTIFICATES_TABLE;
+  delete process.env.HUBDB_MODULES_TABLE_ID;
+});
+
+describe('handleShadowPathwayStatus — error paths', () => {
+  it('403 when APP_STAGE is not shadow/production', async () => {
+    process.env.APP_STAGE = 'dev';
+    const result = await handleShadowPathwayStatus(makeEvent());
+    expect(result.statusCode).toBe(403);
+  });
+
+  it('401 on auth failure', async () => {
+    mockVerifyCookieAuth.mockRejectedValue(new Error('bad'));
+    const result = await handleShadowPathwayStatus(makeEvent());
+    expect(result.statusCode).toBe(401);
+  });
+
+  it('400 when pathway_slug missing', async () => {
+    const result = await handleShadowPathwayStatus(makeEvent({}));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('pathway_slug query parameter is required');
+  });
+
+  it('400 when pathway_slug is unknown', async () => {
+    const result = await handleShadowPathwayStatus(makeEvent({ pathway_slug: 'nonexistent' }));
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body).error).toBe('pathway not found');
+  });
+});
+
+describe('handleShadowPathwayStatus — success paths', () => {
+  it('empty state: all courses not_started', async () => {
+    // HubSpot modules call may be invoked multiple times; use mockReturnValue
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules([]) as any);
+    // DynamoDB returns empty for BatchGet (entity-completions); single call returns empty cert table
+    mockDynamoSend.mockResolvedValue({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [], [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowPathwayStatus(makeEvent());
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.pathway_slug).toBe(PATHWAY_SLUG);
+    expect(body.pathway_status).toBe('not_started');
+    expect(body.courses_total).toBe(4);
+    expect(body.courses_completed).toBe(0);
+    expect(body.courses).toHaveLength(4);
+  });
+
+  it('per-course entries do NOT include modules[] (bounded payload)', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules([]) as any);
+    mockDynamoSend.mockResolvedValue({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [], [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowPathwayStatus(makeEvent());
+    const body = JSON.parse(result.body);
+    for (const c of body.courses) {
+      expect(c.modules).toBeUndefined();
+    }
+  });
+
+  it('contract shape: required top-level keys present', async () => {
+    mockGetHubSpotClient.mockReturnValue(hubspotWithModules([]) as any);
+    mockDynamoSend.mockResolvedValue({ Responses: { [ENTITY_COMPLETIONS_TABLE]: [], [CERTS_TABLE]: [] } });
+
+    const result = await handleShadowPathwayStatus(makeEvent());
+    const body = JSON.parse(result.body);
+    expect(body).toHaveProperty('pathway_slug');
+    expect(body).toHaveProperty('pathway_title');
+    expect(body).toHaveProperty('pathway_status');
+    expect(body).toHaveProperty('courses_completed');
+    expect(body).toHaveProperty('courses_total');
+    expect(body).toHaveProperty('courses');
+    expect(body).toHaveProperty('pathway_cert_id');
+    expect(['not_started', 'in_progress', 'complete']).toContain(body.pathway_status);
+  });
+});


### PR DESCRIPTION
## Issue #473 — Restore production learner-progress bare routes for Layer 2 parity

Implements the accepted **#472 Option A** decision: restore the server-authoritative bare routes so the deployed production API matches the deployed `/learn` frontend contract. This is a **topology / merge-completeness fix, not an auth fix** — #461 is untouched.

> **Review gate / stop point:** This PR is the implementation artifact. It does **not** deploy. Per #473, the lead owns the deploy + post-deploy verification step.

### Root cause (from accepted #472)
The Phase 5A backend (Issue #451, branch `issue-451-phase5a-backend`, commits `b6a58ec`+`2ead749`) that registers/serves these routes was **never merged to `main`**, while the Phase 5B frontend (#459) that *calls* them shipped to `main` and is live. Production therefore returns gateway `404 {"message":"Not Found"}` on the three routes.

### Routes restored
| Route | Handler | Shape |
|---|---|---|
| `GET /course/status?course_slug=` | `handleShadowCourseStatus` | server-authoritative course rollup |
| `GET /pathway/status?pathway_slug=` | `handleShadowPathwayStatus` | server-authoritative pathway rollup |
| `GET /module/progress?module_slug=` | `handleShadowModuleProgress` | per-attempt answer-review (sensitive-safe) |

All three are `GET`, query-param based, ownership-scoped (`PK=USER#<cookieUserId>`, query params cannot retarget), read-only (no DynamoDB writes).

### Files changed
**New (forward-ported verbatim from `issue-451-phase5a-backend` tip):**
- `src/api/lambda/shadow-aggregation.ts` — `classifyModule`, `computeShadowCourseStatus`, `computeShadowPathwayStatus`
- `src/api/lambda/shadow-course-status.ts`, `shadow-pathway-status.ts`, `shadow-module-progress.ts`

**Wiring / config:**
- `src/api/lambda/index.ts` — 3 imports + 3 dispatch lines (placed after `/tasks/status`)
- `serverless.yml` — 3 `httpApi` route registrations (same static-bare-path form as `/tasks/status`)
- `src/api/lambda/completion.ts` — **additive only**: optional `title?` on `CourseMetadata`/`PathwayMetadata`, title population in `loadMetadataCache`, and `listAllCourseSlugs`/`listAllPathwaySlugs` accessors. CRM aggregators untouched.

**Tests (6 suites, 61 tests, ported from #451 tip):**
- `shadow-aggregation.test.ts`, `shadow-aggregation-parity.test.ts`
- `shadow-course-status.test.ts`, `shadow-pathway-status.test.ts`
- `shadow-module-progress.test.ts`, `shadow-module-progress.answer-review.test.ts`

### Why this is #461-safe (acceptance criterion: bypass cookie rejected in prod)
The restored handlers call the **same `verifyCookieAuth` path as the live `/tasks/status` handler**, and use the identical stage guard (`APP_STAGE` must be `shadow` or `production`). Because they compile against the current `cognito-auth.ts`, they inherit the #461 dual-guard (`isTestBypassEnabled` = `APP_STAGE==='shadow' && ENABLE_TEST_BYPASS==='true'`) **by construction**. In production (`APP_STAGE=production`) the bypass is off → sentinel cookie rejected. Unauth requests return handler-shaped `401 {"error":"Unauthorized"}`, not gateway `404`.

### No infra/IAM change required (verified)
- Env vars `TASK_RECORDS_TABLE` / `TASK_ATTEMPTS_TABLE` / `ENTITY_COMPLETIONS_TABLE` / `CERTIFICATES_TABLE` already resolve to `-prod` names at `stage=production`.
- IAM already grants the `-prod` tables (`serverless.yml` lines 104-109), including `BatchGetItem` and the certificates index. The new handlers read the same tables `/tasks/status` already reads in production.

### Deliberate scope exclusion
The #451 `certificate-issuance.ts` **pathway-cert** change is **not** included — it is a write-path concern outside #473, and touches #461-era cert code. Its negative-control test (`shadow-aggregation-negative-control.test.ts`) is deferred with it. Flagging for a future cert-forward-port ticket so the invariant isn't lost.

### Verification done locally
- `tsc -p tsconfig.lambda.json` → clean
- `eslint` on changed source → 0 errors
- Full unit suite → **169 passed**, 1 failure (`certificate-issuance.test.ts` cert-verify case) that is **pre-existing on `main`** (reproduced on a clean `main` checkout) and unrelated to this change.

### dist-lambda note
`dist-lambda/` is intentionally **not** committed. It is a build artifact regenerated by `npm run build` at deploy; `main`'s committed copy is pre-#461 stale (lacks `isTestBypassEnabled`) yet production has #461 live — confirming the deploy rebuilds from source.

### Post-deploy probe matrix (for the lead-owned deploy step)
Expected after deploy:
```
GET /course/status      (no cookie)            -> 401 {"error":"Unauthorized"}   (was 404 gateway)
GET /pathway/status     (no cookie)            -> 401
GET /module/progress    (no cookie)            -> 401
GET /course/status      (shadow_e2e sentinel)  -> 401   (bypass rejected in prod, #461)
GET /tasks/status       (regression check)     -> 401   (unchanged)
GET /certificates       (regression check)     -> 401   (unchanged)
POST /admin/test/reset  (bad cookie)           -> 403   (unchanged)
```

Closes #473 on merge + deploy + post-deploy verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
