### PR TITLE
fix(packaging): bundle course/pathway metadata for restored status routes (Issue #476)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -318,6 +318,14 @@ package:
     - '!src/**'
     - '!tests/**'
     - '!content/**'
+    # Re-include ONLY the course/pathway metadata the restored learner-progress
+    # handlers read at runtime (Issue #476; defect found in #475). loadMetadataCache()
+    # in completion.ts reads content/courses + content/pathways from process.cwd();
+    # without these the deployed Lambda's metadata cache is empty and
+    # /course/status + /pathway/status return handler 400 "not found".
+    # content/modules is NOT needed — module titles come from HubDB (HUBDB_MODULES_TABLE_ID).
+    - 'content/courses/**'
+    - 'content/pathways/**'
     - '!docs/**'
     - '!reference/**'
     - '!hubdb-schemas/**'

--- a/tests/unit/serverless-content-packaging.test.ts
+++ b/tests/unit/serverless-content-packaging.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Packaging guard for the restored learner-progress routes (Issue #476).
+ *
+ * /course/status and /pathway/status resolve course/pathway metadata via
+ * completion.ts loadMetadataCache(), which reads content/courses + content/pathways
+ * from process.cwd()/content at runtime. The Lambda package excludes content/** by
+ * default; #475 proved that exclusion makes both routes return handler 400
+ * "not found" in production.
+ *
+ * This guard asserts serverless.yml re-includes ONLY those two metadata dirs
+ * (after the broad content exclusion, so the re-include wins), and that the files
+ * the handlers look up actually exist in the repo.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const SERVERLESS_YML = path.join(REPO_ROOT, 'serverless.yml');
+
+describe('Lambda packaging — learner-progress metadata (Issue #476)', () => {
+  const yml = fs.readFileSync(SERVERLESS_YML, 'utf-8');
+
+  const idxExclude = yml.indexOf("'!content/**'");
+  const idxCourses = yml.indexOf("'content/courses/**'");
+  const idxPathways = yml.indexOf("'content/pathways/**'");
+
+  it('re-includes content/courses/** and content/pathways/** in the package patterns', () => {
+    expect(idxCourses).toBeGreaterThan(-1);
+    expect(idxPathways).toBeGreaterThan(-1);
+  });
+
+  it('re-includes them AFTER the broad !content/** exclusion (so the include wins)', () => {
+    expect(idxExclude).toBeGreaterThan(-1);
+    expect(idxCourses).toBeGreaterThan(idxExclude);
+    expect(idxPathways).toBeGreaterThan(idxExclude);
+  });
+
+  it('does NOT broadly re-include all of content/** (keeps the fix minimal)', () => {
+    // A bare content/** re-include after the exclusion would defeat minimization.
+    expect(yml).not.toMatch(/^\s*-\s*'content\/\*\*'\s*$/m);
+    // content/modules is intentionally not bundled (module titles come from HubDB).
+    expect(yml).not.toMatch(/'content\/modules\/\*\*'/);
+  });
+
+  it('the course/pathway metadata files the handlers read exist in the repo', () => {
+    const courses = fs.readdirSync(path.join(REPO_ROOT, 'content', 'courses')).filter(f => f.endsWith('.json'));
+    const pathways = fs.readdirSync(path.join(REPO_ROOT, 'content', 'pathways')).filter(f => f.endsWith('.json'));
+    expect(courses.length).toBeGreaterThan(0);
+    expect(pathways.length).toBeGreaterThan(0);
+    // The slugs exercised by the #475 authenticated harness must be present.
+    expect(courses).toContain('network-like-hyperscaler-foundations.json');
+    expect(pathways).toContain('network-like-hyperscaler.json');
+  });
+});


### PR DESCRIPTION
## Issue #476 — Fix Lambda packaging for authenticated `/course/status` + `/pathway/status`

Implements the accepted #475 diagnosis: a **Lambda packaging defect**, not auth. This PR is the implementation artifact and **does not deploy** (lead-owned next step).

### Root cause (accepted from #475)
- `shadow-course-status.ts` → `computeShadowCourseStatus` and `shadow-pathway-status.ts` → `computeShadowPathwayStatus` resolve metadata via `completion.ts loadMetadataCache()`, which reads `content/courses` + `content/pathways` from `process.cwd()/content` at runtime.
- `serverless.yml` excluded `content/**` from the package → deployed Lambda's metadata cache empty → `getCourseMetadata()`/`getPathwayMetadata()` undefined → `shadow-aggregation.ts:256-257` returns `null` → handler `400 "not found"`.
- `/tasks/status` was unaffected (uses HubDB). `/module/progress` returned `200` but with `null` breadcrumbs (same metadata cause).

### The change (minimal — 8 lines)
`serverless.yml`, immediately after the existing `- '!content/**'`:
```yaml
    - '!content/**'
    - 'content/courses/**'      # course metadata for /course/status + breadcrumbs
    - 'content/pathways/**'     # pathway metadata for /pathway/status + breadcrumbs
    - '!docs/**'
```
Serverless applies patterns in order (last match wins), so these re-includes override the broad exclusion. **`content/modules` is deliberately NOT bundled** — module titles come from HubDB (`HUBDB_MODULES_TABLE_ID`), so it isn't on this metadata path. No auth, frontend, or aggregation/completion logic changes.

### Proof the bundle will actually contain the files
`serverless package --stage production` → inspected `.serverless/api.zip`:
```
content/courses/hedgehog-lab-foundations.json
content/courses/network-like-hyperscaler-foundations.json
content/courses/network-like-hyperscaler-observability.json
content/courses/network-like-hyperscaler-provisioning.json
content/courses/network-like-hyperscaler-troubleshooting.json
content/pathways/network-like-hyperscaler.json
--------------------------------------------------------------
content/courses *.json bundled : 5   (expect 5)
content/pathways *.json bundled: 1   (expect 1)
content/modules  files bundled : 0   (expect 0, minimal)
```
These sit at the zip root → `/var/task/content/...` at runtime, which is exactly what `process.cwd()/content` resolves to in the Lambda. So `network-like-hyperscaler-foundations` (course) and `network-like-hyperscaler` (pathway) — the slugs the #475 harness probes — will resolve.

### Regression guard (test)
`tests/unit/serverless-content-packaging.test.ts` (4 tests, all pass) asserts:
- `content/courses/**` + `content/pathways/**` are present in the patterns,
- they appear **after** `!content/**` (so the include wins),
- the fix stays minimal (no bare `content/**`, no `content/modules`),
- the course/pathway files the handlers read (incl. the #475 harness slugs) exist in the repo.

### CI / test status
- New guard test: **4/4 pass**.
- Full unit suite: **173 pass**, 1 fail = `certificate-issuance.test.ts` — **pre-existing on clean `main`** (reproduced: 1 failed/20 passed) and unrelated to packaging.

### Out of scope (per #476 constraints)
No auth changes, no frontend changes, no production data seeding, no `#451` cert-issuance work, no broad refactor.

### After merge (lead-owned)
1. Deploy from merged `main` (rebuild — `dist-lambda` regenerated by `npm run build`).
2. Re-run the ready #475 harness — expect `/course/status` + `/pathway/status` → authenticated `200`, `/module/progress` breadcrumbs populated, and `/module/progress` safety assertions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
